### PR TITLE
Implement full-featured multiple windows with New Window button 

### DIFF
--- a/src/components/toolbar.rs
+++ b/src/components/toolbar.rs
@@ -19,6 +19,7 @@ pub struct ToolbarState<'a> {
     pub dark_mode: &'a mut bool,
     pub show_settings: &'a mut bool,
     pub update_available: bool,
+    pub new_window_requested: &'a mut bool,
 }
 
 impl Toolbar {
@@ -39,6 +40,10 @@ impl Toolbar {
                         *state.error = None;
                         self.previous_file_type = *state.file_type;
                     }
+                }
+
+                if ui.button("🪟 New Window").clicked() {
+                    *state.new_window_requested = true;
                 }
 
                 if ui.button("✖ Clear").clicked() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -15,6 +16,31 @@ mod file;
 mod helpers;
 mod search;
 mod update;
+
+// Per-window state that can be used by child windows
+struct ChildWindowState {
+    toolbar: components::toolbar::Toolbar,
+    central_panel: components::central_panel::CentralPanel,
+    error: Option<String>,
+    file_path: Option<PathBuf>,
+    file_type: file::lazy_loader::FileType,
+    search: search::Search,
+    search_rx: Option<std::sync::mpsc::Receiver<search::Search>>,
+}
+
+impl Default for ChildWindowState {
+    fn default() -> Self {
+        Self {
+            toolbar: Default::default(),
+            central_panel: Default::default(),
+            error: None,
+            file_path: None,
+            file_type: Default::default(),
+            search: Default::default(),
+            search_rx: None,
+        }
+    }
+}
 
 struct ThothApp {
     toolbar: components::toolbar::Toolbar,
@@ -39,7 +65,7 @@ struct ThothApp {
     dark_mode: bool,
 
     // Multi-window support
-    show_new_windows: Vec<usize>,
+    child_windows: HashMap<usize, ChildWindowState>,
     next_window_id: usize,
 }
 
@@ -61,7 +87,7 @@ impl Default for ThothApp {
             pending_install_path: None,
             update_notification_shown: false,
             dark_mode: false,
-            show_new_windows: Vec::new(),
+            child_windows: HashMap::new(),
             next_window_id: 1,
         }
     }
@@ -84,11 +110,10 @@ impl App for ThothApp {
         self.handle_file_drop(ctx);
 
         // Check for Ctrl/Cmd+N to open new window
+        let mut new_window_requested = false;
         ctx.input(|i| {
             if i.modifiers.command && i.key_pressed(egui::Key::N) {
-                let new_id = self.next_window_id;
-                self.next_window_id += 1;
-                self.show_new_windows.push(new_id);
+                new_window_requested = true;
             }
         });
 
@@ -123,8 +148,17 @@ impl App for ThothApp {
                 dark_mode: &mut self.dark_mode,
                 show_settings: &mut self.settings_panel.show,
                 update_available,
+                new_window_requested: &mut new_window_requested,
             },
         );
+
+        // Create new window if requested
+        if new_window_requested {
+            let new_id = self.next_window_id;
+            self.next_window_id += 1;
+            self.child_windows
+                .insert(new_id, ChildWindowState::default());
+        }
 
         // We will forward a processed message (with results) to the CentralPanel
         let mut msg_to_central: Option<search::SearchMessage> = None;
@@ -191,43 +225,171 @@ impl ThothApp {
         // Keep track of which windows should be closed
         let mut windows_to_remove = Vec::new();
 
-        for window_id in &self.show_new_windows {
+        // Get window IDs to iterate over (to avoid borrow issues)
+        let window_ids: Vec<usize> = self.child_windows.keys().copied().collect();
+
+        for window_id in window_ids {
             let mut should_close = false;
 
-            ctx.show_viewport_immediate(
-                egui::ViewportId::from_hash_of(("child_window", *window_id)),
-                egui::ViewportBuilder::default()
-                    .with_title("Thoth — JSON & NDJSON Viewer")
-                    .with_inner_size([1200.0, 800.0]),
-                |ctx, _class| {
-                    // Apply theme
-                    theme::apply_theme(ctx, ctx.style().visuals.dark_mode);
+            // Get the window state (we need to work around borrow checker here)
+            if let Some(state) = self.child_windows.get_mut(&window_id) {
+                ctx.show_viewport_immediate(
+                    egui::ViewportId::from_hash_of(("child_window", window_id)),
+                    egui::ViewportBuilder::default()
+                        .with_title("Thoth — JSON & NDJSON Viewer")
+                        .with_inner_size([1200.0, 800.0]),
+                    |ctx, _class| {
+                        // Apply theme
+                        theme::apply_theme(ctx, ctx.style().visuals.dark_mode);
 
-                    // Check if window should close
-                    if ctx.input(|i| i.viewport().close_requested()) {
-                        should_close = true;
-                        return;
-                    }
+                        // Check if window should close
+                        if ctx.input(|i| i.viewport().close_requested()) {
+                            should_close = true;
+                            return;
+                        }
 
-                    // Render a simple placeholder UI for the child window
-                    egui::CentralPanel::default().show(ctx, |ui| {
-                        ui.heading("New Window");
-                        ui.label("This is a new Thoth window.");
-                        ui.separator();
-                        ui.label("You can drag and drop a JSON/NDJSON file here to open it.");
-                        ui.label("Press Cmd/Ctrl+N in the main window to open more windows.");
-                    });
-                },
-            );
+                        // Render the full Thoth UI for this window
+                        Self::render_window_ui(ctx, state);
+                    },
+                );
+            }
 
             if should_close {
-                windows_to_remove.push(*window_id);
+                windows_to_remove.push(window_id);
             }
         }
 
         // Remove closed windows
-        self.show_new_windows
-            .retain(|id| !windows_to_remove.contains(id));
+        for id in windows_to_remove {
+            self.child_windows.remove(&id);
+        }
+    }
+
+    fn render_window_ui(ctx: &egui::Context, state: &mut ChildWindowState) {
+        // Handle file drop
+        let hovering_files = ctx.input(|i| i.raw.hovered_files.clone());
+        if !hovering_files.is_empty() {
+            let mut text = String::from("Drop file to open:\n");
+            for file in &hovering_files {
+                if let Some(path) = &file.path {
+                    use std::fmt::Write as _;
+                    let _ = write!(text, "\n{}", path.display());
+                } else if !file.mime.is_empty() {
+                    use std::fmt::Write as _;
+                    let _ = write!(text, "\n{}", file.mime);
+                }
+            }
+
+            let painter = ctx.layer_painter(egui::LayerId::new(
+                egui::Order::Foreground,
+                egui::Id::new("file_drop_overlay"),
+            ));
+            let screen_rect = ctx.screen_rect();
+            painter.rect_filled(screen_rect, 0.0, egui::Color32::from_black_alpha(180));
+            painter.text(
+                screen_rect.center(),
+                egui::Align2::CENTER_CENTER,
+                text,
+                egui::TextStyle::Heading.resolve(&ctx.style()),
+                egui::Color32::WHITE,
+            );
+        }
+
+        // Handle dropped files
+        let dropped_files = ctx.input(|i| i.raw.dropped_files.clone());
+        if !dropped_files.is_empty() {
+            for file in dropped_files {
+                if let Some(path) = file.path {
+                    match file::detect_file_type::sniff_file_type(&path) {
+                        Ok(detected) => {
+                            let ft: file::lazy_loader::FileType = detected.into();
+                            state.file_type = ft;
+                            state.file_path = Some(path);
+                            state.error = None;
+                            state.toolbar.previous_file_type = ft;
+                        }
+                        Err(e) => {
+                            state.error = Some(format!(
+                                "Failed to detect file type (expect JSON / NDJSON): {e}"
+                            ));
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        // Update window title
+        if let Some(path) = &state.file_path {
+            let file_name = std::path::Path::new(path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("Unknown file");
+            ctx.send_viewport_cmd(egui::ViewportCommand::Title(format!(
+                "Thoth — {}",
+                file_name
+            )));
+        } else {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Title(
+                "Thoth — JSON & NDJSON Viewer".to_owned(),
+            ));
+        }
+
+        // Render toolbar (child windows don't show settings or update notifications)
+        let mut child_new_window_requested = false; // Child windows can't spawn new windows
+        let incoming_msg = state.toolbar.ui(
+            ctx,
+            &mut components::toolbar::ToolbarState {
+                file_path: &mut state.file_path,
+                file_type: &mut state.file_type,
+                error: &mut state.error,
+                dark_mode: &mut false, // Don't let child windows control dark mode
+                show_settings: &mut false, // Don't show settings in child windows
+                update_available: false,
+                new_window_requested: &mut child_new_window_requested,
+            },
+        );
+
+        // Handle search messages
+        let mut msg_to_central: Option<search::SearchMessage> = None;
+
+        if let Some(rx) = &state.search_rx {
+            if let Ok(done) = rx.try_recv() {
+                state.search = done.clone();
+                msg_to_central = Some(search::SearchMessage::StartSearch(done));
+                state.search_rx = None;
+            }
+        }
+
+        if let Some(msg) = incoming_msg {
+            match msg {
+                search::SearchMessage::StartSearch(s) => {
+                    state.search = s.clone();
+                    state.search.scanning = true;
+                    msg_to_central = Some(search::SearchMessage::StartSearch(state.search.clone()));
+
+                    let rx = state
+                        .search
+                        .start_scanning(&state.file_path, &state.file_type);
+                    state.search_rx = Some(rx);
+
+                    ctx.request_repaint();
+                }
+                search::SearchMessage::StopSearch => {
+                    state.search_rx = None;
+                    msg_to_central = Some(search::SearchMessage::StopSearch);
+                }
+            }
+        }
+
+        // Render the central panel
+        state.central_panel.ui(
+            ctx,
+            &state.file_path,
+            &mut state.file_type,
+            &mut state.error,
+            msg_to_central,
+        );
     }
 
     fn handle_update_messages(&mut self, ctx: &egui::Context) {


### PR DESCRIPTION
- Each child window now has complete Thoth functionality
- Added 'New Window' button to toolbar (next to Open button)
- Child windows support:
  - Full JSON/NDJSON viewing
  - File drag-and-drop
  - File type switching
  - Search functionality
  - Independent window state
- Keyboard shortcut Cmd/Ctrl+N still works
- Child windows can be closed independently
- Window titles update based on opened file

Closes https://github.com/anitnilay20/thoth/issues/29