### PR TITLE
Feat/consent flow and component reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust ${{ matrix.rust }}
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
 
@@ -49,9 +49,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.94.0
-          profile: minimal
-          override: true
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,15 +66,7 @@ icons = [
 # Resources to include in the bundle
 resources = ["assets"]
 
-# macOS bundle configuration
-[package.metadata.packager.macos]
-# File associations are declared in a custom Info.plist (CFBundleDocumentTypes).
-# cargo-packager merges this with its auto-generated plist.
-info_plist_path = "assets/Info.plist"
-
-# Windows installer configuration
-[package.metadata.packager.windows]
-# File associations for Windows "Open With" and default app
+# File associations (top-level — applies to all platforms cargo-packager supports)
 file_associations = [
   { ext = [
     "json",
@@ -87,6 +79,15 @@ file_associations = [
     "geojson",
   ], name = "GeoJSON File", description = "GeoJSON File", icon = "assets/thoth_icon_256.ico", role = "Editor", mime = "application/geo+json" },
 ]
+
+# macOS bundle configuration
+[package.metadata.packager.macos]
+# File associations are declared in a custom Info.plist (CFBundleDocumentTypes).
+# cargo-packager merges this with its auto-generated plist.
+info_plist_path = "assets/Info.plist"
+
+# Windows installer configuration (signing only — no extra fields needed here)
+[package.metadata.packager.windows]
 
 # Debian/Linux package configuration
 [package.metadata.packager.deb]

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -143,8 +143,7 @@ impl ThothApp {
                     }),
                 )
                 .with_action("Later", std::sync::Arc::new(|| {}))
-                .with_toast(true)
-                .with_status(crate::notification::NotificationStatus::ConsentRequired),
+                .with_toast(true),
             );
         }
     }

--- a/src/components/marketplace/mod.rs
+++ b/src/components/marketplace/mod.rs
@@ -114,8 +114,7 @@ impl StatelessComponent for MarketplaceDetail {
                         }),
                     )
                     .with_action("Later", std::sync::Arc::new(|| {}))
-                    .with_toast(true)
-                    .with_status(crate::notification::NotificationStatus::ConsentRequired),
+                    .with_toast(true),
                 );
             }
         }
@@ -167,10 +166,7 @@ impl StatelessComponent for MarketplaceDetail {
                                         }),
                                     )
                                     .with_action("Later", std::sync::Arc::new(|| {}))
-                                    .with_toast(true)
-                                    .with_status(
-                                        crate::notification::NotificationStatus::ConsentRequired,
-                                    ),
+                                    .with_toast(true),
                                 );
                             }
                             Err(e) => {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -5,6 +5,7 @@ pub mod common;
 // paths (e.g. `crate::components::button::Button`) continue to work.
 pub use common::breadcrumbs;
 pub use common::button;
+pub use common::button_group;
 pub use common::card;
 pub use common::data_row;
 pub use common::icon_button;

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -133,12 +133,14 @@ impl ContextComponent for StatusBar {
                     let domain = domain.to_string();
                     let plugin_id = plugin_id.to_string();
                     Settings::update(&ctx, |s| {
-                        s.plugins
+                        let domains = &mut s.plugins
                             .network_policies
                             .entry(plugin_id)
                             .or_default()
-                            .allowed_domains
-                            .push(domain);
+                            .allowed_domains;
+                        if !domains.contains(&domain) {
+                            domains.push(domain);
+                        }
                     });
                 }
             }

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -4,13 +4,13 @@ use std::path::Path;
 
 use crate::components::breadcrumbs::{Breadcrumbs, BreadcrumbsEvent, BreadcrumbsProps};
 use crate::components::traits::{ContextComponent, StatelessComponent};
-use crate::file::loaders::FileKind;
 use crate::consent::{
     manager::ConsentManager,
     modal::{ConsentModal, ConsentModalProps},
 };
-use crate::settings::Settings;
+use crate::file::loaders::FileKind;
 use crate::notification::notification_dropdown::{NotificationDropdown, NotificationDropdownProps};
+use crate::settings::Settings;
 
 /// Status bar component displaying file info and application status
 #[derive(Default)]
@@ -119,8 +119,12 @@ impl ContextComponent for StatusBar {
         let on_accept = |remember: bool| {
             // Pass `remember` to the callback so the in-memory NetworkPolicy is
             // updated immediately (via runtime_allowed_handle).
-            if let Some(ref f) = allow_fn { f(remember); }
-            if let Some(ref id) = id_accept { ConsentManager::resolve(id); }
+            if let Some(ref f) = allow_fn {
+                f(remember);
+            }
+            if let Some(ref id) = id_accept {
+                ConsentManager::resolve(id);
+            }
             if remember {
                 // Also persist to Settings so the domain survives a restart.
                 if let (Some(domain), Some(plugin_id)) =
@@ -140,12 +144,20 @@ impl ContextComponent for StatusBar {
             }
         };
         let on_cancel = || {
-            if let Some(ref f) = deny_fn { f(false); }
-            if let Some(ref id) = id_cancel { ConsentManager::resolve(id); }
+            if let Some(ref f) = deny_fn {
+                f(false);
+            }
+            if let Some(ref id) = id_cancel {
+                ConsentManager::resolve(id);
+            }
         };
         self.consent_modal.render(
             ui,
-            ConsentModalProps { request: consent_request, on_accept: &on_accept, on_cancel: &on_cancel },
+            ConsentModalProps {
+                request: consent_request,
+                on_accept: &on_accept,
+                on_cancel: &on_cancel,
+            },
         );
 
         // Use theme colors from context

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -5,12 +5,18 @@ use std::path::Path;
 use crate::components::breadcrumbs::{Breadcrumbs, BreadcrumbsEvent, BreadcrumbsProps};
 use crate::components::traits::{ContextComponent, StatelessComponent};
 use crate::file::loaders::FileKind;
+use crate::consent::{
+    manager::ConsentManager,
+    modal::{ConsentModal, ConsentModalProps},
+};
+use crate::settings::Settings;
 use crate::notification::notification_dropdown::{NotificationDropdown, NotificationDropdownProps};
 
 /// Status bar component displaying file info and application status
 #[derive(Default)]
 pub struct StatusBar {
     notification_dropdown: NotificationDropdown,
+    consent_modal: ConsentModal,
 }
 
 /// Props for the status bar component (immutable, one-way binding)
@@ -97,6 +103,50 @@ impl ContextComponent for StatusBar {
 
     fn render(&mut self, ui: &mut egui::Ui, props: Self::Props<'_>) -> Self::Output {
         let mut events = Vec::new();
+
+        // Render consent modal (uses egui::Modal, so it floats above everything)
+        let consent = ConsentManager::take_first();
+        let (consent_request, allow_fn, deny_fn) = match consent {
+            Some((r, a, d)) => (Some(r), Some(a), Some(d)),
+            None => (None, None, None),
+        };
+        let id_accept = consent_request.as_ref().map(|r| r.id.clone());
+        let id_cancel = id_accept.clone();
+        let remember_domain = consent_request.as_ref().and_then(|r| r.domain.clone());
+        let remember_plugin_id = consent_request.as_ref().and_then(|r| r.plugin_id.clone());
+
+        let ctx = ui.ctx().clone();
+        let on_accept = |remember: bool| {
+            // Pass `remember` to the callback so the in-memory NetworkPolicy is
+            // updated immediately (via runtime_allowed_handle).
+            if let Some(ref f) = allow_fn { f(remember); }
+            if let Some(ref id) = id_accept { ConsentManager::resolve(id); }
+            if remember {
+                // Also persist to Settings so the domain survives a restart.
+                if let (Some(domain), Some(plugin_id)) =
+                    (remember_domain.as_deref(), remember_plugin_id.as_deref())
+                {
+                    let domain = domain.to_string();
+                    let plugin_id = plugin_id.to_string();
+                    Settings::update(&ctx, |s| {
+                        s.plugins
+                            .network_policies
+                            .entry(plugin_id)
+                            .or_default()
+                            .allowed_domains
+                            .push(domain);
+                    });
+                }
+            }
+        };
+        let on_cancel = || {
+            if let Some(ref f) = deny_fn { f(false); }
+            if let Some(ref id) = id_cancel { ConsentManager::resolve(id); }
+        };
+        self.consent_modal.render(
+            ui,
+            ConsentModalProps { request: consent_request, on_accept: &on_accept, on_cancel: &on_cancel },
+        );
 
         // Use theme colors from context
         let bg_color = ui.ctx().memory(|mem| {

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -133,7 +133,8 @@ impl ContextComponent for StatusBar {
                     let domain = domain.to_string();
                     let plugin_id = plugin_id.to_string();
                     Settings::update(&ctx, |s| {
-                        let domains = &mut s.plugins
+                        let domains = &mut s
+                            .plugins
                             .network_policies
                             .entry(plugin_id)
                             .or_default()

--- a/src/consent/manager.rs
+++ b/src/consent/manager.rs
@@ -1,0 +1,120 @@
+use std::{collections::VecDeque, sync::Arc, time::SystemTime};
+
+// ── Data types ────────────────────────────────────────────────────────────────
+
+/// A single permission the plugin is requesting.
+#[derive(Clone)]
+pub struct PermissionEntry {
+    /// Phosphor glyph for the permission type (e.g. `egui_phosphor::regular::GLOBE`).
+    pub icon: &'static str,
+    pub label: String,
+    /// Short monospace scope hint shown next to the label.
+    pub scope: String,
+    /// Whether this permission is considered high-sensitivity.
+    pub sensitive: bool,
+}
+
+/// Structured description of one consent request, passed to the modal for rendering.
+#[derive(Clone)]
+pub struct ConsentRequest {
+    /// Queue key — passed to `ConsentManager::resolve` after the user decides.
+    pub id: String,
+    pub title: String,
+    pub message: String,
+    pub permissions: Vec<PermissionEntry>,
+    /// The domain being requested (set for HTTP consent requests).
+    pub domain: Option<String>,
+    /// The plugin that raised this request (set for HTTP consent requests).
+    pub plugin_id: Option<String>,
+}
+
+/// A pending consent request: display data + allow/deny callbacks.
+/// `bool` is `true` when the user checked "Remember this choice".
+pub type ConsentCallback = Arc<dyn Fn(bool) + Send + Sync + 'static>;
+
+pub struct PendingConsent {
+    pub request: ConsentRequest,
+    pub on_allow: ConsentCallback,
+    pub on_deny: ConsentCallback,
+}
+
+// ── Manager ───────────────────────────────────────────────────────────────────
+
+/// Queue for permission consent requests. Completely independent of
+/// `NotificationManager` — separate storage, separate global, separate UI.
+#[derive(Default)]
+pub struct ConsentManager {
+    pub(super) queue: VecDeque<PendingConsent>,
+}
+
+impl ConsentManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enqueue a network-access consent request built from a domain name.
+    pub fn push_http_consent(
+        domain: &str,
+        plugin_id: &str,
+        on_allow: ConsentCallback,
+        on_deny: ConsentCallback,
+    ) {
+        let id = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .to_string();
+        Self::push(PendingConsent {
+            request: ConsentRequest {
+                id,
+                title: "Network Request Consent".to_string(),
+                message: format!("A plugin is requesting access to '{domain}'."),
+                permissions: vec![PermissionEntry {
+                    icon: egui_phosphor::regular::GLOBE,
+                    label: "Make network requests".to_string(),
+                    scope: format!("to {domain}"),
+                    sensitive: false,
+                }],
+                domain: Some(domain.to_string()),
+                plugin_id: Some(plugin_id.to_string()),
+            },
+            on_allow,
+            on_deny,
+        });
+    }
+
+    /// Enqueue any consent request.
+    pub fn push(consent: PendingConsent) {
+        if let Some(mutex) = crate::CONSENT_MANAGER.get() {
+            if let Ok(mut cm) = mutex.lock() {
+                cm.queue.push_back(consent);
+            }
+        }
+    }
+
+    /// Remove the consent with the given id (call after the user decides).
+    pub fn resolve(id: &str) {
+        if let Some(mutex) = crate::CONSENT_MANAGER.get() {
+            if let Ok(mut cm) = mutex.lock() {
+                cm.queue.retain(|c| c.request.id != id);
+            }
+        }
+    }
+
+    /// Clone the first pending consent's data so the caller can render without
+    /// holding the lock across frames.
+    pub fn take_first() -> Option<(
+        ConsentRequest,
+        ConsentCallback,
+        ConsentCallback,
+    )> {
+        crate::CONSENT_MANAGER
+            .get()
+            .and_then(|m| m.lock().ok())
+            .and_then(|cm| {
+                cm.queue.front().map(|c| {
+                    (c.request.clone(), Arc::clone(&c.on_allow), Arc::clone(&c.on_deny))
+                })
+            })
+    }
+}

--- a/src/consent/manager.rs
+++ b/src/consent/manager.rs
@@ -103,17 +103,17 @@ impl ConsentManager {
 
     /// Clone the first pending consent's data so the caller can render without
     /// holding the lock across frames.
-    pub fn take_first() -> Option<(
-        ConsentRequest,
-        ConsentCallback,
-        ConsentCallback,
-    )> {
+    pub fn take_first() -> Option<(ConsentRequest, ConsentCallback, ConsentCallback)> {
         crate::CONSENT_MANAGER
             .get()
             .and_then(|m| m.lock().ok())
             .and_then(|cm| {
                 cm.queue.front().map(|c| {
-                    (c.request.clone(), Arc::clone(&c.on_allow), Arc::clone(&c.on_deny))
+                    (
+                        c.request.clone(),
+                        Arc::clone(&c.on_allow),
+                        Arc::clone(&c.on_deny),
+                    )
                 })
             })
     }

--- a/src/consent/manager.rs
+++ b/src/consent/manager.rs
@@ -1,4 +1,6 @@
-use std::{collections::VecDeque, sync::Arc, time::SystemTime};
+use std::{collections::VecDeque, sync::Arc, sync::atomic::{AtomicU64, Ordering}};
+
+static CONSENT_ID: AtomicU64 = AtomicU64::new(1);
 
 // ── Data types ────────────────────────────────────────────────────────────────
 
@@ -59,11 +61,7 @@ impl ConsentManager {
         on_allow: ConsentCallback,
         on_deny: ConsentCallback,
     ) {
-        let id = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-            .to_string();
+        let id = format!("consent-{}", CONSENT_ID.fetch_add(1, Ordering::Relaxed));
         Self::push(PendingConsent {
             request: ConsentRequest {
                 id,

--- a/src/consent/manager.rs
+++ b/src/consent/manager.rs
@@ -1,4 +1,8 @@
-use std::{collections::VecDeque, sync::Arc, sync::atomic::{AtomicU64, Ordering}};
+use std::{
+    collections::VecDeque,
+    sync::Arc,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 static CONSENT_ID: AtomicU64 = AtomicU64::new(1);
 

--- a/src/consent/mod.rs
+++ b/src/consent/mod.rs
@@ -1,0 +1,5 @@
+pub mod manager;
+pub mod modal;
+
+pub use manager::{ConsentManager, ConsentRequest, PermissionEntry, PendingConsent};
+pub use modal::{ConsentModal, ConsentModalProps};

--- a/src/consent/mod.rs
+++ b/src/consent/mod.rs
@@ -1,5 +1,5 @@
 pub mod manager;
 pub mod modal;
 
-pub use manager::{ConsentManager, ConsentRequest, PermissionEntry, PendingConsent};
+pub use manager::{ConsentManager, ConsentRequest, PendingConsent, PermissionEntry};
 pub use modal::{ConsentModal, ConsentModalProps};

--- a/src/consent/modal.rs
+++ b/src/consent/modal.rs
@@ -65,7 +65,13 @@ impl ContextComponent for ConsentModal {
                     ui.add(egui::Separator::default().spacing(0.0));
                     render_body(ui, &request, &colors);
                     ui.add(egui::Separator::default().spacing(0.0));
-                    render_footer(ui, &mut self.remember, &mut accepted, &mut cancelled, &colors);
+                    render_footer(
+                        ui,
+                        &mut self.remember,
+                        &mut accepted,
+                        &mut cancelled,
+                        &colors,
+                    );
                 });
         });
 
@@ -85,13 +91,19 @@ impl ContextComponent for ConsentModal {
 
 fn render_header(ui: &mut egui::Ui, request: &ConsentRequest, colors: &ThemeColors) {
     Frame::new()
-        .inner_margin(Margin { left: 24, right: 24, top: 20, bottom: 16 })
+        .inner_margin(Margin {
+            left: 24,
+            right: 24,
+            top: 20,
+            bottom: 16,
+        })
         .show(ui, |ui| {
             ui.horizontal(|ui| {
                 // Plugin avatar with shield-warning badge
                 let avatar_size = egui::vec2(44.0, 44.0);
                 let (avatar_rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
-                ui.painter().rect_filled(avatar_rect, CornerRadius::same(8), colors.surface);
+                ui.painter()
+                    .rect_filled(avatar_rect, CornerRadius::same(8), colors.surface);
                 ui.painter().text(
                     avatar_rect.center(),
                     Align2::CENTER_CENTER,
@@ -104,7 +116,8 @@ fn render_header(ui: &mut egui::Ui, request: &ConsentRequest, colors: &ThemeColo
                     avatar_rect.max - egui::vec2(14.0, 14.0),
                     egui::vec2(18.0, 18.0),
                 );
-                ui.painter().rect_filled(badge_rect, CornerRadius::same(9), colors.warning);
+                ui.painter()
+                    .rect_filled(badge_rect, CornerRadius::same(9), colors.warning);
                 ui.painter().rect_stroke(
                     badge_rect,
                     CornerRadius::same(9),
@@ -139,7 +152,12 @@ fn render_header(ui: &mut egui::Ui, request: &ConsentRequest, colors: &ThemeColo
 
 fn render_body(ui: &mut egui::Ui, request: &ConsentRequest, colors: &ThemeColors) {
     Frame::new()
-        .inner_margin(Margin { left: 24, right: 24, top: 16, bottom: 12 })
+        .inner_margin(Margin {
+            left: 24,
+            right: 24,
+            top: 16,
+            bottom: 12,
+        })
         .show(ui, |ui| {
             if !request.message.is_empty() {
                 Typography::body_large(ui, &request.message);
@@ -173,7 +191,12 @@ fn render_footer(
     colors: &ThemeColors,
 ) {
     Frame::new()
-        .inner_margin(Margin { left: 24, right: 24, top: 12, bottom: 16 })
+        .inner_margin(Margin {
+            left: 24,
+            right: 24,
+            top: 12,
+            bottom: 16,
+        })
         .fill(colors.bg_panel)
         .show(ui, |ui| {
             ui.horizontal(|ui| {
@@ -187,10 +210,18 @@ fn render_footer(
                 ui.painter().rect(
                     cb_rect,
                     CornerRadius::same(3),
-                    if *remember { colors.accent } else { Color32::TRANSPARENT },
+                    if *remember {
+                        colors.accent
+                    } else {
+                        Color32::TRANSPARENT
+                    },
                     Stroke::new(
                         1.0,
-                        if *remember { colors.accent } else { colors.surface_active },
+                        if *remember {
+                            colors.accent
+                        } else {
+                            colors.surface_active
+                        },
                     ),
                     egui::StrokeKind::Outside,
                 );
@@ -256,9 +287,15 @@ fn render_footer(
 
 fn render_permission_row(ui: &mut egui::Ui, entry: &PermissionEntry, colors: &ThemeColors) {
     ui.horizontal(|ui| {
-        let icon_color = if entry.sensitive { colors.warning } else { colors.accent };
+        let icon_color = if entry.sensitive {
+            colors.warning
+        } else {
+            colors.accent
+        };
         ui.label(
-            egui::RichText::new(entry.icon).font(phosphor_font_id(16.0)).color(icon_color),
+            egui::RichText::new(entry.icon)
+                .font(phosphor_font_id(16.0))
+                .color(icon_color),
         );
         ui.add_space(8.0);
         Typography::body_large(ui, &entry.label);
@@ -278,7 +315,12 @@ fn render_permission_row(ui: &mut egui::Ui, entry: &PermissionEntry, colors: &Th
                 Frame::new()
                     .fill(Color32::from_rgba_premultiplied(249, 226, 175, 26))
                     .corner_radius(CornerRadius::same(3))
-                    .inner_margin(Margin { left: 5, right: 5, top: 2, bottom: 2 })
+                    .inner_margin(Margin {
+                        left: 5,
+                        right: 5,
+                        top: 2,
+                        bottom: 2,
+                    })
                     .show(ui, |ui| {
                         Typography::render(
                             ui,

--- a/src/consent/modal.rs
+++ b/src/consent/modal.rs
@@ -1,0 +1,297 @@
+use eframe::egui::{self, Align2, Color32, CornerRadius, Frame, Layout, Margin, Stroke};
+
+use crate::{
+    components::{
+        button::{Button, ButtonColor, ButtonProps, ButtonSize, ButtonType},
+        traits::{ContextComponent, StatelessComponent},
+        typography::{Typography, TypographyProps, TypographyVariant},
+    },
+    theme::{ThemeColors, phosphor_font_id},
+};
+
+use super::manager::{ConsentRequest, PermissionEntry};
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+pub struct ConsentModalProps<'a> {
+    /// The active consent request, or `None` when nothing is pending.
+    pub request: Option<ConsentRequest>,
+    /// Called when the user clicks Allow.
+    /// The `bool` argument is `true` when "Remember this choice" is checked.
+    pub on_accept: &'a dyn Fn(bool),
+    /// Called when the user clicks Cancel.
+    pub on_cancel: &'a dyn Fn(),
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+pub struct ConsentModal {
+    remember: bool,
+}
+
+impl ContextComponent for ConsentModal {
+    type Props<'a> = ConsentModalProps<'a>;
+    type Output = ();
+
+    fn render(&mut self, ui: &mut egui::Ui, props: Self::Props<'_>) -> Self::Output {
+        let Some(request) = props.request else {
+            self.remember = false;
+            return;
+        };
+
+        let colors = ui.ctx().memory(|mem| {
+            mem.data
+                .get_temp::<ThemeColors>(egui::Id::new("theme_colors"))
+                .unwrap_or_else(|| crate::theme::Theme::default().colors())
+        });
+
+        let mut accepted = false;
+        let mut cancelled = false;
+
+        let modal = egui::Modal::new(egui::Id::new("consent_modal"))
+            .backdrop_color(Color32::from_black_alpha(153));
+
+        modal.show(ui.ctx(), |ui| {
+            ui.set_width(480.0);
+
+            Frame::new()
+                .fill(colors.bg)
+                .stroke(Stroke::new(1.0, colors.surface))
+                .corner_radius(CornerRadius::same(8))
+                .inner_margin(Margin::ZERO)
+                .show(ui, |ui| {
+                    render_header(ui, &request, &colors);
+                    ui.add(egui::Separator::default().spacing(0.0));
+                    render_body(ui, &request, &colors);
+                    ui.add(egui::Separator::default().spacing(0.0));
+                    render_footer(ui, &mut self.remember, &mut accepted, &mut cancelled, &colors);
+                });
+        });
+
+        // Backdrop clicks are intentionally absorbed — the user must make an explicit choice.
+
+        if accepted {
+            (props.on_accept)(self.remember);
+            self.remember = false;
+        } else if cancelled {
+            (props.on_cancel)();
+            self.remember = false;
+        }
+    }
+}
+
+// ── Section renderers ─────────────────────────────────────────────────────────
+
+fn render_header(ui: &mut egui::Ui, request: &ConsentRequest, colors: &ThemeColors) {
+    Frame::new()
+        .inner_margin(Margin { left: 24, right: 24, top: 20, bottom: 16 })
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                // Plugin avatar with shield-warning badge
+                let avatar_size = egui::vec2(44.0, 44.0);
+                let (avatar_rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
+                ui.painter().rect_filled(avatar_rect, CornerRadius::same(8), colors.surface);
+                ui.painter().text(
+                    avatar_rect.center(),
+                    Align2::CENTER_CENTER,
+                    egui_phosphor::regular::PUZZLE_PIECE,
+                    phosphor_font_id(22.0),
+                    colors.accent,
+                );
+
+                let badge_rect = egui::Rect::from_min_size(
+                    avatar_rect.max - egui::vec2(14.0, 14.0),
+                    egui::vec2(18.0, 18.0),
+                );
+                ui.painter().rect_filled(badge_rect, CornerRadius::same(9), colors.warning);
+                ui.painter().rect_stroke(
+                    badge_rect,
+                    CornerRadius::same(9),
+                    Stroke::new(2.0, colors.bg),
+                    egui::StrokeKind::Outside,
+                );
+                ui.painter().text(
+                    badge_rect.center(),
+                    Align2::CENTER_CENTER,
+                    egui_phosphor::regular::SHIELD_WARNING,
+                    phosphor_font_id(10.0),
+                    colors.bg,
+                );
+
+                ui.add_space(12.0);
+                ui.vertical(|ui| {
+                    Typography::render(
+                        ui,
+                        TypographyProps {
+                            text: "PERMISSION REQUESTED",
+                            variant: TypographyVariant::GroupLabel,
+                            color: Some(colors.warning),
+                            ..Default::default()
+                        },
+                    );
+                    ui.add_space(2.0);
+                    Typography::heading(ui, &request.title);
+                });
+            });
+        });
+}
+
+fn render_body(ui: &mut egui::Ui, request: &ConsentRequest, colors: &ThemeColors) {
+    Frame::new()
+        .inner_margin(Margin { left: 24, right: 24, top: 16, bottom: 12 })
+        .show(ui, |ui| {
+            if !request.message.is_empty() {
+                Typography::body_large(ui, &request.message);
+                ui.add_space(12.0);
+            }
+
+            Typography::group_label(ui, "THIS WILL ALLOW THE PLUGIN TO");
+            ui.add_space(6.0);
+
+            Frame::new()
+                .fill(colors.bg_sunken)
+                .stroke(Stroke::new(1.0, colors.surface))
+                .corner_radius(CornerRadius::same(4))
+                .inner_margin(Margin::same(12))
+                .show(ui, |ui| {
+                    for (i, entry) in request.permissions.iter().enumerate() {
+                        if i > 0 {
+                            ui.add_space(8.0);
+                        }
+                        render_permission_row(ui, entry, colors);
+                    }
+                });
+        });
+}
+
+fn render_footer(
+    ui: &mut egui::Ui,
+    remember: &mut bool,
+    accepted: &mut bool,
+    cancelled: &mut bool,
+    colors: &ThemeColors,
+) {
+    Frame::new()
+        .inner_margin(Margin { left: 24, right: 24, top: 12, bottom: 16 })
+        .fill(colors.bg_panel)
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                // Custom checkbox — distinct from ToggleSwitch shape
+                let cb_size = egui::vec2(14.0, 14.0);
+                let (cb_rect, cb_resp) = ui.allocate_exact_size(cb_size, egui::Sense::click());
+                if cb_resp.clicked() {
+                    *remember = !*remember;
+                }
+                cb_resp.on_hover_cursor(egui::CursorIcon::PointingHand);
+                ui.painter().rect(
+                    cb_rect,
+                    CornerRadius::same(3),
+                    if *remember { colors.accent } else { Color32::TRANSPARENT },
+                    Stroke::new(
+                        1.0,
+                        if *remember { colors.accent } else { colors.surface_active },
+                    ),
+                    egui::StrokeKind::Outside,
+                );
+                if *remember {
+                    ui.painter().text(
+                        cb_rect.center(),
+                        Align2::CENTER_CENTER,
+                        egui_phosphor::regular::CHECK,
+                        phosphor_font_id(10.0),
+                        colors.bg,
+                    );
+                }
+                ui.add_space(6.0);
+                Typography::render(
+                    ui,
+                    TypographyProps {
+                        text: "Remember this choice",
+                        variant: TypographyVariant::Subtitle,
+                        ..Default::default()
+                    },
+                );
+
+                ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.spacing_mut().item_spacing.x = 8.0;
+
+                    if Button::render(
+                        ui,
+                        ButtonProps {
+                            label: "Allow".to_string(),
+                            button_type: ButtonType::Elevated,
+                            color: ButtonColor::Primary,
+                            button_size: ButtonSize::Medium,
+                            height: Some(32.0),
+                            width: Some(100.0),
+                            ..Default::default()
+                        },
+                    )
+                    .clicked
+                    {
+                        *accepted = true;
+                    }
+
+                    if Button::render(
+                        ui,
+                        ButtonProps {
+                            label: "Cancel".to_string(),
+                            button_type: ButtonType::Elevated,
+                            color: ButtonColor::Default,
+                            button_size: ButtonSize::Medium,
+                            height: Some(32.0),
+                            width: Some(100.0),
+                            ..Default::default()
+                        },
+                    )
+                    .clicked
+                    {
+                        *cancelled = true;
+                    }
+                });
+            });
+        });
+}
+
+fn render_permission_row(ui: &mut egui::Ui, entry: &PermissionEntry, colors: &ThemeColors) {
+    ui.horizontal(|ui| {
+        let icon_color = if entry.sensitive { colors.warning } else { colors.accent };
+        ui.label(
+            egui::RichText::new(entry.icon).font(phosphor_font_id(16.0)).color(icon_color),
+        );
+        ui.add_space(8.0);
+        Typography::body_large(ui, &entry.label);
+        ui.add_space(6.0);
+        Typography::render(
+            ui,
+            TypographyProps {
+                text: &entry.scope,
+                variant: TypographyVariant::Mono,
+                size_override: Some(11.0),
+                color: Some(colors.fg_muted),
+                ..Default::default()
+            },
+        );
+        if entry.sensitive {
+            ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
+                Frame::new()
+                    .fill(Color32::from_rgba_premultiplied(249, 226, 175, 26))
+                    .corner_radius(CornerRadius::same(3))
+                    .inner_margin(Margin { left: 5, right: 5, top: 2, bottom: 2 })
+                    .show(ui, |ui| {
+                        Typography::render(
+                            ui,
+                            TypographyProps {
+                                text: "SENSITIVE",
+                                variant: TypographyVariant::Label,
+                                bold: true,
+                                color: Some(colors.warning),
+                                ..Default::default()
+                            },
+                        );
+                    });
+            });
+        }
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use crate::plugin::manager::PluginManager;
 
 pub mod app;
 pub mod components;
+pub mod consent;
 pub mod constants;
 pub mod error;
 pub mod file;
@@ -25,4 +26,6 @@ pub mod update;
 
 pub static PLUGIN_MANAGER: OnceLock<Option<PluginManager>> = OnceLock::new();
 pub static NOTIFICATION_MANAGER: OnceLock<std::sync::Mutex<notification::NotificationManager>> =
+    OnceLock::new();
+pub static CONSENT_MANAGER: OnceLock<std::sync::Mutex<consent::manager::ConsentManager>> =
     OnceLock::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,9 @@ use eframe::{
 };
 use std::path::PathBuf;
 use thoth::{
-    CONSENT_MANAGER, NOTIFICATION_MANAGER, PLUGIN_MANAGER, app, error::Result, helpers::load_icon,
-    consent::manager::ConsentManager,
-    notification::NotificationManager,
-    plugin::manager::PluginManager,
-    settings,
+    CONSENT_MANAGER, NOTIFICATION_MANAGER, PLUGIN_MANAGER, app, consent::manager::ConsentManager,
+    error::Result, helpers::load_icon, notification::NotificationManager,
+    plugin::manager::PluginManager, settings,
 };
 
 /// Parse command-line arguments to extract file path

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,11 @@ use eframe::{
 };
 use std::path::PathBuf;
 use thoth::{
-    NOTIFICATION_MANAGER, PLUGIN_MANAGER, app, error::Result, helpers::load_icon,
-    notification::NotificationManager, plugin::manager::PluginManager, settings,
+    CONSENT_MANAGER, NOTIFICATION_MANAGER, PLUGIN_MANAGER, app, error::Result, helpers::load_icon,
+    consent::manager::ConsentManager,
+    notification::NotificationManager,
+    plugin::manager::PluginManager,
+    settings,
 };
 
 /// Parse command-line arguments to extract file path
@@ -81,6 +84,9 @@ fn main() -> Result<()> {
 
     NOTIFICATION_MANAGER
         .set(std::sync::Mutex::new(NotificationManager::new()))
+        .ok();
+    CONSENT_MANAGER
+        .set(std::sync::Mutex::new(ConsentManager::new()))
         .ok();
 
     let plugin_settings = settings.plugins.plugin_settings.clone();

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -17,12 +17,23 @@ pub enum NotificationStatus {
     Created,
     Viewed,
     Error,
-    ConsentRequired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NotificationKind {
+    Success,
+    Error,
+    Warn,
+    Update,
+    Plugin,
+    Tip,
+    #[default]
+    Info,
 }
 
 #[derive(Clone)]
 pub struct Notification {
-    id: String,
+    pub id: String,
     pub title: String,
     pub message: String,
     pub actions: Vec<(String, Arc<dyn Fn() + Send + Sync + 'static>)>,
@@ -30,6 +41,8 @@ pub struct Notification {
     pub show_toast: bool,
     pub show_in_status_bar: bool,
     pub status: NotificationStatus,
+    pub kind: NotificationKind,
+    pub unread: bool,
 }
 
 pub struct NotificationManager {
@@ -63,29 +76,9 @@ impl NotificationManager {
         Self::notify(
             notification
                 .with_status(NotificationStatus::Error)
+                .with_kind(NotificationKind::Error)
                 .with_toast(true),
         )
-    }
-
-    pub fn show_http_consent_notification(
-        domain: &str,
-        actions: Vec<(String, Arc<dyn Fn() + Send + Sync + 'static>)>,
-    ) -> String {
-        let mut notification = Notification::new(
-            "Network Request Consent",
-            &format!(
-                "A plugin is trying to access '{}'. Do you allow this?",
-                domain
-            ),
-        )
-        .with_status(NotificationStatus::ConsentRequired)
-        .with_toast(false);
-
-        for (label, action) in actions {
-            notification = notification.with_action(&label, action);
-        }
-
-        Self::notify(notification)
     }
 
     pub fn mark_notification_as_complete(id: &str) {
@@ -112,20 +105,6 @@ impl NotificationManager {
             .unwrap_or_default()
     }
 
-    pub fn all_consent_notifications() -> Vec<Notification> {
-        let notifications: Vec<Notification> = NOTIFICATION_MANAGER
-            .get()
-            .and_then(|mutex| mutex.lock().ok())
-            .map(|nm| nm.tasks.values().cloned().collect())
-            .unwrap_or_default();
-
-        notifications
-            .iter()
-            .filter(|n| n.status == NotificationStatus::ConsentRequired)
-            .cloned()
-            .collect()
-    }
-
     pub fn is_notification_empty() -> bool {
         NOTIFICATION_MANAGER
             .get()
@@ -135,10 +114,7 @@ impl NotificationManager {
     }
 
     pub fn add_notification(&mut self, notification: Notification) {
-        if notification.status == NotificationStatus::Running
-            || notification.show_in_status_bar
-            || notification.status == NotificationStatus::ConsentRequired
-        {
+        if notification.status == NotificationStatus::Running || notification.show_in_status_bar {
             self.tasks
                 .insert(notification.id.clone(), notification.clone());
         } else {
@@ -161,6 +137,19 @@ impl NotificationManager {
     pub fn clear_notifications(&mut self) {
         self.notifications.clear();
         self.toasts.dismiss_all_toasts();
+    }
+
+    pub fn mark_all_read(&mut self) {
+        for n in self.notifications.values_mut() {
+            n.unread = false;
+            if n.status == NotificationStatus::Created {
+                n.status = NotificationStatus::Viewed;
+            }
+        }
+    }
+
+    pub fn unread_count(&self) -> usize {
+        self.notifications.values().filter(|n| n.unread).count()
     }
 
     pub fn move_to_notifications(&mut self, id: &str) {
@@ -192,7 +181,14 @@ impl Notification {
             show_toast: true,
             show_in_status_bar: false,
             status: NotificationStatus::Created,
+            kind: NotificationKind::default(),
+            unread: true,
         }
+    }
+
+    pub fn with_kind(mut self, kind: NotificationKind) -> Self {
+        self.kind = kind;
+        self
     }
 
     pub fn with_id(mut self, id: &str) -> Self {

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -34,6 +34,9 @@ pub enum NotificationKind {
 #[derive(Clone)]
 pub struct Notification {
     pub id: String,
+    /// Creation time as Unix epoch milliseconds. Independent of `id` so callers
+    /// can override `id` via `with_id()` without breaking time-based display.
+    pub created_at: i64,
     pub title: String,
     pub message: String,
     pub actions: Vec<(String, Arc<dyn Fn() + Send + Sync + 'static>)>,
@@ -168,12 +171,13 @@ impl Default for NotificationManager {
 
 impl Notification {
     pub fn new(title: &str, message: &str) -> Self {
+        let now_ms = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
         Self {
-            id: SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_millis()
-                .to_string(),
+            id: now_ms.to_string(),
+            created_at: now_ms,
             title: title.to_string(),
             message: message.to_string(),
             actions: Vec::new(),

--- a/src/notification/notification_dropdown.rs
+++ b/src/notification/notification_dropdown.rs
@@ -17,7 +17,7 @@ use crate::{
 
 type NotifAction = Arc<dyn Fn() + Send + Sync + 'static>;
 
-// id, title, message, status, kind, unread, actions
+// id, title, message, status, kind, unread, actions, created_at
 type NotifRow = (
     String,
     String,
@@ -26,6 +26,7 @@ type NotifRow = (
     NotificationKind,
     bool,
     Vec<(String, NotifAction)>,
+    i64,
 );
 
 // ── Filter ────────────────────────────────────────────────────────────────────
@@ -264,22 +265,25 @@ impl NotificationDropdown {
                                     n.kind,
                                     n.unread,
                                     n.actions.clone(),
+                                    n.created_at,
                                 )
                             })
                             .collect();
-                        items.sort_by(|a, b| b.0.cmp(&a.0));
+                        items.sort_by(|a, b| b.7.cmp(&a.7));
                         items
                     })
                     .unwrap_or_default();
 
                 let visible: Vec<&NotifRow> = notifications
                     .iter()
-                    .filter(|(_, _, _, status, kind, unread, _)| match new_filter {
+                    .filter(|(_, _, _, status, kind, unread, _, _)| match new_filter {
                         Filter::All => true,
                         Filter::Unread => *unread,
                         Filter::Plugins => *kind == NotificationKind::Plugin,
                         Filter::Errors => {
-                            *status == NotificationStatus::Error || *kind == NotificationKind::Error
+                            *status == NotificationStatus::Error
+                                || *kind == NotificationKind::Error
+                                || *kind == NotificationKind::Warn
                         }
                     })
                     .collect();
@@ -296,7 +300,7 @@ impl NotificationDropdown {
                                 let bucket: Vec<&NotifRow> = visible
                                     .iter()
                                     .copied()
-                                    .filter(|(id, ..)| date_bucket(id) == bucket_label)
+                                    .filter(|row| date_bucket(row.7) == bucket_label)
                                     .collect();
 
                                 if bucket.is_empty() {
@@ -318,12 +322,12 @@ impl NotificationDropdown {
                                 // must outlive the ListItem borrows below).
                                 let descs: Vec<String> = bucket
                                     .iter()
-                                    .map(|(id, _, message, ..)| {
-                                        let ts = relative_time(id);
-                                        if message.is_empty() {
+                                    .map(|row| {
+                                        let ts = relative_time(row.7);
+                                        if row.2.is_empty() {
                                             ts
                                         } else {
-                                            format!("{message}\n{ts}")
+                                            format!("{}\n{ts}", row.2)
                                         }
                                     })
                                     .collect();
@@ -331,7 +335,7 @@ impl NotificationDropdown {
                                 let list_items: Vec<ListItem<'_>> = bucket
                                     .iter()
                                     .zip(descs.iter())
-                                    .map(|((_, title, _, _, kind, unread, _), desc)| {
+                                    .map(|((_, title, _, _, kind, unread, _, _), desc)| {
                                         let (icon, icon_color) = kind_icon(*kind, colors);
                                         ListItem {
                                             title: title.as_str(),
@@ -381,10 +385,10 @@ impl NotificationDropdown {
                                     }
                                 }
 
-                                // Clicking a row fires its registered actions.
+                                // Clicking a row fires the primary (first) action only.
                                 if let Some(idx) = list_out.row_clicked {
                                     if let Some(row) = bucket.get(idx) {
-                                        for (_, cb) in &row.6 {
+                                        if let Some((_, cb)) = row.6.first() {
                                             cb();
                                         }
                                     }
@@ -506,14 +510,13 @@ fn kind_icon(kind: NotificationKind, colors: &ThemeColors) -> (&'static str, Col
     }
 }
 
-fn date_bucket(id: &str) -> &'static str {
+fn date_bucket(created_ms: i64) -> &'static str {
     let now_ms = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_millis();
-    let created_ms: u128 = id.parse().unwrap_or(0);
-    let age_ms = now_ms.saturating_sub(created_ms);
-    let day_ms: u128 = 24 * 60 * 60 * 1000;
+        .as_millis() as i64;
+    let age_ms = (now_ms - created_ms).max(0);
+    let day_ms: i64 = 24 * 60 * 60 * 1000;
     if age_ms < day_ms {
         "Today"
     } else if age_ms < 2 * day_ms {
@@ -523,13 +526,12 @@ fn date_bucket(id: &str) -> &'static str {
     }
 }
 
-fn relative_time(id: &str) -> String {
+fn relative_time(created_ms: i64) -> String {
     let now_ms = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_millis();
-    let created_ms: u128 = id.parse().unwrap_or(0);
-    let age_secs = now_ms.saturating_sub(created_ms) / 1000;
+        .as_millis() as i64;
+    let age_secs = ((now_ms - created_ms).max(0)) / 1000;
     if age_secs < 60 {
         "just now".to_string()
     } else if age_secs < 3600 {

--- a/src/notification/notification_dropdown.rs
+++ b/src/notification/notification_dropdown.rs
@@ -103,7 +103,11 @@ impl ContextComponent for NotificationDropdown {
                 icon: bell_icon,
                 tooltip: Some("Notifications"),
                 frame: false,
-                badge_color: if unread_count > 0 { Some(colors.error) } else { None },
+                badge_color: if unread_count > 0 {
+                    Some(colors.error)
+                } else {
+                    None
+                },
                 size: None,
                 disabled: false,
                 icon_size: None,
@@ -146,7 +150,12 @@ impl NotificationDropdown {
 
                 // ── Header ────────────────────────────────────────────────────
                 Frame::new()
-                    .inner_margin(Margin { left: 16, right: 12, top: 12, bottom: 10 })
+                    .inner_margin(Margin {
+                        left: 16,
+                        right: 12,
+                        top: 12,
+                        bottom: 10,
+                    })
                     .show(ui, |ui| {
                         ui.horizontal(|ui| {
                             Typography::title(ui, "Notifications");
@@ -202,16 +211,33 @@ impl NotificationDropdown {
 
                 // ── Filter tabs ───────────────────────────────────────────────
                 Frame::new()
-                    .inner_margin(Margin { left: 12, right: 12, top: 8, bottom: 8 })
+                    .inner_margin(Margin {
+                        left: 12,
+                        right: 12,
+                        top: 8,
+                        bottom: 8,
+                    })
                     .show(ui, |ui| {
                         let out = ButtonGroup::render(
                             ui,
                             ButtonGroupProps {
                                 items: &[
-                                    ButtonGroupItem { value: "all", label: "All" },
-                                    ButtonGroupItem { value: "unread", label: "Unread" },
-                                    ButtonGroupItem { value: "plugins", label: "Plugins" },
-                                    ButtonGroupItem { value: "errors", label: "Errors" },
+                                    ButtonGroupItem {
+                                        value: "all",
+                                        label: "All",
+                                    },
+                                    ButtonGroupItem {
+                                        value: "unread",
+                                        label: "Unread",
+                                    },
+                                    ButtonGroupItem {
+                                        value: "plugins",
+                                        label: "Plugins",
+                                    },
+                                    ButtonGroupItem {
+                                        value: "errors",
+                                        label: "Errors",
+                                    },
                                 ],
                                 active: new_filter.as_str(),
                             },
@@ -253,8 +279,7 @@ impl NotificationDropdown {
                         Filter::Unread => *unread,
                         Filter::Plugins => *kind == NotificationKind::Plugin,
                         Filter::Errors => {
-                            *status == NotificationStatus::Error
-                                || *kind == NotificationKind::Error
+                            *status == NotificationStatus::Error || *kind == NotificationKind::Error
                         }
                     })
                     .collect();
@@ -286,10 +311,7 @@ impl NotificationDropdown {
                                         bottom: 4,
                                     })
                                     .show(ui, |ui| {
-                                        Typography::group_label(
-                                            ui,
-                                            &bucket_label.to_uppercase(),
-                                        );
+                                        Typography::group_label(ui, &bucket_label.to_uppercase());
                                     });
 
                                 // Pre-build descriptions (formatted Strings that
@@ -374,7 +396,12 @@ impl NotificationDropdown {
                 // ── Footer ────────────────────────────────────────────────────
                 ui.add(egui::Separator::default().spacing(0.0));
                 Frame::new()
-                    .inner_margin(Margin { left: 14, right: 14, top: 8, bottom: 8 })
+                    .inner_margin(Margin {
+                        left: 14,
+                        right: 14,
+                        top: 8,
+                        bottom: 8,
+                    })
                     .fill(colors.bg_sunken)
                     .show(ui, |ui| {
                         ui.horizontal(|ui| {
@@ -438,7 +465,12 @@ fn render_empty_state(ui: &mut egui::Ui, filter: Filter) {
     });
 
     Frame::new()
-        .inner_margin(Margin { left: 0, right: 0, top: 40, bottom: 40 })
+        .inner_margin(Margin {
+            left: 0,
+            right: 0,
+            top: 40,
+            bottom: 40,
+        })
         .show(ui, |ui| {
             ui.with_layout(Layout::top_down(egui::Align::Center), |ui| {
                 ui.label(

--- a/src/notification/notification_dropdown.rs
+++ b/src/notification/notification_dropdown.rs
@@ -1,28 +1,78 @@
-use eframe::egui::{self, Align2, CornerRadius, Layout};
+use eframe::egui::{self, Align2, Color32, CornerRadius, Frame, Layout, Margin, RichText, Stroke};
+use std::sync::Arc;
+use std::time::SystemTime;
 
 use crate::{
     components::{
-        button::{Button, ButtonColor, ButtonProps},
+        button::{Button, ButtonColor, ButtonProps, ButtonSize, ButtonType},
+        button_group::{ButtonGroup, ButtonGroupItem, ButtonGroupProps},
         icon_button::{IconButton, IconButtonProps},
-        list::{List, ListItem, ListProps},
+        list::{List, ListItem, ListItemPostfix, ListItemPrefix, ListProps},
         traits::{ContextComponent, StatelessComponent},
+        typography::{Typography, TypographyProps, TypographyVariant},
     },
-    notification::{Notification, NotificationManager, NotificationStatus},
+    notification::{NotificationKind, NotificationManager, NotificationStatus},
+    theme::{ThemeColors, phosphor_font_id},
 };
+
+type NotifAction = Arc<dyn Fn() + Send + Sync + 'static>;
+
+// id, title, message, status, kind, unread, actions
+type NotifRow = (
+    String,
+    String,
+    String,
+    NotificationStatus,
+    NotificationKind,
+    bool,
+    Vec<(String, NotifAction)>,
+);
+
+// ── Filter ────────────────────────────────────────────────────────────────────
+
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+enum Filter {
+    #[default]
+    All,
+    Unread,
+    Plugins,
+    Errors,
+}
+
+impl Filter {
+    fn as_str(self) -> &'static str {
+        match self {
+            Filter::All => "all",
+            Filter::Unread => "unread",
+            Filter::Plugins => "plugins",
+            Filter::Errors => "errors",
+        }
+    }
+
+    fn from_str(s: &str) -> Self {
+        match s {
+            "unread" => Filter::Unread,
+            "plugins" => Filter::Plugins,
+            "errors" => Filter::Errors,
+            _ => Filter::All,
+        }
+    }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
 
 #[derive(Default)]
 pub struct NotificationDropdown {
-    state: NotificationDropdownState,
+    state: State,
 }
 
 #[derive(Default)]
-pub struct NotificationDropdownState {
+struct State {
     is_open: bool,
+    filter: Filter,
 }
 
-pub struct NotificationDropdownProps {
-    // Define any properties needed for the dropdown
-}
+pub struct NotificationDropdownProps;
 
 impl ContextComponent for NotificationDropdown {
     type Props<'a> = NotificationDropdownProps;
@@ -31,237 +81,430 @@ impl ContextComponent for NotificationDropdown {
     fn render(&mut self, ui: &mut egui::Ui, _props: Self::Props<'_>) -> Self::Output {
         let colors = ui.ctx().memory(|mem| {
             mem.data
-                .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
+                .get_temp::<ThemeColors>(egui::Id::new("theme_colors"))
                 .unwrap_or_else(|| crate::theme::Theme::default().colors())
         });
 
-        let notification_manager = crate::NOTIFICATION_MANAGER.get();
-        let notification_empty = notification_manager
-            .and_then(|mutex| mutex.lock().ok())
-            .map(|nm| nm.notifications.is_empty())
-            .unwrap_or(true);
+        let unread_count = crate::NOTIFICATION_MANAGER
+            .get()
+            .and_then(|m| m.lock().ok())
+            .map(|nm| nm.unread_count())
+            .unwrap_or(0);
 
-        let badge_color = if !notification_empty {
-            Some(colors.error)
+        let bell_icon = if unread_count > 0 {
+            egui_phosphor::regular::BELL_RINGING
         } else {
-            None
+            egui_phosphor::regular::BELL
         };
 
-        let button_output = IconButton::render(
+        let btn = IconButton::render(
             ui,
             IconButtonProps {
-                icon: egui_phosphor::regular::BELL,
+                icon: bell_icon,
                 tooltip: Some("Notifications"),
                 frame: false,
-                badge_color,
+                badge_color: if unread_count > 0 { Some(colors.error) } else { None },
                 size: None,
                 disabled: false,
                 icon_size: None,
-                selected: false,
+                selected: self.state.is_open,
             },
         );
 
-        if button_output.clicked {
+        if btn.clicked {
             self.state.is_open = !self.state.is_open;
         }
 
         if self.state.is_open {
-            // Render the dropdown menu
-            egui::Window::new("Notifications")
-                .frame(egui::Frame::window(&ui.ctx().global_style()).inner_margin(0))
-                .title_bar(false)
-                .anchor(Align2::RIGHT_BOTTOM, egui::vec2(-10.0, -28.0))
-                .resizable(false)
-                .collapsible(false)
-                .movable(false)
-                .min_height(25.0)
-                .scroll([false, true])
-                .show(ui.ctx(), |ui| {
-                    egui::Frame::new()
-                        .inner_margin(egui::Margin::same(8))
-                        .corner_radius(CornerRadius::same(4))
-                        .fill(colors.surface_raised)
-                        .stroke(ui.style().visuals.window_stroke())
-                        .show(ui, |ui| {
-                            ui.set_min_width(ui.available_width());
+            self.render_panel(ui, &colors, unread_count);
+        }
+    }
+}
 
-                            ui.horizontal(|ui| {
-                                ui.heading("Notifications");
-                                ui.with_layout(Layout::right_to_left(egui::Align::TOP), |ui| {
-                                    let close_button = IconButton::render(
-                                        ui,
-                                        IconButtonProps {
-                                            icon: egui_phosphor::regular::CARET_DOWN,
-                                            tooltip: Some("Close notifications"),
-                                            frame: false,
-                                            badge_color: None,
-                                            size: None,
-                                            disabled: false,
-                                            icon_size: None,
-                                            selected: false,
-                                        },
-                                    );
-                                    if let Some(mutex) = notification_manager {
-                                        if let Ok(mut nm) = mutex.lock() {
-                                            let clear_button = IconButton::render(
-                                                ui,
-                                                IconButtonProps {
-                                                    icon: egui_phosphor::regular::X,
-                                                    tooltip: Some("Clear notifications"),
-                                                    frame: false,
-                                                    badge_color: None,
-                                                    size: None,
-                                                    disabled: nm.notifications.is_empty(),
-                                                    selected: false,
-                                                    icon_size: None,
-                                                },
-                                            );
+impl NotificationDropdown {
+    fn render_panel(&mut self, ui: &mut egui::Ui, colors: &ThemeColors, unread_count: usize) {
+        let mut close_panel = false;
+        let mut to_dismiss: Option<String> = None;
+        let mut new_filter = self.state.filter;
 
-                                            if clear_button.clicked {
-                                                nm.clear_notifications();
-                                            }
+        egui::Window::new("##notification_panel")
+            .title_bar(false)
+            .resizable(false)
+            .collapsible(false)
+            .movable(false)
+            .anchor(Align2::RIGHT_BOTTOM, egui::vec2(-4.0, -28.0))
+            .fixed_size(egui::vec2(380.0, 520.0))
+            .frame(
+                Frame::new()
+                    .fill(colors.bg_panel)
+                    .stroke(Stroke::new(1.0, colors.surface))
+                    .corner_radius(CornerRadius::same(8)),
+            )
+            .show(ui.ctx(), |ui| {
+                ui.set_min_width(380.0);
+                ui.set_max_width(380.0);
+
+                // ── Header ────────────────────────────────────────────────────
+                Frame::new()
+                    .inner_margin(Margin { left: 16, right: 12, top: 12, bottom: 10 })
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            Typography::title(ui, "Notifications");
+                            if unread_count > 0 {
+                                ui.add_space(6.0);
+                                Typography::caption(ui, &format!("{unread_count} unread"));
+                            }
+                            ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
+                                if IconButton::render(
+                                    ui,
+                                    IconButtonProps {
+                                        icon: egui_phosphor::regular::X,
+                                        tooltip: Some("Close"),
+                                        frame: false,
+                                        badge_color: None,
+                                        size: Some(egui::vec2(20.0, 20.0)),
+                                        icon_size: Some(13.0),
+                                        disabled: false,
+                                        selected: false,
+                                    },
+                                )
+                                .clicked
+                                {
+                                    close_panel = true;
+                                }
+                                ui.add_space(4.0);
+                                if IconButton::render(
+                                    ui,
+                                    IconButtonProps {
+                                        icon: egui_phosphor::regular::CHECKS,
+                                        tooltip: Some("Mark all as read"),
+                                        frame: false,
+                                        badge_color: None,
+                                        size: Some(egui::vec2(20.0, 20.0)),
+                                        icon_size: Some(13.0),
+                                        disabled: unread_count == 0,
+                                        selected: false,
+                                    },
+                                )
+                                .clicked
+                                {
+                                    if let Some(m) = crate::NOTIFICATION_MANAGER.get() {
+                                        if let Ok(mut nm) = m.lock() {
+                                            nm.mark_all_read();
                                         }
                                     }
-
-                                    if close_button.clicked {
-                                        self.state.is_open = false;
-                                    }
-                                });
+                                }
                             });
                         });
+                    });
 
-                    // Collect notification data while holding the lock briefly
-                    let notifications: Vec<(String, String, String, NotificationStatus)> =
-                        notification_manager
-                            .and_then(|m| m.lock().ok())
-                            .map(|nm| {
-                                nm.notifications
-                                    .iter()
-                                    .map(|(id, n)| {
-                                        (id.clone(), n.title.clone(), n.message.clone(), n.status)
-                                    })
-                                    .collect()
+                ui.add(egui::Separator::default().spacing(0.0));
+
+                // ── Filter tabs ───────────────────────────────────────────────
+                Frame::new()
+                    .inner_margin(Margin { left: 12, right: 12, top: 8, bottom: 8 })
+                    .show(ui, |ui| {
+                        let out = ButtonGroup::render(
+                            ui,
+                            ButtonGroupProps {
+                                items: &[
+                                    ButtonGroupItem { value: "all", label: "All" },
+                                    ButtonGroupItem { value: "unread", label: "Unread" },
+                                    ButtonGroupItem { value: "plugins", label: "Plugins" },
+                                    ButtonGroupItem { value: "errors", label: "Errors" },
+                                ],
+                                active: new_filter.as_str(),
+                            },
+                        );
+                        if let Some(v) = out.selected {
+                            new_filter = Filter::from_str(&v);
+                        }
+                    });
+
+                // ── Notification list ─────────────────────────────────────────
+                let notifications: Vec<NotifRow> = crate::NOTIFICATION_MANAGER
+                    .get()
+                    .and_then(|m| m.lock().ok())
+                    .map(|nm| {
+                        let mut items: Vec<NotifRow> = nm
+                            .notifications
+                            .values()
+                            .map(|n| {
+                                (
+                                    n.id.clone(),
+                                    n.title.clone(),
+                                    n.message.clone(),
+                                    n.status,
+                                    n.kind,
+                                    n.unread,
+                                    n.actions.clone(),
+                                )
                             })
-                            .unwrap_or_default();
+                            .collect();
+                        items.sort_by(|a, b| b.0.cmp(&a.0));
+                        items
+                    })
+                    .unwrap_or_default();
 
-                    let items: Vec<ListItem> = notifications
-                        .iter()
-                        .map(|(_, title, message, status)| {
-                            let (icon, color) = match status {
-                                NotificationStatus::Error => {
-                                    (egui_phosphor::regular::WARNING, colors.error)
+                let visible: Vec<&NotifRow> = notifications
+                    .iter()
+                    .filter(|(_, _, _, status, kind, unread, _)| match new_filter {
+                        Filter::All => true,
+                        Filter::Unread => *unread,
+                        Filter::Plugins => *kind == NotificationKind::Plugin,
+                        Filter::Errors => {
+                            *status == NotificationStatus::Error
+                                || *kind == NotificationKind::Error
+                        }
+                    })
+                    .collect();
+
+                egui::ScrollArea::vertical()
+                    .max_height(380.0)
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        if visible.is_empty() {
+                            render_empty_state(ui, new_filter);
+                        } else {
+                            for bucket_label in ["Today", "Yesterday", "Earlier"] {
+                                // Rows for this date bucket
+                                let bucket: Vec<&NotifRow> = visible
+                                    .iter()
+                                    .copied()
+                                    .filter(|(id, ..)| date_bucket(id) == bucket_label)
+                                    .collect();
+
+                                if bucket.is_empty() {
+                                    continue;
                                 }
-                                NotificationStatus::Completed => {
-                                    (egui_phosphor::regular::CHECK, colors.success)
-                                }
-                                NotificationStatus::Running => {
-                                    (egui_phosphor::regular::CLOCK, colors.warning)
-                                }
-                                _ => (egui_phosphor::regular::INFO, colors.info),
-                            };
-                            ListItem {
-                                title,
-                                description: if message.is_empty() {
-                                    None
-                                } else {
-                                    Some(message.as_str())
-                                },
-                                prefix: Some(
-                                    crate::components::common::list::ListItemPrefix::Icon {
-                                        glyph: icon,
-                                        color: Some(color),
-                                    },
-                                ),
-                                badge: None,
-                                postfix: None,
-                                selected: false,
-                                tags: &[],
-                            }
-                        })
-                        .collect();
 
-                    ui.set_min_width(280.0);
-                    let _list_out = List::render(
-                        ui,
-                        ListProps {
-                            items: &items,
-                            empty_label: Some("No notifications"),
-                            shrink_to_fit: false,
-                            show_separators: true,
-                            compact: false,
-                        },
-                    );
-                });
-        }
+                                Frame::new()
+                                    .inner_margin(Margin {
+                                        left: 16,
+                                        right: 16,
+                                        top: 8,
+                                        bottom: 4,
+                                    })
+                                    .show(ui, |ui| {
+                                        Typography::group_label(
+                                            ui,
+                                            &bucket_label.to_uppercase(),
+                                        );
+                                    });
 
-        let running_tasks: Vec<Notification> =
-            NotificationManager::all_running_notifications_tasks();
+                                // Pre-build descriptions (formatted Strings that
+                                // must outlive the ListItem borrows below).
+                                let descs: Vec<String> = bucket
+                                    .iter()
+                                    .map(|(id, _, message, ..)| {
+                                        let ts = relative_time(id);
+                                        if message.is_empty() {
+                                            ts
+                                        } else {
+                                            format!("{message}\n{ts}")
+                                        }
+                                    })
+                                    .collect();
 
-        for task in running_tasks {
-            ui.add(egui::Spinner::new().size(16.0).color(colors.warning));
-            ui.label(&task.title);
-        }
+                                let list_items: Vec<ListItem<'_>> = bucket
+                                    .iter()
+                                    .zip(descs.iter())
+                                    .map(|((_, title, _, _, kind, unread, _), desc)| {
+                                        let (icon, icon_color) = kind_icon(*kind, colors);
+                                        ListItem {
+                                            title: title.as_str(),
+                                            description: Some(desc.as_str()),
+                                            prefix: Some(ListItemPrefix::Icon {
+                                                glyph: icon,
+                                                color: Some(icon_color),
+                                            }),
+                                            badge: None,
+                                            postfix: Some(ListItemPostfix::IconButton(
+                                                IconButtonProps {
+                                                    icon: egui_phosphor::regular::X,
+                                                    tooltip: Some("Dismiss"),
+                                                    frame: false,
+                                                    badge_color: None,
+                                                    size: Some(egui::vec2(18.0, 18.0)),
+                                                    icon_size: Some(11.0),
+                                                    disabled: false,
+                                                    selected: false,
+                                                },
+                                            )),
+                                            // selected drives the left accent border
+                                            // and the hover highlight — maps to unread.
+                                            selected: *unread,
+                                            tags: &[],
+                                        }
+                                    })
+                                    .collect();
 
-        let open_consent_notifications: Vec<Notification> =
-            NotificationManager::all_consent_notifications();
-
-        if !open_consent_notifications.is_empty() {
-            egui::Window::new("Notifications - Consent")
-                .frame(egui::Frame::window(&ui.ctx().global_style()).inner_margin(0))
-                .title_bar(false)
-                .anchor(Align2::RIGHT_BOTTOM, egui::vec2(-10.0, -28.0))
-                .resizable(false)
-                .collapsible(false)
-                .movable(false)
-                .min_height(25.0)
-                .scroll([false, true])
-                .show(ui.ctx(), |ui| {
-                    ui.set_min_width(300.0);
-                    ui.heading("Action Required");
-
-                    let mut clicked: Option<(
-                        String,
-                        std::sync::Arc<dyn Fn() + Send + Sync + 'static>,
-                    )> = None;
-
-                    for n in &open_consent_notifications {
-                        ui.horizontal(|ui| {
-                            ui.colored_label(colors.warning, egui_phosphor::regular::WARNING);
-                            ui.vertical(|ui| {
-                                ui.label(&n.title);
-                                if !n.message.is_empty() {
-                                    ui.label(egui::RichText::new(&n.message).weak().small());
-                                }
-                            });
-                        });
-                        ui.horizontal(|ui| {
-                            for (i, (label, callback)) in n.actions.iter().enumerate() {
-                                let color = if i == 0 {
-                                    ButtonColor::Primary
-                                } else {
-                                    ButtonColor::Default
-                                };
-                                let btn = Button::render(
+                                let list_out = List::render(
                                     ui,
-                                    ButtonProps {
-                                        label: label.clone(),
-                                        color,
-                                        ..Default::default()
+                                    ListProps {
+                                        items: &list_items,
+                                        empty_label: None,
+                                        // Must be true so the List's inner ScrollArea
+                                        // shrinks to content and doesn't conflict with
+                                        // our outer ScrollArea.
+                                        shrink_to_fit: true,
+                                        show_separators: true,
+                                        compact: false,
                                     },
                                 );
-                                if btn.clicked && clicked.is_none() {
-                                    clicked = Some((n.id.clone(), callback.clone()));
+
+                                if let Some(idx) = list_out.postfix_clicked {
+                                    if let Some(row) = bucket.get(idx) {
+                                        to_dismiss = Some(row.0.clone());
+                                    }
+                                }
+
+                                // Clicking a row fires its registered actions.
+                                if let Some(idx) = list_out.row_clicked {
+                                    if let Some(row) = bucket.get(idx) {
+                                        for (_, cb) in &row.6 {
+                                            cb();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    });
+
+                // ── Footer ────────────────────────────────────────────────────
+                ui.add(egui::Separator::default().spacing(0.0));
+                Frame::new()
+                    .inner_margin(Margin { left: 14, right: 14, top: 8, bottom: 8 })
+                    .fill(colors.bg_sunken)
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            if Button::render(
+                                ui,
+                                ButtonProps {
+                                    label: "Clear all".to_string(),
+                                    button_type: ButtonType::Text,
+                                    color: ButtonColor::Default,
+                                    button_size: ButtonSize::Small,
+                                    ..Default::default()
+                                },
+                            )
+                            .clicked
+                            {
+                                if let Some(m) = crate::NOTIFICATION_MANAGER.get() {
+                                    if let Ok(mut nm) = m.lock() {
+                                        nm.clear_notifications();
+                                    }
                                 }
                             }
                         });
-                        ui.separator();
-                    }
+                    });
+            });
 
-                    if let Some((id, callback)) = clicked {
-                        callback();
-                        NotificationManager::mark_notification_as_complete(&id);
-                    }
-                });
+        self.state.filter = new_filter;
+        if close_panel {
+            self.state.is_open = false;
         }
+        if let Some(id) = to_dismiss {
+            NotificationManager::remove_notification(&id);
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn render_empty_state(ui: &mut egui::Ui, filter: Filter) {
+    let (icon, title, body) = match filter {
+        Filter::All | Filter::Unread => (
+            egui_phosphor::regular::BELL,
+            "All caught up",
+            "No notifications yet",
+        ),
+        Filter::Plugins => (
+            egui_phosphor::regular::PUZZLE_PIECE,
+            "No plugin events",
+            "Plugin activity will appear here",
+        ),
+        Filter::Errors => (
+            egui_phosphor::regular::WARNING_CIRCLE,
+            "No errors",
+            "Errors and warnings will appear here",
+        ),
+    };
+
+    let colors = ui.ctx().memory(|mem| {
+        mem.data
+            .get_temp::<ThemeColors>(egui::Id::new("theme_colors"))
+            .unwrap_or_else(|| crate::theme::Theme::default().colors())
+    });
+
+    Frame::new()
+        .inner_margin(Margin { left: 0, right: 0, top: 40, bottom: 40 })
+        .show(ui, |ui| {
+            ui.with_layout(Layout::top_down(egui::Align::Center), |ui| {
+                ui.label(
+                    RichText::new(icon)
+                        .font(phosphor_font_id(32.0))
+                        .color(colors.surface_active),
+                );
+                ui.add_space(8.0);
+                Typography::render(
+                    ui,
+                    TypographyProps {
+                        text: title,
+                        variant: TypographyVariant::BodyLarge,
+                        bold: true,
+                        ..Default::default()
+                    },
+                );
+                ui.add_space(4.0);
+                Typography::body_muted(ui, body);
+            });
+        });
+}
+
+fn kind_icon(kind: NotificationKind, colors: &ThemeColors) -> (&'static str, Color32) {
+    match kind {
+        NotificationKind::Success => (egui_phosphor::regular::CHECK_CIRCLE, colors.success),
+        NotificationKind::Error => (egui_phosphor::regular::WARNING_CIRCLE, colors.error),
+        NotificationKind::Warn => (egui_phosphor::regular::WARNING, colors.warning),
+        NotificationKind::Update => (egui_phosphor::regular::ARROW_CIRCLE_UP, colors.info),
+        NotificationKind::Plugin => (egui_phosphor::regular::PUZZLE_PIECE, colors.accent),
+        NotificationKind::Tip => (egui_phosphor::regular::LIGHTBULB, colors.info),
+        NotificationKind::Info => (egui_phosphor::regular::INFO, colors.info),
+    }
+}
+
+fn date_bucket(id: &str) -> &'static str {
+    let now_ms = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let created_ms: u128 = id.parse().unwrap_or(0);
+    let age_ms = now_ms.saturating_sub(created_ms);
+    let day_ms: u128 = 24 * 60 * 60 * 1000;
+    if age_ms < day_ms {
+        "Today"
+    } else if age_ms < 2 * day_ms {
+        "Yesterday"
+    } else {
+        "Earlier"
+    }
+}
+
+fn relative_time(id: &str) -> String {
+    let now_ms = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let created_ms: u128 = id.parse().unwrap_or(0);
+    let age_secs = now_ms.saturating_sub(created_ms) / 1000;
+    if age_secs < 60 {
+        "just now".to_string()
+    } else if age_secs < 3600 {
+        format!("{}m ago", age_secs / 60)
+    } else if age_secs < 86400 {
+        format!("{}h ago", age_secs / 3600)
+    } else {
+        format!("{}d ago", age_secs / 86400)
     }
 }

--- a/src/plugin/network_policy.rs
+++ b/src/plugin/network_policy.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use reqwest::Url;
 
 use crate::{plugin::NetworkDeclarations, settings::PluginNetworkPolicy};
@@ -6,6 +8,9 @@ pub struct NetworkPolicy {
     config: PluginNetworkPolicy,
     request_count: u32,
     window_start: std::time::Instant,
+    /// Domains approved at runtime via "Remember this choice" — checked after
+    /// the static policy so consent-modal approvals take effect immediately.
+    runtime_allowed: Arc<Mutex<Vec<String>>>,
 }
 
 pub enum CheckOutcome {
@@ -90,8 +95,16 @@ impl NetworkPolicy {
             config,
             request_count: 0,
             window_start: std::time::Instant::now(),
+            runtime_allowed: Arc::new(Mutex::new(Vec::new())),
         }
     }
+
+    /// Returns a handle to the runtime-approved domain list so it can be shared
+    /// into consent callbacks and populated when the user checks "Remember".
+    pub fn runtime_allowed_handle(&self) -> Arc<Mutex<Vec<String>>> {
+        Arc::clone(&self.runtime_allowed)
+    }
+
     pub fn check(&mut self, url: &str) -> Result<CheckOutcome, PolicyViolation> {
         let parsed_url =
             Url::parse(url).map_err(|err| PolicyViolation::InvalidUrl(err.to_string()))?;
@@ -114,8 +127,8 @@ impl NetworkPolicy {
             return Err(PolicyViolation::UserBlocked);
         }
 
-        // Check if domain is explicitly allowed
-        if self.is_allowed(&host) {
+        // Check static allowed list, then runtime approvals from consent modal
+        if self.is_allowed(&host) || self.is_runtime_allowed(&host) {
             return Ok(CheckOutcome::Allowed);
         }
 
@@ -137,6 +150,14 @@ impl NetworkPolicy {
             .allowed_domains
             .iter()
             .any(|domain| self.domain_matches(host, domain))
+    }
+
+    fn is_runtime_allowed(&self, host: &str) -> bool {
+        if let Ok(list) = self.runtime_allowed.lock() {
+            list.iter().any(|d| self.domain_matches(host, d))
+        } else {
+            false
+        }
     }
 
     fn domain_matches(&self, host: &str, pattern: &str) -> bool {

--- a/src/plugin/network_policy.rs
+++ b/src/plugin/network_policy.rs
@@ -11,6 +11,10 @@ pub struct NetworkPolicy {
     /// Domains approved at runtime via "Remember this choice" — checked after
     /// the static policy so consent-modal approvals take effect immediately.
     runtime_allowed: Arc<Mutex<Vec<String>>>,
+    /// Original normalised plugin-manifest domain list. Runtime consent can
+    /// only relax user-side restrictions; it cannot expand the plugin's own
+    /// declared scope.
+    plugin_declared_domains: Vec<String>,
 }
 
 pub enum CheckOutcome {
@@ -96,6 +100,7 @@ impl NetworkPolicy {
             request_count: 0,
             window_start: std::time::Instant::now(),
             runtime_allowed: Arc::new(Mutex::new(Vec::new())),
+            plugin_declared_domains: norm(&plugin.allowed_domains),
         }
     }
 
@@ -127,8 +132,12 @@ impl NetworkPolicy {
             return Err(PolicyViolation::UserBlocked);
         }
 
-        // Check static allowed list, then runtime approvals from consent modal
-        if self.is_allowed(&host) || self.is_runtime_allowed(&host) {
+        // Static allowed list passes unconditionally.
+        // Runtime approvals only apply within the plugin's declared scope so a
+        // user approval cannot expand the plugin beyond its manifest.
+        if self.is_allowed(&host)
+            || (self.is_within_plugin_scope(&host) && self.is_runtime_allowed(&host))
+        {
             return Ok(CheckOutcome::Allowed);
         }
 
@@ -150,6 +159,20 @@ impl NetworkPolicy {
             .allowed_domains
             .iter()
             .any(|domain| self.domain_matches(host, domain))
+    }
+
+    /// Returns true when `host` falls within what the plugin's manifest declared.
+    /// An empty or wildcard manifest means the plugin imposed no domain
+    /// restrictions, so any host is considered within scope.
+    pub fn is_within_plugin_scope(&self, host: &str) -> bool {
+        if self.plugin_declared_domains.is_empty()
+            || self.plugin_declared_domains.contains(&"*".to_string())
+        {
+            return true;
+        }
+        self.plugin_declared_domains
+            .iter()
+            .any(|d| self.domain_matches(host, d))
     }
 
     fn is_runtime_allowed(&self, host: &str) -> bool {

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -159,10 +159,30 @@ impl thoth::plugin::http_client::Host for DataSourcePluginState {
                 })
             }
             Ok(CheckOutcome::NeedsConsent { domain }) => {
-                // fetch() is synchronous: return Err immediately so the plugin
-                // can show an error. If the user later approves, the retry goes
-                // through retry_tx and is delivered as an async http event.
-                self.push_consent(&domain, req, next_request_id(), Arc::new(|_| {}));
+                // fetch() is synchronous — return Err immediately.
+                // Show the consent modal so the user is informed, and update
+                // runtime_allowed on approval so a subsequent fetch() succeeds.
+                // We do NOT queue a retry here: the plugin already received an
+                // error and there is no request-id for the caller to correlate
+                // an async result against.
+                let _ = self.consent_tx.send(ConsentRequest {
+                    domain: domain.clone(),
+                    plugin_id: self.plugin_id.clone(),
+                });
+                let runtime_allowed = self.policy.runtime_allowed_handle();
+                let dom = domain.clone();
+                ConsentManager::push_http_consent(
+                    &domain,
+                    &self.plugin_id,
+                    Arc::new(move |remember: bool| {
+                        if remember {
+                            if let Ok(mut list) = runtime_allowed.lock() {
+                                list.push(dom.clone());
+                            }
+                        }
+                    }),
+                    Arc::new(|_| {}),
+                );
                 Err(thoth::plugin::http_client::PluginError {
                     code: 403,
                     message: format!("domain '{domain}' not approved — waiting for user consent"),

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -7,8 +7,8 @@ use wasmtime::{Engine, Store};
 use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
 use crate::app::persistent_state::PersistentState;
-use crate::error::{Result, ThothError};
 use crate::consent::manager::{ConsentCallback, ConsentManager};
+use crate::error::{Result, ThothError};
 use crate::plugin::network_policy::{CheckOutcome, NetworkPolicy};
 use crate::settings::PluginSettingData;
 

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -8,7 +8,7 @@ use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiVie
 
 use crate::app::persistent_state::PersistentState;
 use crate::error::{Result, ThothError};
-use crate::notification::NotificationManager;
+use crate::consent::manager::{ConsentCallback, ConsentManager};
 use crate::plugin::network_policy::{CheckOutcome, NetworkPolicy};
 use crate::settings::PluginSettingData;
 
@@ -98,6 +98,48 @@ impl WasiView for DataSourcePluginState {
     }
 }
 
+// ── consent helper ────────────────────────────────────────────────────────────
+
+impl DataSourcePluginState {
+    /// Register a pending consent request for `domain`.
+    ///
+    /// Notifies the host via `consent_tx` so the UI can show an indicator, then
+    /// queues a `ConsentManager` entry whose `on_allow` closure retries `req`
+    /// through `retry_tx` (the host re-dispatches it as a normal async request).
+    /// `on_deny` is called if the user rejects; for synchronous `fetch()` callers
+    /// the plugin already received an error, so pass `Arc::new(|| {})`.
+    fn push_consent(
+        &self,
+        domain: &str,
+        req: thoth::plugin::http_client::HttpRequest,
+        retry_id: String,
+        on_deny: ConsentCallback,
+    ) {
+        let _ = self.consent_tx.send(ConsentRequest {
+            domain: domain.to_string(),
+            plugin_id: self.plugin_id.clone(),
+        });
+        let retry_tx = Arc::clone(&self.retry_tx);
+        let runtime_allowed = self.policy.runtime_allowed_handle();
+        let dom = domain.to_string();
+        ConsentManager::push_http_consent(
+            domain,
+            &self.plugin_id,
+            Arc::new(move |remember: bool| {
+                if let Ok(tx) = retry_tx.lock() {
+                    let _ = tx.send((retry_id.clone(), req.clone()));
+                }
+                if remember {
+                    if let Ok(mut list) = runtime_allowed.lock() {
+                        list.push(dom.clone());
+                    }
+                }
+            }),
+            on_deny,
+        );
+    }
+}
+
 // ── http-client WIT import — host side ───────────────────────────────────────
 
 impl thoth::plugin::http_client::Host for DataSourcePluginState {
@@ -117,27 +159,10 @@ impl thoth::plugin::http_client::Host for DataSourcePluginState {
                 })
             }
             Ok(CheckOutcome::NeedsConsent { domain }) => {
-                let _ = self.consent_tx.send(ConsentRequest {
-                    domain: domain.clone(),
-                    plugin_id: self.plugin_id.clone(),
-                });
-
-                let retry_tx = Arc::clone(&self.retry_tx);
-                let retry_id = next_request_id();
-                let retry_req = req.clone();
-
-                NotificationManager::show_http_consent_notification(
-                    &domain,
-                    vec![(
-                        "Allow".to_string(),
-                        Arc::new(move || {
-                            if let Ok(tx) = retry_tx.lock() {
-                                let _ = tx.send((retry_id.clone(), retry_req.clone()));
-                            }
-                        }),
-                    )],
-                );
-
+                // fetch() is synchronous: return Err immediately so the plugin
+                // can show an error. If the user later approves, the retry goes
+                // through retry_tx and is delivered as an async http event.
+                self.push_consent(&domain, req, next_request_id(), Arc::new(|_| {}));
                 Err(thoth::plugin::http_client::PluginError {
                     code: 403,
                     message: format!("domain '{domain}' not approved — waiting for user consent"),
@@ -175,32 +200,27 @@ impl thoth::plugin::http_client::Host for DataSourcePluginState {
                 });
             }
             Ok(CheckOutcome::NeedsConsent { domain }) => {
-                let _ = self.consent_tx.send(ConsentRequest {
-                    domain: domain.clone(),
-                    plugin_id: self.plugin_id.clone(),
-                });
-                // pending_count is incremented below before the immediate error send
-                // so drain_http_results' fetch_sub stays balanced. The retry path
-                // also increments separately when the user approves.
-
-                let retry_tx = Arc::clone(&self.retry_tx);
-                let retry_id = request_id.clone();
-                let retry_req = req.clone();
-                NotificationManager::show_http_consent_notification(
+                let deny_tx = tx.clone();
+                let deny_id = id.clone();
+                let deny_domain = domain.clone();
+                let deny_count = Arc::clone(&self.pending_count);
+                self.push_consent(
                     &domain,
-                    vec![(
-                        "Allow".to_string(),
-                        Arc::new(move || {
-                            if let Ok(tx) = retry_tx.lock() {
-                                let _ = tx.send((retry_id.clone(), retry_req.clone()));
-                            }
-                        }),
-                    )],
+                    req,
+                    request_id.clone(),
+                    Arc::new(move |_remember: bool| {
+                        deny_count.fetch_add(1, Ordering::Relaxed);
+                        let _ = deny_tx.send((
+                            deny_id.clone(),
+                            Err::<HttpResponseRaw, String>(format!(
+                                "domain '{deny_domain}' access denied by user"
+                            )),
+                        ));
+                    }),
                 );
 
-                // Deliver an immediate error so the plugin can show "awaiting consent".
-                // Must increment pending_count before sending so drain_http_results'
-                // unconditional fetch_sub stays balanced.
+                // Immediate "awaiting consent" notification — lets the plugin update
+                // its UI state while the modal is open.
                 self.pending_count.fetch_add(1, Ordering::Relaxed);
                 let _ = tx.send((
                     id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin permission consent modal with "Remember this choice" and integrated consent queue for host/domain approvals.
  * Status bar now surfaces consent requests and updates plugin network approvals when remembered.
  * Notifications redesigned with unread counts, filters (All/Unread/Plugins/Errors), chronological grouping, per-item dismiss, and "mark all read"/"clear all".
  * Marketplace toasts for plugin install/uninstall; new common button group available in UI components.

* **Chores**
  * CI updated to use the stable Rust toolchain and revised clippy setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anitnilay20/thoth/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->