### PR TITLE
Refactor path registration to use OS-specific symlinks/environment variables

### DIFF
--- a/src/platform/path_registry.rs
+++ b/src/platform/path_registry.rs
@@ -1,10 +1,10 @@
 /// Platform-specific PATH registration for making `thoth` command available in CLI
 ///
-/// - macOS:   Symlink at `/usr/local/bin/thoth`.  Tries direct creation first;
-///            falls back to `osascript` admin dialog (same as VS Code "Install
-///            'code' command in PATH") when the directory is root-owned.
-/// - Linux:   Symlink at `~/.local/bin/thoth` — XDG standard, no root needed,
-///            on PATH by default on Ubuntu 20.04+, Fedora, Arch, etc.
+/// - macOS: Symlink at `/usr/local/bin/thoth`. Tries direct creation first;
+///   falls back to `osascript` admin dialog (same as VS Code "Install
+///   'code' command in PATH") when the directory is root-owned.
+/// - Linux: Symlink at `~/.local/bin/thoth` — XDG standard, no root needed,
+///   on PATH by default on Ubuntu 20.04+, Fedora, Arch, etc.
 /// - Windows: Modifies the User PATH registry key via PowerShell.
 use crate::error::{Result, ThothError};
 use std::env;
@@ -40,8 +40,18 @@ fn get_executable_path() -> Result<PathBuf> {
 
 // ── macOS ─────────────────────────────────────────────────────────────────────
 
-/// Returns the target symlink path and attempts a direct `symlink()` call.
-/// Returns `true` when the direct call succeeded, `false` on permission error.
+/// Escapes single quotes so a path can be safely embedded in a single-quoted
+/// POSIX shell string (`'…'`).  Each `'` becomes `'\''` (close quote, escaped
+/// literal, reopen quote).
+#[cfg(target_os = "macos")]
+fn shell_escape_single_quoted(s: &str) -> String {
+    s.replace('\'', "'\\''")
+}
+
+/// Attempts a direct `symlink()` call without privilege elevation.
+/// Returns `Ok(())` on success; callers should inspect the error kind
+/// (e.g. `ErrorKind::PermissionDenied`) to decide whether to retry with
+/// elevated privileges.
 #[cfg(target_os = "macos")]
 fn try_symlink_direct(exe: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {
     use std::os::unix::fs::symlink;
@@ -70,9 +80,10 @@ pub fn register_in_path() -> Result<()> {
 
     // Fall back: native macOS admin dialog via osascript — identical UX to
     // VS Code "Install 'code' command in PATH".
+    let exe_escaped = shell_escape_single_quoted(&exe_path.to_string_lossy());
     let script = format!(
         "do shell script \"mkdir -p /usr/local/bin && ln -sf '{}' '/usr/local/bin/thoth'\" with administrator privileges",
-        exe_path.to_string_lossy()
+        exe_escaped
     );
     let output = Command::new("osascript")
         .args(["-e", &script])
@@ -179,19 +190,26 @@ pub fn unregister_from_path() -> Result<()> {
 // ── Windows ───────────────────────────────────────────────────────────────────
 
 #[cfg(target_os = "windows")]
-pub fn register_in_path() -> Result<()> {
-    let exe_dir = get_executable_path()?
+fn get_executable_dir() -> Result<PathBuf> {
+    get_executable_path()?
         .parent()
         .map(|p| p.to_path_buf())
         .ok_or_else(|| ThothError::PathRegistryError {
             reason: "Failed to get executable directory".to_string(),
-        })?;
-    let exe_dir_str = exe_dir.to_string_lossy();
+        })
+}
 
+#[cfg(target_os = "windows")]
+pub fn register_in_path() -> Result<()> {
+    let exe_dir_str = get_executable_dir()?.to_string_lossy().into_owned();
+
+    // Split on ';' and compare each trimmed segment exactly to avoid false
+    // positives from substring matches (e.g. C:\Foo\thoth matching C:\thoth).
     let script = format!(
         r#"
         $currentPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-        if ($currentPath -notlike '*{0}*') {{
+        $segments = $currentPath -split ';' | ForEach-Object {{ $_.Trim() }}
+        if ($segments -notcontains '{0}') {{
             [Environment]::SetEnvironmentVariable('Path', $currentPath + ';{0}', 'User')
         }}
         "#,
@@ -216,13 +234,7 @@ pub fn register_in_path() -> Result<()> {
 
 #[cfg(target_os = "windows")]
 pub fn unregister_from_path() -> Result<()> {
-    let exe_dir = get_executable_path()?
-        .parent()
-        .map(|p| p.to_path_buf())
-        .ok_or_else(|| ThothError::PathRegistryError {
-            reason: "Failed to get executable directory".to_string(),
-        })?;
-    let exe_dir_str = exe_dir.to_string_lossy();
+    let exe_dir_str = get_executable_dir()?.to_string_lossy().into_owned();
 
     let script = format!(
         r#"

--- a/src/platform/path_registry.rs
+++ b/src/platform/path_registry.rs
@@ -1,335 +1,255 @@
 /// Platform-specific PATH registration for making `thoth` command available in CLI
 ///
-/// This module handles adding the Thoth binary to the system PATH on different platforms:
-/// - macOS/Linux: Creates/modifies shell profile files (.zshrc, .bashrc, etc.)
-/// - Windows: Modifies User PATH environment variable via registry
+/// - macOS:   Symlink at `/usr/local/bin/thoth`.  Tries direct creation first;
+///            falls back to `osascript` admin dialog (same as VS Code "Install
+///            'code' command in PATH") when the directory is root-owned.
+/// - Linux:   Symlink at `~/.local/bin/thoth` — XDG standard, no root needed,
+///            on PATH by default on Ubuntu 20.04+, Fedora, Arch, etc.
+/// - Windows: Modifies the User PATH registry key via PowerShell.
 use crate::error::{Result, ThothError};
 use std::env;
 use std::path::PathBuf;
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-use std::fs::OpenOptions;
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-use std::io::{BufRead, BufReader, Write};
-
 #[cfg(target_os = "windows")]
 use std::process::Command;
 
-/// Check if Thoth is already available in PATH
+/// Check if Thoth is already registered.
+///
+/// On Unix we check for the well-known symlink directly so the status updates
+/// immediately in the same session (no shell restart, no process-env check).
 pub fn is_in_path() -> bool {
-    // Try to find 'thoth' in PATH
-    which::which("thoth").is_ok()
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/usr/local/bin/thoth").exists()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        local_bin_link().map(|p| p.exists()).unwrap_or(false)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        which::which("thoth").is_ok()
+    }
 }
 
-/// Get the path to the Thoth executable
 fn get_executable_path() -> Result<PathBuf> {
     env::current_exe().map_err(|e| ThothError::PathRegistryError {
         reason: format!("Failed to get executable path: {}", e),
     })
 }
 
-/// Get the directory containing the Thoth executable
-fn get_executable_dir() -> Result<PathBuf> {
+// ── macOS ─────────────────────────────────────────────────────────────────────
+
+/// Returns the target symlink path and attempts a direct `symlink()` call.
+/// Returns `true` when the direct call succeeded, `false` on permission error.
+#[cfg(target_os = "macos")]
+fn try_symlink_direct(exe: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::fs::symlink;
+    if let Some(parent) = link.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    if link.symlink_metadata().is_ok() {
+        std::fs::remove_file(link)?;
+    }
+    symlink(exe, link)
+}
+
+#[cfg(target_os = "macos")]
+pub fn register_in_path() -> Result<()> {
+    use std::process::Command;
+
     let exe_path = get_executable_path()?;
-    exe_path
+    let link_path = PathBuf::from("/usr/local/bin/thoth");
+
+    // Happy path: /usr/local/bin writable without auth (e.g. Homebrew setups).
+    if try_symlink_direct(&exe_path, &link_path).is_ok() {
+        return Ok(());
+    }
+
+    // Fall back: native macOS admin dialog via osascript — identical UX to
+    // VS Code "Install 'code' command in PATH".
+    let script = format!(
+        "do shell script \"mkdir -p /usr/local/bin && ln -sf '{}' '/usr/local/bin/thoth'\" with administrator privileges",
+        exe_path.to_string_lossy()
+    );
+    let output = Command::new("osascript")
+        .args(["-e", &script])
+        .output()
+        .map_err(|e| ThothError::PathRegistryError {
+            reason: format!("Failed to launch authorization dialog: {}", e),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(ThothError::PathRegistryError {
+            reason: format!("Could not install shell command: {}", stderr.trim()),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn unregister_from_path() -> Result<()> {
+    use std::process::Command;
+
+    let link_path = PathBuf::from("/usr/local/bin/thoth");
+    if link_path.symlink_metadata().is_err() {
+        return Ok(());
+    }
+
+    // Try direct removal first.
+    if std::fs::remove_file(&link_path).is_ok() {
+        return Ok(());
+    }
+
+    // Needs privilege elevation.
+    let output = Command::new("osascript")
+        .args([
+            "-e",
+            "do shell script \"rm -f '/usr/local/bin/thoth'\" with administrator privileges",
+        ])
+        .output()
+        .map_err(|e| ThothError::PathRegistryError {
+            reason: format!("Failed to launch authorization dialog: {}", e),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(ThothError::PathRegistryError {
+            reason: format!("Could not remove shell command: {}", stderr.trim()),
+        });
+    }
+
+    Ok(())
+}
+
+// ── Linux ─────────────────────────────────────────────────────────────────────
+
+/// `~/.local/bin/thoth` — XDG convention, no root required.
+#[cfg(target_os = "linux")]
+fn local_bin_link() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| ThothError::PathRegistryError {
+        reason: "Cannot determine home directory".to_string(),
+    })?;
+    Ok(home.join(".local/bin/thoth"))
+}
+
+#[cfg(target_os = "linux")]
+pub fn register_in_path() -> Result<()> {
+    use std::os::unix::fs::symlink;
+
+    let exe_path = get_executable_path()?;
+    let link_path = local_bin_link()?;
+
+    if let Some(parent) = link_path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent).map_err(|e| ThothError::PathRegistryError {
+                reason: format!("Failed to create ~/.local/bin: {}", e),
+            })?;
+        }
+    }
+
+    if link_path.symlink_metadata().is_ok() {
+        std::fs::remove_file(&link_path).map_err(|e| ThothError::PathRegistryError {
+            reason: format!("Failed to remove existing symlink: {}", e),
+        })?;
+    }
+
+    symlink(&exe_path, &link_path).map_err(|e| ThothError::PathRegistryError {
+        reason: format!("Failed to create symlink at ~/.local/bin/thoth: {}", e),
+    })?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn unregister_from_path() -> Result<()> {
+    let link_path = local_bin_link()?;
+    if link_path.symlink_metadata().is_ok() {
+        std::fs::remove_file(&link_path).map_err(|e| ThothError::PathRegistryError {
+            reason: format!("Failed to remove ~/.local/bin/thoth: {}", e),
+        })?;
+    }
+    Ok(())
+}
+
+// ── Windows ───────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "windows")]
+pub fn register_in_path() -> Result<()> {
+    let exe_dir = get_executable_path()?
         .parent()
         .map(|p| p.to_path_buf())
         .ok_or_else(|| ThothError::PathRegistryError {
             reason: "Failed to get executable directory".to_string(),
-        })
-}
-
-/// Register Thoth in system PATH
-#[cfg(target_os = "macos")]
-pub fn register_in_path() -> Result<()> {
-    let exe_dir = get_executable_dir()?;
+        })?;
     let exe_dir_str = exe_dir.to_string_lossy();
 
-    // Determine which shell profile to update
-    let home_dir = dirs::home_dir().ok_or_else(|| ThothError::PathRegistryError {
-        reason: "Failed to get home directory".to_string(),
-    })?;
-
-    // Check for .zshrc (default on macOS Catalina+)
-    let zshrc_path = home_dir.join(".zshrc");
-    let profile_path = if zshrc_path.exists() {
-        zshrc_path
-    } else {
-        // Fall back to .bash_profile
-        home_dir.join(".bash_profile")
-    };
-
-    // Check if PATH is already added
-    if profile_path.exists() {
-        let file =
-            std::fs::File::open(&profile_path).map_err(|e| ThothError::PathRegistryError {
-                reason: format!("Failed to read shell profile: {}", e),
-            })?;
-        let reader = BufReader::new(file);
-
-        for line in reader.lines().map_while(|r| r.ok()) {
-            if line.contains(&*exe_dir_str) && line.contains("PATH") {
-                // Already registered
-                return Ok(());
-            }
-        }
-    }
-
-    // Append PATH export to profile
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&profile_path)
-        .map_err(|e| ThothError::PathRegistryError {
-            reason: format!("Failed to open shell profile for writing: {}", e),
-        })?;
-
-    let export_line = format!(
-        "\n# Added by Thoth\nexport PATH=\"$PATH:{}\"\n",
-        exe_dir_str
-    );
-    file.write_all(export_line.as_bytes())
-        .map_err(|e| ThothError::PathRegistryError {
-            reason: format!("Failed to write to shell profile: {}", e),
-        })?;
-
-    Ok(())
-}
-
-/// Register Thoth in system PATH
-#[cfg(target_os = "linux")]
-pub fn register_in_path() -> Result<()> {
-    let exe_dir = get_executable_dir()?;
-    let exe_dir_str = exe_dir.to_string_lossy();
-
-    // Determine which shell profile to update
-    let home_dir = dirs::home_dir().ok_or_else(|| ThothError::PathRegistryError {
-        reason: "Failed to get home directory".to_string(),
-    })?;
-
-    // Check for .bashrc (most common on Linux)
-    let bashrc_path = home_dir.join(".bashrc");
-    let profile_path = if bashrc_path.exists() {
-        bashrc_path
-    } else {
-        // Fall back to .profile
-        home_dir.join(".profile")
-    };
-
-    // Check if PATH is already added
-    if profile_path.exists() {
-        let file =
-            std::fs::File::open(&profile_path).map_err(|e| ThothError::PathRegistryError {
-                reason: format!("Failed to read shell profile: {}", e),
-            })?;
-        let reader = BufReader::new(file);
-
-        for line in reader.lines().map_while(|r| r.ok()) {
-            if line.contains(&*exe_dir_str) && line.contains("PATH") {
-                // Already registered
-                return Ok(());
-            }
-        }
-    }
-
-    // Append PATH export to profile
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&profile_path)
-        .map_err(|e| ThothError::PathRegistryError {
-            reason: format!("Failed to open shell profile for writing: {}", e),
-        })?;
-
-    let export_line = format!(
-        "\n# Added by Thoth\nexport PATH=\"$PATH:{}\"\n",
-        exe_dir_str
-    );
-    file.write_all(export_line.as_bytes())
-        .map_err(|e| ThothError::PathRegistryError {
-            reason: format!("Failed to write to shell profile: {}", e),
-        })?;
-
-    Ok(())
-}
-
-/// Register Thoth in system PATH
-#[cfg(target_os = "windows")]
-pub fn register_in_path() -> Result<()> {
-    let exe_dir = get_executable_dir()?;
-    let exe_dir_str = exe_dir.to_string_lossy();
-
-    // Use PowerShell to modify User PATH environment variable
-    let powershell_script = format!(
+    let script = format!(
         r#"
         $currentPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-        if ($currentPath -notlike '*{}*') {{
-            $newPath = $currentPath + ';{}'
-            [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
-            Write-Output 'SUCCESS'
-        }} else {{
-            Write-Output 'ALREADY_EXISTS'
+        if ($currentPath -notlike '*{0}*') {{
+            [Environment]::SetEnvironmentVariable('Path', $currentPath + ';{0}', 'User')
         }}
         "#,
-        exe_dir_str, exe_dir_str
+        exe_dir_str
     );
 
     let output = Command::new("powershell")
-        .args(&["-Command", &powershell_script])
+        .args(["-Command", &script])
         .output()
         .map_err(|e| ThothError::PathRegistryError {
             reason: format!("Failed to execute PowerShell: {}", e),
         })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(ThothError::PathRegistryError {
-            reason: format!("PowerShell command failed: {}", stderr),
+            reason: String::from_utf8_lossy(&output.stderr).into_owned(),
         });
     }
 
     Ok(())
 }
 
-/// Unregister Thoth from system PATH
-#[cfg(target_os = "macos")]
-pub fn unregister_from_path() -> Result<()> {
-    let exe_dir = get_executable_dir()?;
-    let exe_dir_str = exe_dir.to_string_lossy();
-
-    let home_dir = dirs::home_dir().ok_or_else(|| ThothError::PathRegistryError {
-        reason: "Failed to get home directory".to_string(),
-    })?;
-
-    // Check both .zshrc and .bash_profile
-    let profiles = vec![home_dir.join(".zshrc"), home_dir.join(".bash_profile")];
-
-    for profile_path in profiles {
-        if !profile_path.exists() {
-            continue;
-        }
-
-        // Read all lines
-        let file =
-            std::fs::File::open(&profile_path).map_err(|e| ThothError::PathRegistryError {
-                reason: format!("Failed to read shell profile: {}", e),
-            })?;
-        let reader = BufReader::new(file);
-        let mut lines: Vec<String> = reader.lines().map_while(|r| r.ok()).collect();
-
-        // Remove lines containing the Thoth PATH
-        let original_len = lines.len();
-        lines.retain(|line| !line.contains(&*exe_dir_str) || !line.contains("PATH"));
-
-        // Also remove "# Added by Thoth" comment if it's on the line before
-        let mut i = 0;
-        while i < lines.len() {
-            if lines[i].contains("# Added by Thoth") {
-                lines.remove(i);
-            } else {
-                i += 1;
-            }
-        }
-
-        // Only write if something changed
-        if lines.len() != original_len {
-            std::fs::write(&profile_path, lines.join("\n") + "\n").map_err(|e| {
-                ThothError::PathRegistryError {
-                    reason: format!("Failed to write shell profile: {}", e),
-                }
-            })?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Unregister Thoth from system PATH
-#[cfg(target_os = "linux")]
-pub fn unregister_from_path() -> Result<()> {
-    let exe_dir = get_executable_dir()?;
-    let exe_dir_str = exe_dir.to_string_lossy();
-
-    let home_dir = dirs::home_dir().ok_or_else(|| ThothError::PathRegistryError {
-        reason: "Failed to get home directory".to_string(),
-    })?;
-
-    // Check both .bashrc and .profile
-    let profiles = vec![home_dir.join(".bashrc"), home_dir.join(".profile")];
-
-    for profile_path in profiles {
-        if !profile_path.exists() {
-            continue;
-        }
-
-        // Read all lines
-        let file =
-            std::fs::File::open(&profile_path).map_err(|e| ThothError::PathRegistryError {
-                reason: format!("Failed to read shell profile: {}", e),
-            })?;
-        let reader = BufReader::new(file);
-        let mut lines: Vec<String> = reader.lines().map_while(|r| r.ok()).collect();
-
-        // Remove lines containing the Thoth PATH
-        let original_len = lines.len();
-        lines.retain(|line| !line.contains(&*exe_dir_str) || !line.contains("PATH"));
-
-        // Also remove "# Added by Thoth" comment
-        let mut i = 0;
-        while i < lines.len() {
-            if lines[i].contains("# Added by Thoth") {
-                lines.remove(i);
-            } else {
-                i += 1;
-            }
-        }
-
-        // Only write if something changed
-        if lines.len() != original_len {
-            std::fs::write(&profile_path, lines.join("\n") + "\n").map_err(|e| {
-                ThothError::PathRegistryError {
-                    reason: format!("Failed to write shell profile: {}", e),
-                }
-            })?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Unregister Thoth from system PATH
 #[cfg(target_os = "windows")]
 pub fn unregister_from_path() -> Result<()> {
-    let exe_dir = get_executable_dir()?;
+    let exe_dir = get_executable_path()?
+        .parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| ThothError::PathRegistryError {
+            reason: "Failed to get executable directory".to_string(),
+        })?;
     let exe_dir_str = exe_dir.to_string_lossy();
 
-    // Use PowerShell to remove from User PATH
-    let powershell_script = format!(
+    let script = format!(
         r#"
         $currentPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-        $newPath = ($currentPath -split ';' | Where-Object {{ $_ -ne '{}' }}) -join ';'
+        $newPath = ($currentPath -split ';' | Where-Object {{ $_ -ne '{0}' }}) -join ';'
         [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
-        Write-Output 'SUCCESS'
         "#,
         exe_dir_str
     );
 
     let output = Command::new("powershell")
-        .args(&["-Command", &powershell_script])
+        .args(["-Command", &script])
         .output()
         .map_err(|e| ThothError::PathRegistryError {
             reason: format!("Failed to execute PowerShell: {}", e),
         })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(ThothError::PathRegistryError {
-            reason: format!("PowerShell command failed: {}", stderr),
+            reason: String::from_utf8_lossy(&output.stderr).into_owned(),
         });
     }
 
     Ok(())
 }
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -337,22 +257,11 @@ mod tests {
 
     #[test]
     fn test_get_executable_path() {
-        let result = get_executable_path();
-        assert!(result.is_ok());
+        assert!(get_executable_path().is_ok());
     }
 
     #[test]
-    fn test_get_executable_dir() {
-        let result = get_executable_dir();
-        assert!(result.is_ok());
-        if let Ok(dir) = result {
-            assert!(dir.is_dir() || dir.to_string_lossy().contains("target"));
-        }
-    }
-
-    #[test]
-    fn test_is_in_path() {
-        // This test just checks that the function doesn't panic
+    fn test_is_in_path_does_not_panic() {
         let _ = is_in_path();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI registration/unregistration in system PATH with robust, platform-specific behaviors for macOS, Linux, and Windows.
  * Added safer macOS handling with a documented fallback for elevated-privilege operations.

* **Tests**
  * Simplified PATH-related tests to focus on executable path retrieval and stability checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anitnilay20/thoth/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->