### PR TITLE
chore: Simplify CI to use Codecov badge only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,77 +92,11 @@ jobs:
         run: cargo install cargo-tarpaulin
 
       - name: Generate coverage
-        run: cargo tarpaulin --out Xml --out Html --all-features --output-dir ./coverage
+        run: cargo tarpaulin --out Xml --all-features
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/cobertura.xml
+          files: ./cobertura.xml
           fail_ci_if_error: false
-
-      - name: Create coverage badge
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: |
-          COVERAGE=$(grep -oP 'line-rate="\K[0-9.]+' coverage/cobertura.xml | head -1)
-          COVERAGE_PERCENT=$(echo "$COVERAGE * 100" | bc | cut -d. -f1)
-          echo "Coverage: ${COVERAGE_PERCENT}%"
-
-          # Determine badge color
-          if [ "$COVERAGE_PERCENT" -ge 80 ]; then
-            COLOR="brightgreen"
-          elif [ "$COVERAGE_PERCENT" -ge 60 ]; then
-            COLOR="yellow"
-          else
-            COLOR="red"
-          fi
-
-          # Create badge JSON
-          mkdir -p badges
-          cat > badges/coverage.json << EOF
-          {
-            "schemaVersion": 1,
-            "label": "coverage",
-            "message": "${COVERAGE_PERCENT}%",
-            "color": "$COLOR"
-          }
-          EOF
-
-      - name: Upload coverage badge
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-badge
-          path: badges/coverage.json
-
-  benchmark:
-    name: Benchmark
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Run benchmarks
-        run: cargo bench --bench file_loading -- --output-format bencher | tee benchmark_results.txt
-
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Rust Benchmark
-          tool: "cargo"
-          output-file-path: benchmark_results.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: "200%"
-          comment-on-alert: true
-          fail-on-alert: false
-          # Store benchmark results in gh-pages branch
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: dev/bench

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 <div align="center">
 
 [![CI](https://github.com/anitnilay20/thoth/workflows/CI/badge.svg)](https://github.com/anitnilay20/thoth/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/anitnilay20/YOUR_GIST_ID/raw/thoth-coverage.json)](https://github.com/anitnilay20/thoth/actions/workflows/badges.yml)
-[![Benchmarks](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/anitnilay20/YOUR_GIST_ID/raw/thoth-benchmarks.json)](https://anitnilay20.github.io/thoth/dev/bench/)
+[![codecov](https://codecov.io/gh/anitnilay20/thoth/branch/main/graph/badge.svg)](https://codecov.io/gh/anitnilay20/thoth)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust Version](https://img.shields.io/badge/rust-1.70%2B-blue.svg)](https://www.rust-lang.org)
 


### PR DESCRIPTION
Changes:
- Removed custom coverage badge generation steps from CI
- Removed benchmark job (can run locally with cargo bench)
- Simplified coverage to output only XML for Codecov
- Updated README badges: removed custom coverage and benchmarks badges
- Added Codecov badge for coverage tracking

CI now includes:
- Multi-platform testing (Ubuntu, macOS, Windows)
- Clippy linting with strict warnings
- Rustfmt formatting checks
- Code coverage with Codecov integration
- Rust caching with Swatinem/rust-cache for faster builds

Setup required:
- Add CODECOV_TOKEN to repository secrets
- Sign up at https://codecov.io and connect the repository