### PR TITLE
feat: add VS Code-style tabs via egui_dock with Catppuccin theming 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,14 @@ jobs:
       - name: Install cargo-packager
         run: cargo install cargo-packager --locked
 
+      # Install cargo-component for building WASM plugins
+      - name: Install cargo-component
+        run: cargo install cargo-component --locked
+
+      # Add WASM target required by cargo-component plugin builds
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
+
       # macOS-specific dependencies
       # Note: cargo-packager handles DMG creation natively, no extra tools needed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -462,7 +462,30 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "atk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
+dependencies = [
+ "atk-sys",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -582,6 +605,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitmaps"
@@ -658,7 +684,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -697,6 +723,31 @@ checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "cairo-rs"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+dependencies = [
+ "bitflags 2.10.0",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -851,6 +902,16 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.12.16",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1170,7 +1231,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.5",
  "wasmtime-internal-core",
 ]
 
@@ -1183,7 +1244,7 @@ dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
  "cranelift-srcgen",
- "heck",
+ "heck 0.5.0",
  "pulley-interpreter",
 ]
 
@@ -1223,7 +1284,7 @@ dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -1240,7 +1301,7 @@ checksum = "a97b583fe9a60f06b0464cee6be5a17f623fd91b217aaac99b51b339d19911af"
 dependencies = [
  "cranelift-codegen",
  "libc",
- "target-lexicon",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -1292,6 +1353,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1395,7 +1465,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1434,7 +1504,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1532,7 +1602,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1571,7 +1641,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e92f10a49176cbffacaedabfaa11d51db1ea0f80a83c26e1873b43cd1742c24"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "proc-macro2-diagnostics",
 ]
@@ -1866,7 +1936,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1887,7 +1957,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1999,7 +2069,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2036,6 +2106,16 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
 
 [[package]]
 name = "filetime"
@@ -2148,7 +2228,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2214,6 +2294,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,7 +2331,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2284,6 +2375,64 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+]
+
+[[package]]
+name = "gdk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
 ]
 
 [[package]]
@@ -2348,6 +2497,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2537,53 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glib"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+dependencies = [
+ "bitflags 2.10.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 2.0.2",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -2437,6 +2665,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "gpu-allocator"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2707,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "gtk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a"
+dependencies = [
+ "atk",
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gio",
+ "glib",
+ "gtk-sys",
+ "gtk3-macros",
+ "libc",
+ "pango",
+ "pkg-config",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk3-macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2522,6 +2813,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -3028,6 +3325,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags 2.10.0",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3412,25 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.5.18",
+]
+
+[[package]]
+name = "libxdo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
+dependencies = [
+ "libxdo-sys",
+]
+
+[[package]]
+name = "libxdo-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
+dependencies = [
+ "libc",
+ "x11",
 ]
 
 [[package]]
@@ -3255,6 +3582,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "muda"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
+dependencies = [
+ "crossbeam-channel",
+ "dpi",
+ "gtk",
+ "keyboard-types",
+ "libxdo",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "png",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "naga"
 version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3378,10 +3726,10 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3767,7 +4115,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3829,6 +4177,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "pango"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -3975,7 +4348,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "unicase",
 ]
 
@@ -3989,7 +4362,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4028,7 +4401,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4195,7 +4568,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -4205,6 +4598,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.7",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -4224,7 +4641,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "version_check",
 ]
 
@@ -4296,7 +4713,7 @@ checksum = "a210c0386ef0ddedb337ec99b91e560ae9c341415ef75958cb39ddb537bb0c84"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4947,7 +5364,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4971,7 +5388,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5247,6 +5664,16 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
@@ -5273,7 +5700,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5295,6 +5722,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 0.8.2",
+ "version-compare",
 ]
 
 [[package]]
@@ -5323,6 +5763,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-lexicon"
@@ -5378,7 +5824,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5389,7 +5835,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5412,10 +5858,12 @@ dependencies = [
  "fontdb",
  "image",
  "memchr",
+ "muda",
  "objc2 0.5.2",
  "open",
  "proptest",
  "puffin",
+ "raw-window-handle",
  "rayon",
  "reqwest",
  "rfd",
@@ -5426,7 +5874,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
- "toml 0.8.23",
+ "toml 0.8.2",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
@@ -5594,14 +6042,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -5621,9 +6069,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
@@ -5639,16 +6087,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.13",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -5671,12 +6129,6 @@ checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
  "winnow 1.0.0",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5749,7 +6201,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5928,6 +6380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6018,7 +6476,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
@@ -6038,7 +6496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd23d12cc95c451c1306db5bc63075fbebb612bb70c53b4237b1ce5bc178343"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "im-rc",
  "indexmap",
  "log",
@@ -6130,7 +6588,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.5",
  "tempfile",
  "wasm-compose",
  "wasm-encoder",
@@ -6174,7 +6632,7 @@ dependencies = [
  "serde_derive",
  "sha2",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.5",
  "wasm-encoder",
  "wasmparser",
  "wasmprinter",
@@ -6211,7 +6669,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
  "wit-parser",
@@ -6253,7 +6711,7 @@ dependencies = [
  "object 0.38.1",
  "pulley-interpreter",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.5",
  "thiserror 2.0.18",
  "wasmparser",
  "wasmtime-environ",
@@ -6322,7 +6780,7 @@ checksum = "772f2b105b7fdd3dfb2cdf70c297baaeb96fe76a95cdc6fa516f713f04090c73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6335,7 +6793,7 @@ dependencies = [
  "gimli 0.33.0",
  "log",
  "object 0.38.1",
- "target-lexicon",
+ "target-lexicon 0.13.5",
  "wasmparser",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
@@ -6350,7 +6808,7 @@ checksum = "c47507f09e68462a0ed9f351ef410584a52e01d7ec92bc588bf7fa597ce528ef"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "wit-parser",
 ]
@@ -6856,10 +7314,10 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9165e5b08a6463d247b5c1292aaab16b103d0d8f5941b60d7bc0c38125eb9ffe"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "wasmtime-environ",
  "witx",
 ]
@@ -6872,7 +7330,7 @@ checksum = "5fb0a5b9476150428eead9ce1a5c83e8fd6aac29806f48c6dbf77d50a067473a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "wiggle-generate",
 ]
 
@@ -6918,7 +7376,7 @@ dependencies = [
  "gimli 0.33.0",
  "regalloc2",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.5",
  "thiserror 2.0.18",
  "wasmparser",
  "wasmtime-environ",
@@ -6979,7 +7437,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6990,7 +7448,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7398,6 +7856,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
@@ -7450,7 +7917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cdef5ccf0b0e9bf30868d6f9c5ed116c84ae95f84ba29d2216d3e922de3963"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -7467,10 +7934,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e76541e2f37ac1729db85765729daa0f3c2b5975d66699114d107525f6d6c8d5"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.110",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7486,7 +7953,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7546,6 +8013,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "x11-dl"
@@ -7639,7 +8116,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -7695,7 +8172,7 @@ checksum = "dc6821851fa840b708b4cbbaf6241868cabc85a2dc22f426361b0292bfc0b836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
@@ -7707,10 +8184,10 @@ version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cdb94821ca8a87ca9c298b5d1cbd80e2a8b67115d99f6e4551ac49e42b6a314"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -7758,7 +8235,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7778,7 +8255,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -7818,7 +8295,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7951,10 +8428,10 @@ version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da58575a1b2b20766513b1ec59d8e2e68db2745379f961f86650655e862d2006"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.110",
  "zvariant_utils",
 ]
 
@@ -7967,6 +8444,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.110",
  "winnow 0.7.13",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1566,6 +1566,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "duplicate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e92f10a49176cbffacaedabfaa11d51db1ea0f80a83c26e1873b43cd1742c24"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+]
+
+[[package]]
 name = "ecolor"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,7 +1696,7 @@ dependencies = [
  "epaint",
  "log",
  "profiling",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "type-map",
  "web-time",
  "wgpu",
@@ -1744,6 +1755,18 @@ dependencies = [
  "egui",
  "egui_extras",
  "pulldown-cmark",
+]
+
+[[package]]
+name = "egui_dock"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db51b9023b9d65cb4d561fd981946f987c54f25413c75b2c8e634c774c3d70ad"
+dependencies = [
+ "duplicate",
+ "egui",
+ "paste",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2423,7 +2446,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows",
 ]
 
@@ -3253,7 +3276,7 @@ dependencies = [
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-ident",
 ]
 
@@ -3849,6 +3872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4185,6 +4214,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]
@@ -5118,7 +5159,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 1.1.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -5322,11 +5363,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5342,9 +5383,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5365,6 +5406,7 @@ dependencies = [
  "egui-phosphor",
  "egui_code_editor",
  "egui_commonmark",
+ "egui_dock",
  "egui_extras",
  "flate2",
  "fontdb",
@@ -6212,7 +6254,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasmparser",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -6333,7 +6375,7 @@ dependencies = [
  "io-lifetimes",
  "rustix 1.1.2",
  "system-interface",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -6659,7 +6701,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-wasm",
@@ -6748,7 +6790,7 @@ dependencies = [
  "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wayland-sys",
  "web-sys",
@@ -6801,7 +6843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4e79079e7f5a8c034307bb5e61b2e63bc668e17d139705a7dea5afceab02510"
 dependencies = [
  "bitflags 2.10.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "wasmtime",
  "wasmtime-environ",
@@ -6877,7 +6919,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasmparser",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -7811,7 +7853,7 @@ dependencies = [
  "displaydoc",
  "indexmap",
  "memchr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -7823,7 +7865,7 @@ checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
 dependencies = [
  "base64",
  "ed25519-dalek",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Anit Nilay <anit.nilay20@gmail.com>"]
 description = "Thoth is a fast, desktop JSON/NDJSON viewer built with Rust + egui. It opens ~500 MB files by lazily parsing only visible/expanded nodes, keeps the UI responsive with an LRU cache and parallel search, and ships with an Andromeda-themed light/dark UI."
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-rust-version = "1.85"
+rust-version = "1.92"
 
 [package.metadata.release]
 # Don't publish to crates.io (this is a desktop app)
@@ -149,6 +149,7 @@ egui_extras = "0.34.1"
 tempfile = "3.15"
 egui_code_editor = "0.2.24"
 egui_commonmark = "0.23"
+egui_dock = "0.19"
 
 [dependencies.puffin]
 git = "https://github.com/EmbarkStudios/puffin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,6 @@ tempfile = "3.15"
 egui_code_editor = "0.2.24"
 egui_commonmark = "0.23"
 egui_dock = "0.19"
-muda = "0.19.2"
 raw-window-handle = "0.6.2"
 
 [dependencies.puffin]
@@ -163,6 +162,9 @@ optional = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"
+
+[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
+muda = "0.19.2"
 
 [dev-dependencies]
 proptest = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,8 @@ tempfile = "3.15"
 egui_code_editor = "0.2.24"
 egui_commonmark = "0.23"
 egui_dock = "0.19"
+muda = "0.19.2"
+raw-window-handle = "0.6.2"
 
 [dependencies.puffin]
 git = "https://github.com/EmbarkStudios/puffin"

--- a/build.rs
+++ b/build.rs
@@ -66,9 +66,10 @@ fn main() {
             // icon.png is optional.
             let icon_src = plugin_dir.join("icon.png");
             if icon_src.exists()
-                && let Err(e) = fs::copy(&icon_src, format!("{dst_dir}/icon.png")) {
-                    println!("cargo:warning=Could not copy icon.png for '{plugin_name}': {e}");
-                }
+                && let Err(e) = fs::copy(&icon_src, format!("{dst_dir}/icon.png"))
+            {
+                println!("cargo:warning=Could not copy icon.png for '{plugin_name}': {e}");
+            }
             continue;
         }
 
@@ -131,8 +132,9 @@ fn main() {
         // Copy icon.png if present — optional.
         let icon_src = plugin_dir.join("icon.png");
         if icon_src.exists()
-            && let Err(e) = fs::copy(&icon_src, format!("{dst_dir}/icon.png")) {
-                println!("cargo:warning=Could not copy icon.png for '{plugin_name}': {e}");
-            }
+            && let Err(e) = fs::copy(&icon_src, format!("{dst_dir}/icon.png"))
+        {
+            println!("cargo:warning=Could not copy icon.png for '{plugin_name}': {e}");
+        }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -65,11 +65,10 @@ fn main() {
             }
             // icon.png is optional.
             let icon_src = plugin_dir.join("icon.png");
-            if icon_src.exists() {
-                if let Err(e) = fs::copy(&icon_src, format!("{dst_dir}/icon.png")) {
+            if icon_src.exists()
+                && let Err(e) = fs::copy(&icon_src, format!("{dst_dir}/icon.png")) {
                     println!("cargo:warning=Could not copy icon.png for '{plugin_name}': {e}");
                 }
-            }
             continue;
         }
 
@@ -131,10 +130,9 @@ fn main() {
 
         // Copy icon.png if present — optional.
         let icon_src = plugin_dir.join("icon.png");
-        if icon_src.exists() {
-            if let Err(e) = fs::copy(&icon_src, format!("{dst_dir}/icon.png")) {
+        if icon_src.exists()
+            && let Err(e) = fs::copy(&icon_src, format!("{dst_dir}/icon.png")) {
                 println!("cargo:warning=Could not copy icon.png for '{plugin_name}': {e}");
             }
-        }
     }
 }

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -12,11 +12,22 @@ Thoth supports keyboard shortcuts for efficient navigation and operation. All sh
 
 ### File Operations ✅
 
-| Action                    | macOS | Windows/Linux | Description                                                | Status     |
-| ------------------------- | ----- | ------------- | ---------------------------------------------------------- | ---------- |
-| Open File                 | `⌘O`  | `Ctrl+O`      | Open a JSON or NDJSON file                                 | ✅ Working |
-| Clear File / Close Window | `⌘W`  | `Ctrl+W`      | Close the current file, or close window if no file is open | ✅ Working |
-| New Window                | `⌘N`  | `Ctrl+N`      | Open a new Thoth window                                    | ✅ Working |
+| Action     | macOS | Windows/Linux | Description                | Status     |
+| ---------- | ----- | ------------- | -------------------------- | ---------- |
+| Open File  | `⌘O`  | `Ctrl+O`      | Open a JSON or NDJSON file | ✅ Working |
+| New Window | `⌘N`  | `Ctrl+N`      | Open a new Thoth window    | ✅ Working |
+
+### Tab Operations ✅
+
+| Action              | macOS    | Windows/Linux    | Description                                                         | Status     |
+| ------------------- | -------- | ---------------- | ------------------------------------------------------------------- | ---------- |
+| New Tab             | `⌘T`     | `Ctrl+T`         | Open a new empty tab (shows Welcome screen)                         | ✅ Working |
+| Close Tab           | `⌘W`     | `Ctrl+W`         | Close the active tab; if the last tab is the welcome screen, exit   | ✅ Working |
+| Next Tab            | `⌘⌥→`   | `Ctrl+Alt+→`     | Cycle to the next tab in the focused pane                           | ✅ Working |
+| Previous Tab        | `⌘⌥←`   | `Ctrl+Alt+←`     | Cycle to the previous tab in the focused pane                       | ✅ Working |
+| Switch to Tab 1–9   | `⌘1`–`⌘9` | `Ctrl+1`–`Ctrl+9` | Jump directly to tab by position; `⌘9` always goes to the last tab | ✅ Working |
+
+> **macOS note:** `⌘⇧[`/`⌘⇧]` and `Ctrl+Tab` are intercepted by the OS before reaching the app (`NSWindowTabbing` and egui focus traversal respectively). `⌘⌥→`/`⌘⌥←` are not affected.
 
 ### UI Controls ✅
 
@@ -65,9 +76,10 @@ Thoth supports keyboard shortcuts for efficient navigation and operation. All sh
 
 ## Summary
 
-**17 keyboard shortcuts are fully implemented and working:**
+**22 keyboard shortcuts are fully implemented and working:**
 
-- 3 File Operations
+- 2 File Operations
+- 5 Tab Operations
 - 3 UI Controls
 - 1 Navigation (+ 2 planned)
 - 2 Movement
@@ -89,8 +101,13 @@ Shortcuts are defined in the `[shortcuts]` section of the settings file:
 [shortcuts]
 # File operations
 open_file = { key = "O", ctrl = false, alt = false, shift = false, command = true }
-clear_file = { key = "W", ctrl = false, alt = false, shift = false, command = true }
 new_window = { key = "N", ctrl = false, alt = false, shift = false, command = true }
+
+# Tab operations
+tab_close = { key = "W", ctrl = false, alt = false, shift = false, command = true }
+tab_new = { key = "T", ctrl = false, alt = false, shift = false, command = true }
+tab_cycle_next = { key = "ArrowRight", ctrl = false, alt = true, shift = false, command = true }
+tab_cycle_prev = { key = "ArrowLeft", ctrl = false, alt = true, shift = false, command = true }
 
 # UI controls
 settings = { key = "Comma", ctrl = false, alt = false, shift = false, command = true }

--- a/src/app/file_picker.rs
+++ b/src/app/file_picker.rs
@@ -10,20 +10,19 @@ fn supported_files(plugins_enabled: bool) -> Vec<(String, Vec<String>)> {
         vec!["json".to_string(), "ndjson".to_string()],
     )];
 
-    if plugins_enabled
-        && let Some(Some(plugin_manager)) = PLUGIN_MANAGER.get() {
-            plugin_manager
-                .get_all_plugin_by_capability(Capability::FileLoader)
-                .iter()
-                .for_each(|p| {
-                    p.file_loader.iter().for_each(|file_type| {
-                        all_supported_file_types.push((
-                            file_type.file_type.clone(),
-                            file_type.supported_extensions.clone(),
-                        ));
-                    });
+    if plugins_enabled && let Some(Some(plugin_manager)) = PLUGIN_MANAGER.get() {
+        plugin_manager
+            .get_all_plugin_by_capability(Capability::FileLoader)
+            .iter()
+            .for_each(|p| {
+                p.file_loader.iter().for_each(|file_type| {
+                    all_supported_file_types.push((
+                        file_type.file_type.clone(),
+                        file_type.supported_extensions.clone(),
+                    ));
                 });
-        }
+            });
+    }
 
     all_supported_file_types
 }

--- a/src/app/file_picker.rs
+++ b/src/app/file_picker.rs
@@ -10,8 +10,8 @@ fn supported_files(plugins_enabled: bool) -> Vec<(String, Vec<String>)> {
         vec!["json".to_string(), "ndjson".to_string()],
     )];
 
-    if plugins_enabled {
-        if let Some(Some(plugin_manager)) = PLUGIN_MANAGER.get() {
+    if plugins_enabled
+        && let Some(Some(plugin_manager)) = PLUGIN_MANAGER.get() {
             plugin_manager
                 .get_all_plugin_by_capability(Capability::FileLoader)
                 .iter()
@@ -24,7 +24,6 @@ fn supported_files(plugins_enabled: bool) -> Vec<(String, Vec<String>)> {
                     });
                 });
         }
-    }
 
     all_supported_file_types
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,9 +2,11 @@ mod file_picker;
 pub mod persistent_state;
 mod search_handler;
 mod shortcut_handler;
+pub mod tab_manager;
 mod thoth_app;
 mod update_handler;
 
 pub use file_picker::pick_file;
 pub use shortcut_handler::ShortcutAction;
+pub use tab_manager::{TabEvent, TabId, TabManager, TabState, ThothTabViewer};
 pub use thoth_app::ThothApp;

--- a/src/app/persistent_state.rs
+++ b/src/app/persistent_state.rs
@@ -299,8 +299,12 @@ impl PersistentState {
 
     /// Replace the full list of persisted tabs and which one was active.
     pub fn set_open_tabs(&mut self, tabs: Vec<PersistedTab>, active_index: usize) {
+        self.active_tab_index = if tabs.is_empty() {
+            0
+        } else {
+            active_index.min(tabs.len() - 1)
+        };
         self.open_tabs = tabs;
-        self.active_tab_index = active_index;
     }
 
     /// Return the tabs saved from the previous session.

--- a/src/app/persistent_state.rs
+++ b/src/app/persistent_state.rs
@@ -10,6 +10,20 @@ const MAX_SEARCH_HISTORY_PER_FILE: usize = 10;
 const MAX_FILES_WITH_HISTORY: usize = 20; // Keep history for at most 20 files
 const MAX_BOOKMARKS: usize = 100; // Maximum number of bookmarks
 
+/// What kind of content a persisted tab holds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PersistedTabKind {
+    File { path: String },
+    Plugin { plugin_id: String },
+}
+
+/// A tab entry that can be restored on the next launch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedTab {
+    pub kind: PersistedTabKind,
+}
+
 /// A bookmark for a specific JSON path within a file
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Bookmark {
@@ -39,6 +53,12 @@ pub struct PersistentState {
     sidebar_expanded: bool,
     #[serde(default)]
     bookmarks: Vec<Bookmark>,
+    /// Tabs open at last save — restored on next launch.
+    #[serde(default)]
+    open_tabs: Vec<PersistedTab>,
+    /// Index into `open_tabs` of the tab that was active at last save.
+    #[serde(default)]
+    active_tab_index: usize,
 }
 
 fn default_sidebar_width() -> f32 {
@@ -53,6 +73,8 @@ impl Default for PersistentState {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         })
     }
 }
@@ -122,6 +144,8 @@ impl PersistentState {
                     sidebar_width: DEFAULT_SIDEBAR_WIDTH,
                     sidebar_expanded: false,
                     bookmarks: Vec::new(),
+                    open_tabs: Vec::new(),
+                    active_tab_index: 0,
                 };
 
                 // Save in new format
@@ -141,6 +165,8 @@ impl PersistentState {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         })
     }
 
@@ -267,6 +293,24 @@ impl PersistentState {
     /// Get all bookmarks
     pub fn get_bookmarks(&self) -> &[Bookmark] {
         &self.bookmarks
+    }
+
+    // Tab session methods
+
+    /// Replace the full list of persisted tabs and which one was active.
+    pub fn set_open_tabs(&mut self, tabs: Vec<PersistedTab>, active_index: usize) {
+        self.open_tabs = tabs;
+        self.active_tab_index = active_index;
+    }
+
+    /// Return the tabs saved from the previous session.
+    pub fn get_open_tabs(&self) -> &[PersistedTab] {
+        &self.open_tabs
+    }
+
+    /// Return the index of the tab that was active at last save.
+    pub fn get_active_tab_index(&self) -> usize {
+        self.active_tab_index
     }
 
     // Search history methods (single file with LRU for most recently used files)
@@ -478,6 +522,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
         state.add_recent_file("file1.json".to_string(), MAX_RECENT_FILES);
         state.add_recent_file("file2.json".to_string(), MAX_RECENT_FILES);
@@ -494,6 +540,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
         state.add_recent_file("file1.json".to_string(), MAX_RECENT_FILES);
         state.add_recent_file("file2.json".to_string(), MAX_RECENT_FILES);
@@ -511,6 +559,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
         for i in 0..15 {
             state.add_recent_file(format!("file{}.json", i), MAX_RECENT_FILES);
@@ -527,6 +577,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
         state.add_recent_file("file1.json".to_string(), MAX_RECENT_FILES);
         state.add_recent_file("file2.json".to_string(), MAX_RECENT_FILES);
@@ -543,6 +595,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
 
         assert_eq!(state.get_sidebar_width(), DEFAULT_SIDEBAR_WIDTH);
@@ -562,6 +616,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
 
         state.add_bookmark(
@@ -586,6 +642,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
 
         state.add_bookmark(
@@ -610,6 +668,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
 
         state.add_bookmark("path1".to_string(), "/file1.json".to_string(), None);
@@ -629,6 +689,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
 
         // Toggle on (add)
@@ -649,6 +711,8 @@ mod tests {
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
+            open_tabs: Vec::new(),
+            active_tab_index: 0,
         };
 
         // Add more than MAX_BOOKMARKS

--- a/src/app/search_handler.rs
+++ b/src/app/search_handler.rs
@@ -18,8 +18,8 @@ impl SearchHandler {
         let mut search_error: Option<ThothError> = None;
 
         // Check if background search has completed
-        if let Some(rx) = &search_state.search_rx {
-            if let Ok(done) = rx.try_recv() {
+        if let Some(rx) = &search_state.search_rx
+            && let Ok(done) = rx.try_recv() {
                 // Check if the search encountered an error
                 if let Some(error) = &done.error {
                     search_error = Some(error.clone());
@@ -28,7 +28,6 @@ impl SearchHandler {
                 msg_to_central = Some(search::SearchMessage::StartSearch(done));
                 search_state.search_rx = None; // finished
             }
-        }
 
         // Handle incoming search message from sidebar
         if let Some(msg) = incoming_msg {

--- a/src/app/search_handler.rs
+++ b/src/app/search_handler.rs
@@ -19,15 +19,16 @@ impl SearchHandler {
 
         // Check if background search has completed
         if let Some(rx) = &search_state.search_rx
-            && let Ok(done) = rx.try_recv() {
-                // Check if the search encountered an error
-                if let Some(error) = &done.error {
-                    search_error = Some(error.clone());
-                }
-                search_state.search = done.clone();
-                msg_to_central = Some(search::SearchMessage::StartSearch(done));
-                search_state.search_rx = None; // finished
+            && let Ok(done) = rx.try_recv()
+        {
+            // Check if the search encountered an error
+            if let Some(error) = &done.error {
+                search_error = Some(error.clone());
             }
+            search_state.search = done.clone();
+            msg_to_central = Some(search::SearchMessage::StartSearch(done));
+            search_state.search_rx = None; // finished
+        }
 
         // Handle incoming search message from sidebar
         if let Some(msg) = incoming_msg {

--- a/src/app/shortcut_handler.rs
+++ b/src/app/shortcut_handler.rs
@@ -92,15 +92,13 @@ impl ShortcutHandler {
 
         // Navigation: ⌘[ / ⌘]
         if ctx.input_mut(|i| {
-            i.modifiers.command
-                && i.consume_key(egui::Modifiers::COMMAND, egui::Key::OpenBracket)
+            i.modifiers.command && i.consume_key(egui::Modifiers::COMMAND, egui::Key::OpenBracket)
         }) {
             actions.push(ShortcutAction::NavBack);
         }
 
         if ctx.input_mut(|i| {
-            i.modifiers.command
-                && i.consume_key(egui::Modifiers::COMMAND, egui::Key::CloseBracket)
+            i.modifiers.command && i.consume_key(egui::Modifiers::COMMAND, egui::Key::CloseBracket)
         }) {
             actions.push(ShortcutAction::NavForward);
         }
@@ -237,9 +235,7 @@ impl ShortcutHandler {
             egui::Key::Num9,
         ];
         for (idx, key) in TAB_KEYS.iter().enumerate() {
-            if ctx.input_mut(|i| {
-                i.consume_key(egui::Modifiers::COMMAND, *key)
-            }) {
+            if ctx.input_mut(|i| i.consume_key(egui::Modifiers::COMMAND, *key)) {
                 actions.push(ShortcutAction::SwitchToTab(idx));
                 break;
             }

--- a/src/app/shortcut_handler.rs
+++ b/src/app/shortcut_handler.rs
@@ -44,6 +44,11 @@ pub enum ShortcutAction {
 
     // Developer
     ToggleProfiler,
+
+    // Tabs
+    CloseTab,
+    NextTab,
+    PrevTab,
 }
 
 /// Handle keyboard shortcuts and return triggered actions
@@ -186,6 +191,29 @@ impl ShortcutHandler {
         if ctx.input_mut(|i| i.consume_shortcut(&shortcuts.toggle_profiler.to_keyboard_shortcut()))
         {
             actions.push(ShortcutAction::ToggleProfiler);
+        }
+
+        // Tabs — check Shift+Tab before Tab to avoid conflict.
+        if ctx.input_mut(|i| {
+            i.modifiers.command
+                && i.modifiers.shift
+                && i.consume_key(
+                    egui::Modifiers::COMMAND | egui::Modifiers::SHIFT,
+                    egui::Key::Tab,
+                )
+        }) {
+            actions.push(ShortcutAction::PrevTab);
+        } else if ctx.input_mut(|i| {
+            i.modifiers.command
+                && i.consume_key(egui::Modifiers::COMMAND, egui::Key::Tab)
+        }) {
+            actions.push(ShortcutAction::NextTab);
+        }
+
+        if ctx.input_mut(|i| {
+            i.modifiers.command && i.consume_key(egui::Modifiers::COMMAND, egui::Key::W)
+        }) {
+            actions.push(ShortcutAction::CloseTab);
         }
 
         actions

--- a/src/app/shortcut_handler.rs
+++ b/src/app/shortcut_handler.rs
@@ -7,7 +7,6 @@ use crate::shortcuts::KeyboardShortcuts;
 pub enum ShortcutAction {
     // File operations
     OpenFile,
-    ClearFile,
     NewWindow,
 
     // Navigation
@@ -47,8 +46,11 @@ pub enum ShortcutAction {
 
     // Tabs
     CloseTab,
+    NewTab,
     NextTab,
     PrevTab,
+    /// Switch to the tab at 0-based visual index in the focused leaf.
+    SwitchToTab(usize),
 }
 
 /// Handle keyboard shortcuts and return triggered actions
@@ -70,10 +72,6 @@ impl ShortcutHandler {
             actions.push(ShortcutAction::OpenFile);
         }
 
-        if ctx.input_mut(|i| i.consume_shortcut(&shortcuts.clear_file.to_keyboard_shortcut())) {
-            actions.push(ShortcutAction::ClearFile);
-        }
-
         if ctx.input_mut(|i| i.consume_shortcut(&shortcuts.new_window.to_keyboard_shortcut())) {
             actions.push(ShortcutAction::NewWindow);
         }
@@ -92,17 +90,42 @@ impl ShortcutHandler {
             actions.push(ShortcutAction::NextMatch);
         }
 
-        // Navigation shortcuts - using direct key handling for bracket keys
+        // Navigation: ⌘[ / ⌘]
         if ctx.input_mut(|i| {
-            i.modifiers.command && i.consume_key(egui::Modifiers::COMMAND, egui::Key::OpenBracket)
+            i.modifiers.command
+                && i.consume_key(egui::Modifiers::COMMAND, egui::Key::OpenBracket)
         }) {
             actions.push(ShortcutAction::NavBack);
         }
 
         if ctx.input_mut(|i| {
-            i.modifiers.command && i.consume_key(egui::Modifiers::COMMAND, egui::Key::CloseBracket)
+            i.modifiers.command
+                && i.consume_key(egui::Modifiers::COMMAND, egui::Key::CloseBracket)
         }) {
             actions.push(ShortcutAction::NavForward);
+        }
+
+        // Tab cycling: ⌘⌥→ / ⌘⌥← — arrow keys have no char-composition issues.
+        if ctx.input_mut(|i| {
+            i.modifiers.command
+                && i.modifiers.alt
+                && i.consume_key(
+                    egui::Modifiers::COMMAND | egui::Modifiers::ALT,
+                    egui::Key::ArrowRight,
+                )
+        }) {
+            actions.push(ShortcutAction::NextTab);
+        }
+
+        if ctx.input_mut(|i| {
+            i.modifiers.command
+                && i.modifiers.alt
+                && i.consume_key(
+                    egui::Modifiers::COMMAND | egui::Modifiers::ALT,
+                    egui::Key::ArrowLeft,
+                )
+        }) {
+            actions.push(ShortcutAction::PrevTab);
         }
 
         // Browser-style mouse back/forward buttons
@@ -193,27 +216,33 @@ impl ShortcutHandler {
             actions.push(ShortcutAction::ToggleProfiler);
         }
 
-        // Tabs — check Shift+Tab before Tab to avoid conflict.
-        if ctx.input_mut(|i| {
-            i.modifiers.command
-                && i.modifiers.shift
-                && i.consume_key(
-                    egui::Modifiers::COMMAND | egui::Modifiers::SHIFT,
-                    egui::Key::Tab,
-                )
-        }) {
-            actions.push(ShortcutAction::PrevTab);
-        } else if ctx.input_mut(|i| {
-            i.modifiers.command
-                && i.consume_key(egui::Modifiers::COMMAND, egui::Key::Tab)
-        }) {
-            actions.push(ShortcutAction::NextTab);
+        if ctx.input_mut(|i| i.consume_shortcut(&shortcuts.close_tab.to_keyboard_shortcut())) {
+            actions.push(ShortcutAction::CloseTab);
         }
 
-        if ctx.input_mut(|i| {
-            i.modifiers.command && i.consume_key(egui::Modifiers::COMMAND, egui::Key::W)
-        }) {
-            actions.push(ShortcutAction::CloseTab);
+        if ctx.input_mut(|i| i.consume_shortcut(&shortcuts.new_tab.to_keyboard_shortcut())) {
+            actions.push(ShortcutAction::NewTab);
+        }
+
+        // ⌘1–⌘9 / Ctrl+1–9: switch to tab by position.
+        const TAB_KEYS: [egui::Key; 9] = [
+            egui::Key::Num1,
+            egui::Key::Num2,
+            egui::Key::Num3,
+            egui::Key::Num4,
+            egui::Key::Num5,
+            egui::Key::Num6,
+            egui::Key::Num7,
+            egui::Key::Num8,
+            egui::Key::Num9,
+        ];
+        for (idx, key) in TAB_KEYS.iter().enumerate() {
+            if ctx.input_mut(|i| {
+                i.consume_key(egui::Modifiers::COMMAND, *key)
+            }) {
+                actions.push(ShortcutAction::SwitchToTab(idx));
+                break;
+            }
         }
 
         actions

--- a/src/app/tab_manager.rs
+++ b/src/app/tab_manager.rs
@@ -130,7 +130,11 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
 
     fn ui(&mut self, ui: &mut egui::Ui, tab_id: &mut TabId) {
         // Take the search message if it belongs to this tab (consumes it exactly once).
-        let search_msg = if self.search_msg.as_ref().is_some_and(|(tid, _)| *tid == *tab_id) {
+        let search_msg = if self
+            .search_msg
+            .as_ref()
+            .is_some_and(|(tid, _)| *tid == *tab_id)
+        {
             self.search_msg.take().map(|(_, msg)| msg)
         } else {
             None
@@ -168,12 +172,13 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
         // Navigation history: push if selection changed.
         let current_path = tab.central_panel.get_selected_path();
         if current_path != previous_path.as_ref()
-            && let Some(path) = current_path {
-                self.events.push(TabEvent::NavigationPush {
-                    tab_id: *tab_id,
-                    path: path.clone(),
-                });
-            }
+            && let Some(path) = current_path
+        {
+            self.events.push(TabEvent::NavigationPush {
+                tab_id: *tab_id,
+                path: path.clone(),
+            });
+        }
 
         // Translate CentralPanelEvents to TabEvents.
         for event in output.events {
@@ -249,7 +254,11 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
             .tabs
             .get(tab_id)
             .is_some_and(|t| t.active_plugin_pane.is_some());
-        let accent = if is_plugin { c.accent_secondary } else { c.accent };
+        let accent = if is_plugin {
+            c.accent_secondary
+        } else {
+            c.accent
+        };
 
         let mut style = global_style.clone();
         // Active/focused: colored top accent strip via outline_color.
@@ -284,13 +293,14 @@ impl TabManager {
     /// Open a file: reuse active tab if empty, otherwise create a new tab.
     pub fn open_file(&mut self, path: PathBuf, nav_capacity: usize) -> TabId {
         if let Some(id) = self.active_tab_id()
-            && self.tabs.get(&id).is_some_and(|t| t.is_empty()) {
-                if let Some(tab) = self.tabs.get_mut(&id) {
-                    tab.file_path = Some(path);
-                    tab.error = None;
-                }
-                return id;
+            && self.tabs.get(&id).is_some_and(|t| t.is_empty())
+        {
+            if let Some(tab) = self.tabs.get_mut(&id) {
+                tab.file_path = Some(path);
+                tab.error = None;
             }
+            return id;
+        }
         let id = self.next_id;
         self.next_id += 1;
         self.tabs
@@ -414,11 +424,11 @@ impl TabManager {
     pub fn ordered_tab_ids(&self) -> Vec<TabId> {
         let mut ids = Vec::new();
         for (path, node) in self.dock_state.iter_all_nodes() {
-            if node.is_leaf() {
-                if let Ok(leaf) = self.dock_state.leaf(path) {
-                    for &id in leaf.tabs() {
-                        ids.push(id);
-                    }
+            if node.is_leaf()
+                && let Ok(leaf) = self.dock_state.leaf(path)
+            {
+                for &id in leaf.tabs() {
+                    ids.push(id);
                 }
             }
         }

--- a/src/app/tab_manager.rs
+++ b/src/app/tab_manager.rs
@@ -409,6 +409,22 @@ impl TabManager {
         self.dock_state.set_focused_node_and_surface(path);
     }
 
+    /// Return tab IDs in the order they appear in the dock tree (left-to-right, pane by pane).
+    /// Used to build the ordered list of tabs for session persistence.
+    pub fn ordered_tab_ids(&self) -> Vec<TabId> {
+        let mut ids = Vec::new();
+        for (path, node) in self.dock_state.iter_all_nodes() {
+            if node.is_leaf() {
+                if let Ok(leaf) = self.dock_state.leaf(path) {
+                    for &id in leaf.tabs() {
+                        ids.push(id);
+                    }
+                }
+            }
+        }
+        ids
+    }
+
     /// Split-borrow helper: returns `(dock_state, tabs)` as independent mutable refs so
     /// `DockArea::new(dock_state)` and `ThothTabViewer { tabs, .. }` can coexist.
     pub fn borrow_parts(&mut self) -> (&mut DockState<TabId>, &mut HashMap<TabId, TabState>) {

--- a/src/app/tab_manager.rs
+++ b/src/app/tab_manager.rs
@@ -160,14 +160,13 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
 
         // Navigation history: push if selection changed.
         let current_path = tab.central_panel.get_selected_path();
-        if current_path != previous_path.as_ref() {
-            if let Some(path) = current_path {
+        if current_path != previous_path.as_ref()
+            && let Some(path) = current_path {
                 self.events.push(TabEvent::NavigationPush {
                     tab_id: *tab_id,
                     path: path.clone(),
                 });
             }
-        }
 
         // Translate CentralPanelEvents to TabEvents.
         for event in output.events {
@@ -271,15 +270,14 @@ impl TabManager {
 
     /// Open a file: reuse active tab if empty, otherwise create a new tab.
     pub fn open_file(&mut self, path: PathBuf, nav_capacity: usize) -> TabId {
-        if let Some(id) = self.active_tab_id() {
-            if self.tabs.get(&id).is_some_and(|t| t.is_empty()) {
+        if let Some(id) = self.active_tab_id()
+            && self.tabs.get(&id).is_some_and(|t| t.is_empty()) {
                 if let Some(tab) = self.tabs.get_mut(&id) {
                     tab.file_path = Some(path);
                     tab.error = None;
                 }
                 return id;
             }
-        }
         let id = self.next_id;
         self.next_id += 1;
         self.tabs

--- a/src/app/tab_manager.rs
+++ b/src/app/tab_manager.rs
@@ -1,0 +1,347 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use eframe::egui;
+use egui_dock::{DockState, tab_viewer::OnCloseResponse};
+
+use crate::{
+    app::persistent_state::PersistentState,
+    components::central_panel::{CentralPanel, CentralPanelProps},
+    components::traits::ContextComponent,
+    error::ThothError,
+    file::lazy_loader::FileKind,
+    plugin::render_node::UiOutput,
+    settings::Settings,
+    state::{ActivePluginPane, NavigationHistory, SearchEngineState},
+};
+
+pub type TabId = usize;
+
+/// Per-tab state — everything that belongs to one open file/plugin pane.
+pub struct TabState {
+    pub id: TabId,
+    pub file_path: Option<PathBuf>,
+    pub file_type: FileKind,
+    pub error: Option<ThothError>,
+    pub total_items: usize,
+    pub search_engine_state: SearchEngineState,
+    pub navigation_history: NavigationHistory,
+    pub pending_navigation: Option<String>,
+    pub active_plugin_pane: Option<ActivePluginPane>,
+    pub plugin_sidebar_output: Option<UiOutput>,
+    pub central_panel: CentralPanel,
+}
+
+impl TabState {
+    pub fn new(id: TabId, file_path: Option<PathBuf>, nav_capacity: usize) -> Self {
+        Self {
+            id,
+            file_path,
+            file_type: FileKind::default(),
+            error: None,
+            total_items: 0,
+            search_engine_state: SearchEngineState::default(),
+            navigation_history: NavigationHistory::with_capacity(nav_capacity),
+            pending_navigation: None,
+            active_plugin_pane: None,
+            plugin_sidebar_output: None,
+            central_panel: CentralPanel::default(),
+        }
+    }
+
+    pub fn title(&self) -> String {
+        self.file_path
+            .as_ref()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "New Tab".to_string())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.file_path.is_none() && self.active_plugin_pane.is_none()
+    }
+}
+
+/// Events emitted from ThothTabViewer to ThothApp, drained after DockArea::show_inside.
+pub enum TabEvent {
+    FileOpened {
+        tab_id: TabId,
+        path: PathBuf,
+        file_type: FileKind,
+        total_items: usize,
+    },
+    FileOpenError {
+        tab_id: TabId,
+        error: ThothError,
+    },
+    FileClosed {
+        tab_id: TabId,
+    },
+    FileTypeChanged {
+        tab_id: TabId,
+        file_type: FileKind,
+    },
+    ErrorCleared {
+        tab_id: TabId,
+    },
+    PluginUiEvent {
+        tab_id: TabId,
+        event: crate::plugin::render_node::UiEvent,
+    },
+    NavigationPush {
+        tab_id: TabId,
+        path: String,
+    },
+    TabClosed(TabId),
+}
+
+/// Implements egui_dock::TabViewer. Holds mutable refs to tabs and settings so each
+/// tab's CentralPanel can be rendered without the app needing to split borrows manually.
+pub struct ThothTabViewer<'a> {
+    pub tabs: &'a mut HashMap<TabId, TabState>,
+    pub settings: &'a Settings,
+    pub persistent_state: &'a mut PersistentState,
+    pub nav_capacity: usize,
+    /// Search message for the focused tab, consumed by the first matching tab::ui call.
+    pub search_msg: Option<(TabId, crate::search::SearchMessage)>,
+    /// Outbound events collected during show_inside, drained by ThothApp afterwards.
+    pub events: Vec<TabEvent>,
+    /// Current theme colors for per-tab style overrides.
+    pub colors: Option<crate::theme::ThemeColors>,
+}
+
+impl egui_dock::TabViewer for ThothTabViewer<'_> {
+    type Tab = TabId;
+
+    fn title(&mut self, tab_id: &mut TabId) -> egui::WidgetText {
+        self.tabs
+            .get(tab_id)
+            .map(|t| t.title())
+            .unwrap_or_else(|| "Tab".to_string())
+            .into()
+    }
+
+    fn id(&mut self, tab_id: &mut TabId) -> egui::Id {
+        egui::Id::new(*tab_id)
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, tab_id: &mut TabId) {
+        // Take the search message if it belongs to this tab (consumes it exactly once).
+        let search_msg = if self.search_msg.as_ref().is_some_and(|(tid, _)| *tid == *tab_id) {
+            self.search_msg.take().map(|(_, msg)| msg)
+        } else {
+            None
+        };
+
+        let Some(tab) = self.tabs.get_mut(tab_id) else {
+            return;
+        };
+
+        let previous_path = tab.central_panel.get_selected_path().cloned();
+
+        // Copy primitive settings values before the mutable borrow of tab.
+        let cache_size = self.settings.performance.cache_size;
+        let syntax_highlighting = self.settings.viewer.syntax_highlighting;
+        let plugin_ui = tab.active_plugin_pane.as_ref().map(|p| &p.ui_output);
+
+        let output = tab.central_panel.render(
+            ui,
+            CentralPanelProps {
+                file_path: &tab.file_path,
+                file_type: tab.file_type,
+                error: &tab.error,
+                search_message: search_msg,
+                cache_size,
+                syntax_highlighting,
+                plugin_ui,
+            },
+        );
+
+        // Navigation history: push if selection changed.
+        let current_path = tab.central_panel.get_selected_path();
+        if current_path != previous_path.as_ref() {
+            if let Some(path) = current_path {
+                self.events.push(TabEvent::NavigationPush {
+                    tab_id: *tab_id,
+                    path: path.clone(),
+                });
+            }
+        }
+
+        // Translate CentralPanelEvents to TabEvents.
+        for event in output.events {
+            use crate::components::central_panel::CentralPanelEvent;
+            match event {
+                CentralPanelEvent::FileOpened {
+                    path,
+                    file_type,
+                    total_items,
+                } => {
+                    self.events.push(TabEvent::FileOpened {
+                        tab_id: *tab_id,
+                        path,
+                        file_type,
+                        total_items,
+                    });
+                }
+                CentralPanelEvent::FileOpenError(err) => {
+                    self.events.push(TabEvent::FileOpenError {
+                        tab_id: *tab_id,
+                        error: err,
+                    });
+                }
+                CentralPanelEvent::FileClosed => {
+                    self.events.push(TabEvent::FileClosed { tab_id: *tab_id });
+                }
+                CentralPanelEvent::FileTypeChanged(ft) => {
+                    self.events.push(TabEvent::FileTypeChanged {
+                        tab_id: *tab_id,
+                        file_type: ft,
+                    });
+                }
+                CentralPanelEvent::ErrorCleared => {
+                    self.events.push(TabEvent::ErrorCleared { tab_id: *tab_id });
+                }
+                CentralPanelEvent::PluginUiEvent(evt) => {
+                    self.events.push(TabEvent::PluginUiEvent {
+                        tab_id: *tab_id,
+                        event: evt,
+                    });
+                }
+            }
+        }
+    }
+
+    fn on_close(&mut self, tab_id: &mut TabId) -> OnCloseResponse {
+        self.tabs.remove(tab_id);
+        self.events.push(TabEvent::TabClosed(*tab_id));
+        OnCloseResponse::Close
+    }
+
+    fn scroll_bars(&self, _tab: &TabId) -> [bool; 2] {
+        [false, false]
+    }
+
+    fn clear_background(&self, _tab: &TabId) -> bool {
+        false
+    }
+
+    fn tab_style_override(
+        &self,
+        tab_id: &TabId,
+        global_style: &egui_dock::TabStyle,
+    ) -> Option<egui_dock::TabStyle> {
+        let c = self.colors?;
+        let is_plugin = self
+            .tabs
+            .get(tab_id)
+            .is_some_and(|t| t.active_plugin_pane.is_some());
+        let accent = if is_plugin { c.accent_secondary } else { c.accent };
+
+        let mut style = global_style.clone();
+        // Active/focused: colored top accent strip via outline_color.
+        style.active.outline_color = accent;
+        style.focused.outline_color = accent;
+        // Inactive: suppress the outline so only active tabs show the accent.
+        style.inactive.outline_color = eframe::egui::Color32::TRANSPARENT;
+        style.hovered.outline_color = accent.gamma_multiply(0.5);
+        Some(style)
+    }
+}
+
+/// Manages the dock layout and all per-tab state.
+pub struct TabManager {
+    pub dock_state: DockState<TabId>,
+    pub tabs: HashMap<TabId, TabState>,
+    next_id: usize,
+}
+
+impl TabManager {
+    pub fn new(nav_capacity: usize) -> Self {
+        let mut tabs = HashMap::new();
+        let id: TabId = 0;
+        tabs.insert(id, TabState::new(id, None, nav_capacity));
+        Self {
+            dock_state: DockState::new(vec![id]),
+            tabs,
+            next_id: 1,
+        }
+    }
+
+    /// Open a file: reuse active tab if empty, otherwise create a new tab.
+    pub fn open_file(&mut self, path: PathBuf, nav_capacity: usize) -> TabId {
+        if let Some(id) = self.active_tab_id() {
+            if self.tabs.get(&id).is_some_and(|t| t.is_empty()) {
+                if let Some(tab) = self.tabs.get_mut(&id) {
+                    tab.file_path = Some(path);
+                    tab.error = None;
+                }
+                return id;
+            }
+        }
+        let id = self.next_id;
+        self.next_id += 1;
+        self.tabs
+            .insert(id, TabState::new(id, Some(path), nav_capacity));
+        self.dock_state.push_to_focused_leaf(id);
+        id
+    }
+
+    /// Get the ID of the currently focused tab, if any.
+    ///
+    /// Falls back to the smallest-ID tab when the dock has no focus set yet
+    /// (i.e. before the first `DockArea::show_inside` call).
+    pub fn active_tab_id(&mut self) -> Option<TabId> {
+        if let Some((_, tab_id)) = self.dock_state.find_active_focused() {
+            return Some(*tab_id);
+        }
+        // No focus set yet — return the first (oldest) open tab.
+        self.tabs.keys().copied().min()
+    }
+
+    /// Get a mutable reference to the currently focused tab's state.
+    pub fn active_tab_mut(&mut self) -> Option<&mut TabState> {
+        let id = self.active_tab_id()?;
+        self.tabs.get_mut(&id)
+    }
+
+    /// If all tabs were closed, insert a new empty one so the window is never blank.
+    pub fn ensure_non_empty(&mut self, nav_capacity: usize) {
+        if self.tabs.is_empty() {
+            let id = self.next_id;
+            self.next_id += 1;
+            self.tabs.insert(id, TabState::new(id, None, nav_capacity));
+            self.dock_state = DockState::new(vec![id]);
+        }
+    }
+
+    /// Cycle the active tab by `delta` (+1 = next, -1 = previous).
+    pub fn cycle_tab(&mut self, delta: i32) {
+        // Get the active tab's ID (terminates the mutable borrow of dock_state).
+        let active = match self.active_tab_id() {
+            Some(id) => id,
+            None => return,
+        };
+
+        // Find the focused leaf and set the adjacent tab active.
+        let Some(path) = self.dock_state.focused_leaf() else {
+            return;
+        };
+        if let Ok(leaf) = self.dock_state.leaf_mut(path) {
+            let tabs = leaf.tabs();
+            if tabs.len() < 2 {
+                return;
+            }
+            let pos = tabs.iter().position(|&id| id == active).unwrap_or(0);
+            let next_pos = (pos as i32 + delta).rem_euclid(tabs.len() as i32) as usize;
+            let _ = leaf.set_active_tab(egui_dock::TabIndex(next_pos));
+        }
+    }
+
+    /// Split-borrow helper: returns `(dock_state, tabs)` as independent mutable refs so
+    /// `DockArea::new(dock_state)` and `ThothTabViewer { tabs, .. }` can coexist.
+    pub fn borrow_parts(&mut self) -> (&mut DockState<TabId>, &mut HashMap<TabId, TabState>) {
+        (&mut self.dock_state, &mut self.tabs)
+    }
+}

--- a/src/app/tab_manager.rs
+++ b/src/app/tab_manager.rs
@@ -50,6 +50,9 @@ impl TabState {
     }
 
     pub fn title(&self) -> String {
+        if let Some(pane) = &self.active_plugin_pane {
+            return pane.plugin_id.clone();
+        }
         self.file_path
             .as_ref()
             .and_then(|p| p.file_name())

--- a/src/app/tab_manager.rs
+++ b/src/app/tab_manager.rs
@@ -94,6 +94,8 @@ pub enum TabEvent {
         path: String,
     },
     TabClosed(TabId),
+    OpenFilePicker,
+    OpenRecentFile(std::path::PathBuf),
 }
 
 /// Implements egui_dock::TabViewer. Holds mutable refs to tabs and settings so each
@@ -134,6 +136,9 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
             None
         };
 
+        // Snapshot recent files before the mutable tab borrow.
+        let recent_files: Vec<String> = self.persistent_state.get_recent_files().to_vec();
+
         let Some(tab) = self.tabs.get_mut(tab_id) else {
             return;
         };
@@ -155,6 +160,8 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
                 cache_size,
                 syntax_highlighting,
                 plugin_ui,
+                recent_files: &recent_files,
+                colors: self.colors,
             },
         );
 
@@ -207,6 +214,12 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
                         tab_id: *tab_id,
                         event: evt,
                     });
+                }
+                CentralPanelEvent::OpenFilePicker => {
+                    self.events.push(TabEvent::OpenFilePicker);
+                }
+                CentralPanelEvent::OpenRecentFile(path) => {
+                    self.events.push(TabEvent::OpenRecentFile(path));
                 }
             }
         }
@@ -314,27 +327,86 @@ impl TabManager {
         }
     }
 
-    /// Cycle the active tab by `delta` (+1 = next, -1 = previous).
-    pub fn cycle_tab(&mut self, delta: i32) {
-        // Get the active tab's ID (terminates the mutable borrow of dock_state).
-        let active = match self.active_tab_id() {
-            Some(id) => id,
-            None => return,
+    /// Close the active tab, removing it from both the dock tree and the tabs map.
+    /// Returns `true` if the closed tab was empty (showing the welcome screen).
+    pub fn close_active_tab(&mut self) -> bool {
+        let Some(id) = self.active_tab_id() else {
+            return false;
         };
+        let was_empty = self.tabs.get(&id).is_some_and(|t| t.is_empty());
+        // Remove from the dock tree first.
+        if let Some(path) = self.dock_state.find_tab(&id) {
+            self.dock_state.remove_tab(path);
+        }
+        self.tabs.remove(&id);
+        was_empty
+    }
 
-        // Find the focused leaf and set the adjacent tab active.
-        let Some(path) = self.dock_state.focused_leaf() else {
+    /// Open a new empty tab and return its id.
+    pub fn open_new_tab(&mut self, nav_capacity: usize) -> TabId {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.tabs.insert(id, TabState::new(id, None, nav_capacity));
+        self.dock_state.push_to_focused_leaf(id);
+        id
+    }
+
+    /// Return the NodePath of the focused leaf, falling back to the first leaf on the main
+    /// surface when focus has not been set yet (before any DockArea::show_inside interaction).
+    fn any_leaf_path(&self) -> Option<egui_dock::NodePath> {
+        if let Some(path) = self.dock_state.focused_leaf() {
+            return Some(path);
+        }
+        // No focus set yet — find the first leaf on the main surface.
+        self.dock_state
+            .iter_all_nodes()
+            .find_map(|(path, node)| node.is_leaf().then_some(path))
+    }
+
+    /// Activate the tab at `index` (0-based) in the focused leaf, clamped to the last tab.
+    pub fn switch_to_tab_by_index(&mut self, index: usize) {
+        let Some(path) = self.any_leaf_path() else {
             return;
         };
         if let Ok(leaf) = self.dock_state.leaf_mut(path) {
-            let tabs = leaf.tabs();
-            if tabs.len() < 2 {
+            let count = leaf.tabs().len();
+            if count == 0 {
                 return;
             }
-            let pos = tabs.iter().position(|&id| id == active).unwrap_or(0);
-            let next_pos = (pos as i32 + delta).rem_euclid(tabs.len() as i32) as usize;
+            let clamped = index.min(count - 1);
+            let _ = leaf.set_active_tab(egui_dock::TabIndex(clamped));
+        }
+        self.dock_state.set_focused_node_and_surface(path);
+    }
+
+    /// Cycle the active tab by `delta` (+1 = next, -1 = previous).
+    pub fn cycle_tab(&mut self, delta: i32) {
+        let Some(active) = self.active_tab_id() else {
+            return;
+        };
+        let Some(path) = self.any_leaf_path() else {
+            return;
+        };
+
+        // Collect the tab list before taking a mutable borrow.
+        let (count, pos) = match self.dock_state.leaf(path) {
+            Ok(leaf) => {
+                let tabs = leaf.tabs();
+                if tabs.len() < 2 {
+                    return;
+                }
+                let pos = tabs.iter().position(|&id| id == active).unwrap_or(0);
+                (tabs.len(), pos)
+            }
+            Err(_) => return,
+        };
+
+        let next_pos = (pos as i32 + delta).rem_euclid(count as i32) as usize;
+        if let Ok(leaf) = self.dock_state.leaf_mut(path) {
             let _ = leaf.set_active_tab(egui_dock::TabIndex(next_pos));
         }
+        // Update dock focus so find_active_focused() reflects the change immediately.
+        self.dock_state.set_focused_node_and_surface(path);
     }
 
     /// Split-borrow helper: returns `(dock_state, tabs)` as independent mutable refs so

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -21,6 +21,14 @@ pub struct ThothApp {
     settings_dialog: components::settings_dialog::SettingsDialog,
     clipboard_text: Option<String>,
     settings_changed: bool,
+    session_dirty: bool,
+    /// Plugin IDs from the persisted session that couldn't be restored yet because
+    /// PLUGIN_MANAGER was still initializing on the background thread. Drained each
+    /// frame once the manager becomes available.
+    pending_plugin_restores: Vec<String>,
+    /// Active-tab index to switch to once all deferred session tabs are open.
+    /// `None` once the switch has been applied (or when no session is being restored).
+    session_restore_active_index: Option<usize>,
 }
 
 impl ThothApp {
@@ -33,14 +41,34 @@ impl ThothApp {
         }
 
         // Replace the default TabManager with one that uses the configured nav history size.
-        window_state.tab_manager =
-            crate::app::TabManager::new(settings.performance.navigation_history_size);
+        let nav_capacity = settings.performance.navigation_history_size;
+        window_state.tab_manager = crate::app::TabManager::new(nav_capacity);
 
-        if let Some(path) = file_to_open {
-            window_state
-                .tab_manager
-                .open_file(path, settings.performance.navigation_history_size);
-        }
+        let (pending_plugin_restores, session_restore_active_index) = if let Some(path) = file_to_open {
+            // A file was passed via CLI / OS file association — open it directly,
+            // skipping session restore so the user sees exactly what they asked for.
+            window_state.tab_manager.open_file(path, nav_capacity);
+            (Vec::new(), None)
+        } else {
+            // Restore the previous session (file tabs whose paths still exist, plugin tabs
+            // that can be re-instantiated). Plugin tabs that can't be opened yet (because
+            // PLUGIN_MANAGER is still initializing on a background thread) are returned
+            // here and retried via poll_pending_plugin_restores() each frame.
+            let (deferred, active_index) = Self::restore_tab_session(
+                &mut window_state.tab_manager,
+                &persistent_state,
+                &settings,
+            );
+            // Switch to the previously-active tab immediately if there are no deferred
+            // plugins; otherwise defer until poll_pending_plugin_restores() finishes.
+            let restore_index = if deferred.is_empty() {
+                window_state.tab_manager.switch_to_tab_by_index(active_index);
+                None
+            } else {
+                Some(active_index)
+            };
+            (deferred, restore_index)
+        };
 
         Self {
             settings,
@@ -50,6 +78,9 @@ impl ThothApp {
             settings_dialog: components::settings_dialog::SettingsDialog::default(),
             clipboard_text: None,
             settings_changed: false,
+            session_dirty: false,
+            pending_plugin_restores,
+            session_restore_active_index,
         }
     }
 
@@ -146,6 +177,9 @@ impl App for ThothApp {
             && let Ok(mut nm) = nm.lock() {
                 nm.show_notifications(ctx);
             }
+
+        // Restore plugin tabs that were deferred at startup (PLUGIN_MANAGER not ready yet).
+        self.poll_pending_plugin_restores();
 
         // Handle OS-dispatched file opens (e.g. macOS Apple Events / Finder)
         self.poll_os_open_requests();
@@ -299,6 +333,7 @@ impl App for ThothApp {
             self.apply_new_settings(new_settings);
         }
         self.save_settings_if_changed();
+        self.save_session_if_dirty();
 
         #[cfg(feature = "profiling")]
         if self.settings.dev.show_profiler {
@@ -499,9 +534,11 @@ impl ThothApp {
                     } else {
                         self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                     }
+                    self.session_dirty = true;
                 }
                 ShortcutAction::NewTab => {
                     self.window_state.tab_manager.open_new_tab(nav_capacity);
+                    // Empty tabs are not persisted, so no session_dirty needed here.
                 }
                 ShortcutAction::NextTab => {
                     self.window_state.tab_manager.cycle_tab(1);
@@ -707,6 +744,7 @@ impl ThothApp {
                         tab.file_path = None;
                         tab.error = None;
                     }
+                    self.session_dirty = true;
                 }
                 components::toolbar::ToolbarEvent::NewWindow => {
                     self.create_new_window();
@@ -740,6 +778,178 @@ impl ThothApp {
                 eprintln!("Failed to save settings: {}", e);
             }
             self.settings_changed = false;
+        }
+    }
+
+    /// Re-open tabs saved from the previous session.
+    /// Returns `(deferred_plugin_ids, active_tab_index)`.
+    /// - `deferred_plugin_ids`: plugin IDs that couldn't be opened yet because
+    ///   PLUGIN_MANAGER was still initializing; retried via `poll_pending_plugin_restores()`.
+    /// - `active_tab_index`: the dock-order index to switch to after all tabs are open.
+    fn restore_tab_session(
+        tab_manager: &mut crate::app::TabManager,
+        persistent_state: &PersistentState,
+        settings: &settings::Settings,
+    ) -> (Vec<String>, usize) {
+        use crate::app::persistent_state::PersistedTabKind;
+
+        let nav_capacity = settings.performance.navigation_history_size;
+        let persisted = persistent_state.get_open_tabs().to_vec();
+        let active_tab_index = persistent_state.get_active_tab_index();
+        let mut deferred_plugins = Vec::new();
+
+        for tab in &persisted {
+            match &tab.kind {
+                PersistedTabKind::File { path } => {
+                    let p = std::path::PathBuf::from(path);
+                    if p.exists() {
+                        tab_manager.open_file(p, nav_capacity);
+                    }
+                }
+                PersistedTabKind::Plugin { plugin_id } => {
+                    // PLUGIN_MANAGER is set by a background thread; it may not be ready yet.
+                    match PLUGIN_MANAGER.get() {
+                        Some(manager_opt) => {
+                            if let Some(manager) = manager_opt.as_ref() {
+                                Self::open_plugin_tab(tab_manager, manager, plugin_id, settings);
+                            }
+                            // manager_opt == None means plugins are disabled — skip silently.
+                        }
+                        None => {
+                            // Manager not initialized yet — defer to poll loop.
+                            deferred_plugins.push(plugin_id.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        (deferred_plugins, active_tab_index)
+    }
+
+    /// Try to open a single plugin tab. Shared by initial restore and the deferred poll loop.
+    fn open_plugin_tab(
+        tab_manager: &mut crate::app::TabManager,
+        manager: &crate::plugin::manager::PluginManager,
+        plugin_id: &str,
+        settings: &settings::Settings,
+    ) {
+        let nav_capacity = settings.performance.navigation_history_size;
+        let Some(plugin) = manager.registry.get_by_id(plugin_id) else {
+            return;
+        };
+        use crate::plugin::network_policy::NetworkPolicy;
+        let user_policy = settings
+            .plugins
+            .network_policies
+            .get(plugin_id)
+            .cloned()
+            .unwrap_or_default();
+        let policy = NetworkPolicy::from_plugin_and_settings(
+            &plugin.network.clone().unwrap_or_default(),
+            &user_policy,
+        );
+        let Ok(loader) = manager.open_data_source(plugin_id, policy) else {
+            return;
+        };
+        let Ok(ui_output) = loader.render_ui() else {
+            return;
+        };
+        let sidebar_output = loader.render_sidebar().ok().flatten();
+        let tab_id = if tab_manager.active_tab_mut().is_some_and(|t| t.is_empty()) {
+            tab_manager.active_tab_id().unwrap()
+        } else {
+            tab_manager.open_new_tab(nav_capacity)
+        };
+        if let Some(t) = tab_manager.tabs.get_mut(&tab_id) {
+            t.active_plugin_pane = Some(crate::state::ActivePluginPane {
+                plugin_id: plugin_id.to_string(),
+                display_url: String::new(),
+                ui_output,
+                loader,
+            });
+            t.plugin_sidebar_output = sidebar_output;
+        }
+    }
+
+    /// Called each frame from `update()`. Once PLUGIN_MANAGER is ready, drains
+    /// `pending_plugin_restores` and opens each plugin tab, then applies the
+    /// saved active-tab index.
+    fn poll_pending_plugin_restores(&mut self) {
+        if self.pending_plugin_restores.is_empty() {
+            return;
+        }
+        // Wait until the background init thread has called PLUGIN_MANAGER.set().
+        let Some(manager_opt) = PLUGIN_MANAGER.get() else {
+            return;
+        };
+        let plugin_ids = std::mem::take(&mut self.pending_plugin_restores);
+        if let Some(manager) = manager_opt.as_ref() {
+            for plugin_id in &plugin_ids {
+                Self::open_plugin_tab(
+                    &mut self.window_state.tab_manager,
+                    manager,
+                    plugin_id,
+                    &self.settings,
+                );
+            }
+            self.session_dirty = true;
+        }
+        // If manager is None (plugins disabled), plugin_ids is simply dropped.
+
+        // All deferred tabs are now open — apply the saved active-tab index.
+        if let Some(idx) = self.session_restore_active_index.take() {
+            self.window_state.tab_manager.switch_to_tab_by_index(idx);
+        }
+    }
+
+    /// Snapshot the current open tabs and write them to persistent_state, then save to disk.
+    fn save_session_if_dirty(&mut self) {
+        if !self.session_dirty {
+            return;
+        }
+        self.session_dirty = false;
+
+        use crate::app::persistent_state::{PersistedTab, PersistedTabKind};
+
+        let ordered_ids = self.window_state.tab_manager.ordered_tab_ids();
+        let active_id = self.window_state.tab_manager.active_tab_id();
+
+        let mut active_tab_index: usize = 0;
+        let mut persisted_index: usize = 0;
+
+        let tabs: Vec<PersistedTab> = ordered_ids
+            .into_iter()
+            .filter_map(|id| {
+                let tab = self.window_state.tab_manager.tabs.get(&id)?;
+                let entry = if let Some(ref path) = tab.file_path {
+                    Some(PersistedTab {
+                        kind: PersistedTabKind::File {
+                            path: path.to_string_lossy().into_owned(),
+                        },
+                    })
+                } else if let Some(ref pane) = tab.active_plugin_pane {
+                    Some(PersistedTab {
+                        kind: PersistedTabKind::Plugin {
+                            plugin_id: pane.plugin_id.clone(),
+                        },
+                    })
+                } else {
+                    None // Empty / welcome tabs are not persisted.
+                };
+                if entry.is_some() {
+                    if Some(id) == active_id {
+                        active_tab_index = persisted_index;
+                    }
+                    persisted_index += 1;
+                }
+                entry
+            })
+            .collect();
+
+        self.persistent_state.set_open_tabs(tabs, active_tab_index);
+        if let Err(e) = self.persistent_state.save() {
+            eprintln!("Failed to save tab session: {e}");
         }
     }
 
@@ -896,6 +1106,7 @@ impl ThothApp {
                         tab.central_panel.navigate_to_path(pending_path);
                     }
                 }
+                self.session_dirty = true;
             }
             TabEvent::FileOpenError { tab_id, error } => {
                 if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
@@ -907,6 +1118,7 @@ impl ThothApp {
                     tab.file_path = None;
                     tab.total_items = 0;
                 }
+                self.session_dirty = true;
             }
             TabEvent::FileTypeChanged { tab_id, file_type } => {
                 if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
@@ -929,6 +1141,7 @@ impl ThothApp {
             TabEvent::TabClosed(id) => {
                 self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                 let _ = id;
+                self.session_dirty = true;
             }
             TabEvent::OpenFilePicker => {
                 let nav_cap = self.settings.performance.navigation_history_size;
@@ -1086,6 +1299,7 @@ impl ThothApp {
                             }
                             self.window_state.sidebar_expanded = false;
                             self.window_state.sidebar_selected_section = None;
+                            self.session_dirty = true;
                         } else {
                             if let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref())
                                 && let Some(plugin) = manager.registry.get_by_id(plugin_id) {
@@ -1121,6 +1335,7 @@ impl ThothApp {
                                                             ui_output,
                                                             loader,
                                                         });
+                                                    self.session_dirty = true;
                                                 }
                                                 if has_sidebar {
                                                     self.window_state.sidebar_expanded = true;

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -79,8 +79,8 @@ impl ThothApp {
             pm.update_plugin_settings(self.settings.plugins.plugin_settings.clone());
         }
 
-        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-            if let Some(pane) = tab.active_plugin_pane.as_mut() {
+        if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+            && let Some(pane) = tab.active_plugin_pane.as_mut() {
                 let updated = self
                     .settings
                     .plugins
@@ -95,7 +95,6 @@ impl ThothApp {
                     );
                 }
             }
-        }
 
         let plugins_changed = self.settings.plugins.enabled != prev_plugins_enabled
             || self.settings.plugins.disabled_plugin_ids != prev_disabled_plugin_ids;
@@ -143,11 +142,10 @@ impl App for ThothApp {
             self.settings_dialog.open_updates(&self.settings);
         }
 
-        if let Some(nm) = NOTIFICATION_MANAGER.get() {
-            if let Ok(mut nm) = nm.lock() {
+        if let Some(nm) = NOTIFICATION_MANAGER.get()
+            && let Ok(mut nm) = nm.lock() {
                 nm.show_notifications(ctx);
             }
-        }
 
         // Handle OS-dispatched file opens (e.g. macOS Apple Events / Finder)
         self.poll_os_open_requests();
@@ -196,11 +194,10 @@ impl App for ThothApp {
             (None, None)
         };
 
-        if let Some(error) = search_error {
-            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+        if let Some(error) = search_error
+            && let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
                 tab.error = Some(error);
             }
-        }
 
         let shortcut_actions =
             ShortcutHandler::handle_shortcuts(ui.ctx(), &self.settings.shortcuts);
@@ -406,18 +403,16 @@ impl ThothApp {
                 ShortcutAction::NextMatch => {}
                 ShortcutAction::PrevMatch => {}
                 ShortcutAction::NavBack => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(path) = tab.navigation_history.back() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(path) = tab.navigation_history.back() {
                             tab.central_panel.navigate_to_path(path);
                         }
-                    }
                 }
                 ShortcutAction::NavForward => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(path) = tab.navigation_history.forward() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(path) = tab.navigation_history.forward() {
                             tab.central_panel.navigate_to_path(path);
                         }
-                    }
                 }
                 ShortcutAction::Escape => {
                     if self.window_state.sidebar_expanded {
@@ -484,32 +479,28 @@ impl ThothApp {
                     }
                 }
                 ShortcutAction::CopyKey => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(text) = tab.central_panel.copy_selected_key() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(text) = tab.central_panel.copy_selected_key() {
                             self.clipboard_text = Some(text);
                         }
-                    }
                 }
                 ShortcutAction::CopyValue => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(text) = tab.central_panel.copy_selected_value() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(text) = tab.central_panel.copy_selected_value() {
                             self.clipboard_text = Some(text);
                         }
-                    }
                 }
                 ShortcutAction::CopyObject => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(text) = tab.central_panel.copy_selected_object() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(text) = tab.central_panel.copy_selected_object() {
                             self.clipboard_text = Some(text);
                         }
-                    }
                 }
                 ShortcutAction::CopyPath => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(text) = tab.central_panel.copy_selected_path() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(text) = tab.central_panel.copy_selected_path() {
                             self.clipboard_text = Some(text);
                         }
-                    }
                 }
                 ShortcutAction::CloseTab => {
                     if let Some(id) = self.window_state.tab_manager.active_tab_id() {
@@ -543,8 +534,8 @@ impl ThothApp {
     }
 
     fn dispatch_plugin_event(&mut self, event: crate::plugin::render_node::UiEvent) {
-        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-            if let Some(pane) = tab.active_plugin_pane.as_mut() {
+        if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+            && let Some(pane) = tab.active_plugin_pane.as_mut() {
                 match pane.loader.handle_event(event) {
                     Ok(new_output) => {
                         pane.ui_output = new_output;
@@ -559,7 +550,6 @@ impl ThothApp {
                     }
                 }
             }
-        }
     }
 
     /// Drain OS-dispatched file open requests (e.g. macOS Apple Events) and
@@ -644,11 +634,10 @@ impl ThothApp {
         }
 
         for (request_id, req) in retry_requests {
-            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                if let Some(pane) = tab.active_plugin_pane.as_mut() {
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                && let Some(pane) = tab.active_plugin_pane.as_mut() {
                     pane.loader.dispatch_approved_request(request_id, req);
                 }
-            }
             self.dispatch_plugin_event(UiEvent {
                 widget_id: "consent-approved".to_string(),
                 kind: "notify".to_string(),
@@ -731,18 +720,16 @@ impl ThothApp {
                     self.open_settings_window(ui.ctx());
                 }
                 components::toolbar::ToolbarEvent::NavigateBack => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(path) = tab.navigation_history.back() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(path) = tab.navigation_history.back() {
                             tab.central_panel.navigate_to_path(path);
                         }
-                    }
                 }
                 components::toolbar::ToolbarEvent::NavigateForward => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(path) = tab.navigation_history.forward() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(path) = tab.navigation_history.forward() {
                             tab.central_panel.navigate_to_path(path);
                         }
-                    }
                 }
             }
         }
@@ -1076,8 +1063,8 @@ impl ThothApp {
                             self.window_state.sidebar_expanded = false;
                             self.window_state.sidebar_selected_section = None;
                         } else {
-                            if let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) {
-                                if let Some(plugin) = manager.registry.get_by_id(plugin_id) {
+                            if let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref())
+                                && let Some(plugin) = manager.registry.get_by_id(plugin_id) {
                                     use crate::plugin::network_policy::NetworkPolicy;
                                     let user_policy = self
                                         .settings
@@ -1155,7 +1142,6 @@ impl ThothApp {
                                         }
                                     }
                                 }
-                            }
                         }
                     } else {
                         let is_plugin_sidebar = matches!(
@@ -1173,14 +1159,13 @@ impl ThothApp {
                                 self.window_state.sidebar_selected_section.clone();
                             self.window_state.sidebar_expanded = true;
                             self.window_state.sidebar_selected_section = Some(section);
-                            if !is_plugin_sidebar {
-                                if let Some(tab) =
+                            if !is_plugin_sidebar
+                                && let Some(tab) =
                                     self.window_state.tab_manager.active_tab_mut()
                                 {
                                     tab.active_plugin_pane = None;
                                     tab.plugin_sidebar_output = None;
                                 }
-                            }
                         }
                     }
 
@@ -1195,18 +1180,15 @@ impl ThothApp {
                     let _ = self.persistent_state.save();
                 }
                 components::sidebar::SidebarEvent::Search(msg) => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(file_path) = &tab.file_path {
-                            if let Some(path_str) = file_path.to_str() {
-                                if let Some(entry) = msg.history_entry() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(file_path) = &tab.file_path
+                            && let Some(path_str) = file_path.to_str()
+                                && let Some(entry) = msg.history_entry() {
                                     let _ =
                                         super::persistent_state::PersistentState::add_search_query(
                                             path_str, entry,
                                         );
                                 }
-                            }
-                        }
-                    }
                     return Some(msg);
                 }
                 components::sidebar::SidebarEvent::NavigateToSearchResult { record_index } => {
@@ -1215,16 +1197,14 @@ impl ThothApp {
                     }
                 }
                 components::sidebar::SidebarEvent::ClearSearchHistory => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if let Some(file_path) = &tab.file_path {
-                            if let Some(path_str) = file_path.to_str() {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                        && let Some(file_path) = &tab.file_path
+                            && let Some(path_str) = file_path.to_str() {
                                 let _ =
                                     super::persistent_state::PersistentState::clear_search_history(
                                         path_str,
                                     );
                             }
-                        }
-                    }
                 }
                 components::sidebar::SidebarEvent::NavigateToBookmark { file_path, path } => {
                     let current_file = self

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -23,6 +23,8 @@ pub struct ThothApp {
     settings_changed: bool,
     session_dirty: bool,
     show_update_consent: bool,
+    /// Holds the live native menu bar (muda) so it isn't dropped.
+    _native_menu: Option<crate::platform::native_menu::NativeMenu>,
     /// Plugin IDs from the persisted session that couldn't be restored yet because
     /// PLUGIN_MANAGER was still initializing on the background thread. Drained each
     /// frame once the manager becomes available.
@@ -33,7 +35,11 @@ pub struct ThothApp {
 }
 
 impl ThothApp {
-    pub fn new(settings: settings::Settings, file_to_open: Option<PathBuf>) -> Self {
+    pub fn new(
+        settings: settings::Settings,
+        file_to_open: Option<PathBuf>,
+        cc: &eframe::CreationContext<'_>,
+    ) -> Self {
         let persistent_state = PersistentState::default();
 
         let mut window_state = state::WindowState::default();
@@ -71,6 +77,16 @@ impl ThothApp {
             (deferred, restore_index)
         };
 
+        // Set up native menu bar (macOS/Windows); Linux uses egui menu in toolbar.
+        use raw_window_handle::HasWindowHandle as _;
+        let native_menu = cc
+            .window_handle()
+            .ok()
+            .map(|h| h.as_raw())
+            .and_then(|raw| {
+                crate::platform::native_menu::setup(raw, &settings.shortcuts)
+            });
+
         Self {
             settings,
             persistent_state,
@@ -81,6 +97,7 @@ impl ThothApp {
             settings_changed: false,
             session_dirty: false,
             show_update_consent: false,
+            _native_menu: native_menu,
             pending_plugin_restores,
             session_restore_active_index,
         }
@@ -778,6 +795,47 @@ impl ThothApp {
                             tab.central_panel.navigate_to_path(path);
                         }
                 }
+            }
+        }
+
+        // Poll native menu bar events (macOS / Windows).
+        // Linux falls back to the egui in-window menu bar rendered by toolbar.rs.
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        for action in crate::platform::native_menu::poll_events() {
+            use crate::platform::native_menu::MenuAction;
+            match action {
+                MenuAction::OpenFile => {
+                    let plugins_enabled = self.settings.plugins.enabled;
+                    if let Some(path) = crate::app::pick_file(plugins_enabled)
+                        && let Some(file_type) =
+                            crate::components::toolbar::infer_file_type_pub(&path)
+                    {
+                        if let Some(path_str) = path.to_str() {
+                            self.persistent_state.add_recent_file(
+                                path_str.to_string(),
+                                self.settings.performance.max_recent_files,
+                            );
+                            let _ = self.persistent_state.save();
+                        }
+                        let id = self
+                            .window_state
+                            .tab_manager
+                            .open_file(path, nav_capacity);
+                        if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&id) {
+                            tab.file_type = file_type;
+                            tab.error = None;
+                        }
+                    }
+                }
+                MenuAction::NewWindow => self.create_new_window(),
+                MenuAction::CloseTab => {
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.file_path = None;
+                        tab.error = None;
+                    }
+                    self.session_dirty = true;
+                }
+                MenuAction::OpenSettings => self.open_settings_window(ui.ctx()),
             }
         }
     }
@@ -1514,6 +1572,9 @@ impl ThothApp {
                 }
                 components::sidebar::SidebarEvent::PluginSidebarEvent(evt) => {
                     self.dispatch_plugin_event(evt);
+                }
+                components::sidebar::SidebarEvent::OpenSettings => {
+                    self.settings_dialog.open(&self.settings);
                 }
             }
         }

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use crate::{
     NOTIFICATION_MANAGER, PLUGIN_MANAGER,
-    app::{file_picker, pick_file},
+    app::{file_picker, pick_file, tab_manager::TabEvent},
     components::{self, traits::ContextComponent},
     settings, state,
 };
@@ -12,51 +12,34 @@ use super::{
     ShortcutAction, persistent_state::PersistentState, search_handler::SearchHandler,
     shortcut_handler::ShortcutHandler, update_handler::UpdateHandler,
 };
-use crate::components::central_panel::CentralPanelProps;
 
 pub struct ThothApp {
-    // Settings for this window
     pub settings: settings::Settings,
-
-    // Persistent state (shared across app, saved to disk)
     pub persistent_state: PersistentState,
-
-    // Window state (per-window, not persisted)
     pub window_state: state::WindowState,
-
-    // Update state
     pub update_state: state::ApplicationUpdateState,
-
-    // Settings dialog
     settings_dialog: components::settings_dialog::SettingsDialog,
-
-    // Clipboard text to copy (set by shortcuts, copied in update loop)
     clipboard_text: Option<String>,
-
-    // Track if settings need to be saved
     settings_changed: bool,
 }
 
 impl ThothApp {
-    /// Create a new ThothApp with loaded settings and optional file to open
     pub fn new(settings: settings::Settings, file_to_open: Option<PathBuf>) -> Self {
-        // Load persistent state (recent files, sidebar width, etc.)
         let persistent_state = PersistentState::default();
 
-        // Initialize window state with saved sidebar state if remember_sidebar_state is enabled
         let mut window_state = state::WindowState::default();
         if settings.ui.remember_sidebar_state {
             window_state.sidebar_expanded = persistent_state.get_sidebar_expanded();
         }
 
-        // Initialize navigation history with configured size
-        window_state.navigation_history =
-            state::NavigationHistory::with_capacity(settings.performance.navigation_history_size);
+        // Replace the default TabManager with one that uses the configured nav history size.
+        window_state.tab_manager =
+            crate::app::TabManager::new(settings.performance.navigation_history_size);
 
-        // If a file path was provided via command line, set it up to load
         if let Some(path) = file_to_open {
-            window_state.file_path = Some(path);
-            // The file will be loaded in the first update() call via the file loading logic
+            window_state
+                .tab_manager
+                .open_file(path, settings.performance.navigation_history_size);
         }
 
         Self {
@@ -70,28 +53,16 @@ impl ThothApp {
         }
     }
 
-    /// Create a new window as an independent process
     pub fn create_new_window(&mut self) {
         use std::process::Command;
-
-        // Get the current executable path
         if let Ok(exe_path) = std::env::current_exe() {
-            // Spawn a new instance of Thoth as an independent process
             match Command::new(exe_path).spawn() {
-                Ok(_) => {
-                    eprintln!("New Thoth window spawned successfully");
-                }
-                Err(e) => {
-                    eprintln!("Failed to spawn new window: {}", e);
-                }
+                Ok(_) => {}
+                Err(e) => eprintln!("Failed to spawn new window: {}", e),
             }
-        } else {
-            eprintln!("Failed to get current executable path");
         }
     }
 
-    /// Apply a new `Settings` value, running all required side-effects.
-    /// Called both from the settings dialog output and from `Settings::take_if_dirty`.
     fn apply_new_settings(&mut self, new_settings: settings::Settings) {
         let prev_remember_sidebar = self.settings.ui.remember_sidebar_state;
         let prev_plugins_enabled = self.settings.plugins.enabled;
@@ -108,19 +79,21 @@ impl ThothApp {
             pm.update_plugin_settings(self.settings.plugins.plugin_settings.clone());
         }
 
-        if let Some(pane) = self.window_state.active_plugin_pane.as_mut() {
-            let updated = self
-                .settings
-                .plugins
-                .plugin_settings
-                .get(&pane.plugin_id)
-                .cloned()
-                .unwrap_or_default();
-            if let Err(e) = pane.loader.on_setting_change(&updated) {
-                eprintln!(
-                    "Failed to notify plugin '{}' of setting change: {e}",
-                    pane.plugin_id
-                );
+        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+            if let Some(pane) = tab.active_plugin_pane.as_mut() {
+                let updated = self
+                    .settings
+                    .plugins
+                    .plugin_settings
+                    .get(&pane.plugin_id)
+                    .cloned()
+                    .unwrap_or_default();
+                if let Err(e) = pane.loader.on_setting_change(&updated) {
+                    eprintln!(
+                        "Failed to notify plugin '{}' of setting change: {e}",
+                        pane.plugin_id
+                    );
+                }
             }
         }
 
@@ -148,11 +121,8 @@ impl ThothApp {
         }
     }
 
-    /// Open settings dialog as a separate viewport window
     fn open_settings_window(&mut self, ctx: &egui::Context) {
         self.settings_dialog.open(&self.settings);
-
-        // Request a repaint to trigger viewport creation
         ctx.request_repaint();
     }
 }
@@ -162,16 +132,13 @@ impl App for ThothApp {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
-        // Check for updates based on settings
         if UpdateHandler::should_check_updates(&self.update_state, &self.settings) {
             UpdateHandler::check_for_updates(&mut self.update_state);
         }
 
-        // Handle update messages
         let should_show_updates =
             UpdateHandler::handle_update_messages(&mut self.update_state, ctx);
 
-        // Auto-open settings on Updates tab if a new update is available
         if should_show_updates && !self.settings_dialog.open {
             self.settings_dialog.open_updates(&self.settings);
         }
@@ -187,8 +154,6 @@ impl App for ThothApp {
 
         // Handle file drops
         self.handle_file_drop(ctx);
-
-        // Update window title
         self.update_window_title(ctx);
     }
 
@@ -198,51 +163,49 @@ impl App for ThothApp {
 
         let ctx = ui.ctx().clone();
 
-        // Publish settings into egui context so any component can read or mutate them.
         settings::Settings::store(&ctx, &self.settings);
 
-        // Poll completed async HTTP requests from the active plugin pane.
-        // Must happen before rendering so the updated ui_output is used this frame.
         self.poll_plugin_http_results(&ctx);
 
-        // Get user's action from Toolbar (if enabled)
         if self.settings.ui.show_toolbar {
             self.render_toolbar(ui);
         }
 
-        // Render status bar (before sidebar so it spans full width) (if enabled)
         if self.settings.ui.show_status_bar {
             self.render_status_bar(ui);
         }
 
-        // Handle clipboard operations
         if let Some(text) = self.clipboard_text.take() {
             ctx.copy_text(text);
         }
 
-        // Render sidebar and handle events (may return search message)
         let sidebar_msg = self.render_sidebar(ui);
 
-        // Handle search messages from sidebar
-        let (msg_to_central, search_error) = SearchHandler::handle_search_messages(
-            sidebar_msg,
-            &mut self.window_state.search_engine_state,
-            &self.window_state.file_path,
-            &self.window_state.file_type,
-            &ctx,
-        );
+        // Handle search messages from sidebar against the active tab.
+        let (msg_to_central, search_error) = if let Some(tab) =
+            self.window_state.tab_manager.active_tab_mut()
+        {
+            SearchHandler::handle_search_messages(
+                sidebar_msg,
+                &mut tab.search_engine_state,
+                &tab.file_path,
+                &tab.file_type,
+                &ctx,
+            )
+        } else {
+            (None, None)
+        };
 
-        // Handle search errors
         if let Some(error) = search_error {
-            self.window_state.error = Some(error);
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                tab.error = Some(error);
+            }
         }
 
-        // Handle keyboard shortcuts
         let shortcut_actions =
             ShortcutHandler::handle_shortcuts(ui.ctx(), &self.settings.shortcuts);
         self.handle_shortcut_actions(ui.ctx(), shortcut_actions);
 
-        // Render settings dialog using ContextComponent trait
         use crate::components::settings_dialog::{SettingsDialogEvent, SettingsDialogProps};
         use crate::components::traits::ContextComponent;
 
@@ -255,24 +218,20 @@ impl App for ThothApp {
             },
         );
 
-        // Apply theme (draft settings are applied inside render() when viewport is open)
         if !self.settings_dialog.open {
             crate::theme::apply_theme(&ctx, &self.settings);
         }
 
-        // Handle settings changes from the dialog
         if let Some(new_settings) = settings_output.new_settings {
             self.apply_new_settings(new_settings);
         }
 
-        // Handle settings dialog events
         for event in settings_output.events {
             match event {
                 SettingsDialogEvent::CheckForUpdates => {
                     UpdateHandler::check_for_updates(&mut self.update_state);
                 }
                 SettingsDialogEvent::DownloadUpdate => {
-                    // Clone the latest release to avoid borrow checker issues
                     let latest_release =
                         if let crate::update::UpdateState::UpdateAvailable { releases, .. } =
                             &self.update_state.update_status.state
@@ -306,7 +265,9 @@ impl App for ThothApp {
                             ctx.request_repaint();
                         }
                         Err(e) => {
-                            self.window_state.error = Some(e);
+                            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                                tab.error = Some(e);
+                            }
                         }
                     }
                 }
@@ -316,15 +277,15 @@ impl App for ThothApp {
                             ctx.request_repaint();
                         }
                         Err(e) => {
-                            self.window_state.error = Some(e);
+                            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                                tab.error = Some(e);
+                            }
                         }
                     }
                 }
             }
         }
 
-        // Render the central panel and handle events.
-        // When the marketplace section is active, show the plugin detail pane instead.
         if self.window_state.sidebar_selected_section
             == Some(components::sidebar::SidebarSection::MarketPlace)
         {
@@ -335,21 +296,15 @@ impl App for ThothApp {
             self.render_central_panel(ui, msg_to_central);
         }
 
-        // Render error modal if there's an error
         self.render_error_modal(&ctx);
 
-        // Collect settings mutations from any component rendered this frame,
-        // then save. Done last so every component has had a chance to call
-        // Settings::update() before we drain and persist.
         if let Some(new_settings) = settings::Settings::take_if_dirty(&ctx) {
             self.apply_new_settings(new_settings);
         }
         self.save_settings_if_changed();
 
-        // Show profiler if enabled (only when profiling feature is enabled)
         #[cfg(feature = "profiling")]
         if self.settings.dev.show_profiler {
-            // Enable puffin profiling
             puffin::GlobalProfiler::lock().new_frame();
 
             egui::Window::new(format!(
@@ -358,7 +313,6 @@ impl App for ThothApp {
             ))
             .default_open(true)
             .show(&ctx, |ui| {
-                // Memory profiling info
                 ui.collapsing("Memory Profiling (dhat)", |ui| {
                     ui.label("📊 Memory allocations are being tracked.");
                     ui.label("When you close the app, dhat-heap.json will be generated.");
@@ -374,14 +328,12 @@ impl App for ThothApp {
 
                 ui.separator();
 
-                // Show frame statistics
                 ui.collapsing("Frame Stats", |ui| {
                     ctx.inspection_ui(ui);
                 });
 
                 ui.separator();
 
-                // Show additional egui settings
                 ui.collapsing("Advanced Settings", |ui| {
                     ctx.settings_ui(ui);
                 });
@@ -391,13 +343,13 @@ impl App for ThothApp {
 }
 
 impl ThothApp {
-    /// Handle keyboard shortcut actions
     fn handle_shortcut_actions(&mut self, ctx: &egui::Context, actions: Vec<ShortcutAction>) {
+        let nav_capacity = self.settings.performance.navigation_history_size;
+
         for action in actions {
             match action {
                 ShortcutAction::OpenFile => {
                     if let Some(path) = file_picker::pick_file(self.settings.plugins.enabled) {
-                        // Add to recent files
                         if let Some(path_str) = path.to_str() {
                             self.persistent_state.add_recent_file(
                                 path_str.to_string(),
@@ -405,18 +357,18 @@ impl ThothApp {
                             );
                             let _ = self.persistent_state.save();
                         }
-
-                        self.window_state.file_path = Some(path);
-                        self.window_state.error = None;
+                        self.window_state.tab_manager.open_file(path, nav_capacity);
                     }
                 }
                 ShortcutAction::ClearFile => {
-                    if self.window_state.file_path.is_some() {
-                        // If a file is open, clear it
-                        self.window_state.file_path = None;
-                        self.window_state.error = None;
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if tab.file_path.is_some() {
+                            tab.file_path = None;
+                            tab.error = None;
+                        } else {
+                            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                        }
                     } else {
-                        // If no file is open, close the window using egui's proper mechanism
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                     }
                 }
@@ -424,7 +376,6 @@ impl ThothApp {
                     self.create_new_window();
                 }
                 ShortcutAction::Settings => {
-                    // Open settings in a new window
                     self.open_settings_window(ctx);
                 }
                 ShortcutAction::ToggleTheme => {
@@ -435,9 +386,7 @@ impl ThothApp {
                     self.settings.dev.show_profiler = !self.settings.dev.show_profiler;
                     self.settings_changed = true;
                 }
-                // Navigation shortcuts - handled by JSON viewer or search
                 ShortcutAction::FocusSearch => {
-                    // Toggle search section
                     let section = components::sidebar::SidebarSection::Search;
                     if self.window_state.sidebar_expanded
                         && self.window_state.sidebar_selected_section == Some(section.clone())
@@ -448,37 +397,32 @@ impl ThothApp {
                         self.window_state.sidebar_selected_section = Some(section);
                     }
 
-                    // Save sidebar state if remember_sidebar_state is enabled
                     if self.settings.ui.remember_sidebar_state {
                         self.persistent_state
                             .set_sidebar_expanded(self.window_state.sidebar_expanded);
                         let _ = self.persistent_state.save();
                     }
                 }
-                ShortcutAction::NextMatch => {
-                    // TODO: Implement next match navigation
-                }
-                ShortcutAction::PrevMatch => {
-                    // TODO: Implement previous match navigation
-                }
+                ShortcutAction::NextMatch => {}
+                ShortcutAction::PrevMatch => {}
                 ShortcutAction::NavBack => {
-                    // Navigate back in history
-                    if let Some(path) = self.window_state.navigation_history.back() {
-                        self.window_state.central_panel.navigate_to_path(path);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(path) = tab.navigation_history.back() {
+                            tab.central_panel.navigate_to_path(path);
+                        }
                     }
                 }
                 ShortcutAction::NavForward => {
-                    // Navigate forward in history
-                    if let Some(path) = self.window_state.navigation_history.forward() {
-                        self.window_state.central_panel.navigate_to_path(path);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(path) = tab.navigation_history.forward() {
+                            tab.central_panel.navigate_to_path(path);
+                        }
                     }
                 }
                 ShortcutAction::Escape => {
-                    // Close sidebar if open
                     if self.window_state.sidebar_expanded {
                         self.window_state.sidebar_expanded = false;
 
-                        // Save sidebar state if remember_sidebar_state is enabled
                         if self.settings.ui.remember_sidebar_state {
                             self.persistent_state.set_sidebar_expanded(false);
                             let _ = self.persistent_state.save();
@@ -486,117 +430,133 @@ impl ThothApp {
                     }
                 }
                 ShortcutAction::ToggleBookmark => {
-                    // Toggle bookmark for currently selected path
-                    if let Some(selected_path) = self.window_state.central_panel.get_selected_path()
-                    {
-                        if let Some(file_path) = &self.window_state.file_path {
-                            if let Some(file_path_str) = file_path.to_str() {
-                                let added = self.persistent_state.toggle_bookmark(
-                                    selected_path.clone(),
-                                    file_path_str.to_string(),
-                                );
-
-                                // Save bookmarks
-                                if let Err(e) = self.persistent_state.save() {
-                                    eprintln!("Failed to save bookmarks: {}", e);
-                                }
-
-                                // Optional: Show feedback to user
-                                if added {
-                                    // Could show a toast notification: "Bookmark added"
-                                } else {
-                                    // Could show a toast notification: "Bookmark removed"
-                                }
-                            }
+                    let info = self.window_state.tab_manager.active_tab_mut().and_then(|tab| {
+                        let path = tab.central_panel.get_selected_path()?.clone();
+                        let file_path = tab.file_path.as_ref()?.to_str()?.to_string();
+                        Some((path, file_path))
+                    });
+                    if let Some((selected_path, file_path_str)) = info {
+                        self.persistent_state
+                            .toggle_bookmark(selected_path, file_path_str);
+                        if let Err(e) = self.persistent_state.save() {
+                            eprintln!("Failed to save bookmarks: {}", e);
                         }
                     }
                 }
                 ShortcutAction::OpenBookmarks => {
-                    // Open bookmarks panel in sidebar
                     self.window_state.sidebar_expanded = true;
                     self.window_state.sidebar_selected_section =
                         Some(components::sidebar::SidebarSection::Bookmarks);
 
-                    // Save sidebar state if remember_sidebar_state is enabled
                     if self.settings.ui.remember_sidebar_state {
                         self.persistent_state.set_sidebar_expanded(true);
                         let _ = self.persistent_state.save();
                     }
                 }
-                // Tree operations
                 ShortcutAction::ExpandNode => {
-                    self.window_state.central_panel.expand_selected_node();
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.central_panel.expand_selected_node();
+                    }
                 }
                 ShortcutAction::CollapseNode => {
-                    self.window_state.central_panel.collapse_selected_node();
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.central_panel.collapse_selected_node();
+                    }
                 }
                 ShortcutAction::ExpandAll => {
-                    self.window_state.central_panel.expand_all_nodes();
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.central_panel.expand_all_nodes();
+                    }
                 }
                 ShortcutAction::CollapseAll => {
-                    self.window_state.central_panel.collapse_all_nodes();
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.central_panel.collapse_all_nodes();
+                    }
                 }
-                // Movement operations
                 ShortcutAction::MoveUp => {
-                    self.window_state.central_panel.move_selection_up();
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.central_panel.move_selection_up();
+                    }
                 }
                 ShortcutAction::MoveDown => {
-                    self.window_state.central_panel.move_selection_down();
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.central_panel.move_selection_down();
+                    }
                 }
-                // Clipboard operations
                 ShortcutAction::CopyKey => {
-                    if let Some(text) = self.window_state.central_panel.copy_selected_key() {
-                        self.clipboard_text = Some(text);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(text) = tab.central_panel.copy_selected_key() {
+                            self.clipboard_text = Some(text);
+                        }
                     }
                 }
                 ShortcutAction::CopyValue => {
-                    if let Some(text) = self.window_state.central_panel.copy_selected_value() {
-                        self.clipboard_text = Some(text);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(text) = tab.central_panel.copy_selected_value() {
+                            self.clipboard_text = Some(text);
+                        }
                     }
                 }
                 ShortcutAction::CopyObject => {
-                    if let Some(text) = self.window_state.central_panel.copy_selected_object() {
-                        self.clipboard_text = Some(text);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(text) = tab.central_panel.copy_selected_object() {
+                            self.clipboard_text = Some(text);
+                        }
                     }
                 }
                 ShortcutAction::CopyPath => {
-                    if let Some(text) = self.window_state.central_panel.copy_selected_path() {
-                        self.clipboard_text = Some(text);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(text) = tab.central_panel.copy_selected_path() {
+                            self.clipboard_text = Some(text);
+                        }
                     }
+                }
+                ShortcutAction::CloseTab => {
+                    if let Some(id) = self.window_state.tab_manager.active_tab_id() {
+                        self.window_state.tab_manager.tabs.remove(&id);
+                        self.window_state
+                            .tab_manager
+                            .ensure_non_empty(nav_capacity);
+                    }
+                }
+                ShortcutAction::NextTab => {
+                    self.window_state.tab_manager.cycle_tab(1);
+                }
+                ShortcutAction::PrevTab => {
+                    self.window_state.tab_manager.cycle_tab(-1);
                 }
             }
         }
     }
 
-    /// Update window title based on current file
-    fn update_window_title(&self, ctx: &egui::Context) {
-        let title = if let Some(path) = &self.window_state.file_path {
-            let file_name = std::path::Path::new(path)
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("Unknown file");
-            format!("Thoth — {}", file_name)
-        } else {
-            "Thoth — JSON & NDJSON Viewer".to_owned()
-        };
+    fn update_window_title(&mut self, ctx: &egui::Context) {
+        // active_tab_id() borrows mutably; store result before the immutable tabs lookup.
+        let active_id = self.window_state.tab_manager.active_tab_id();
+        let title = active_id
+            .and_then(|id| self.window_state.tab_manager.tabs.get(&id))
+            .and_then(|tab| tab.file_path.as_deref())
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .map(|name| format!("Thoth — {}", name))
+            .unwrap_or_else(|| "Thoth — JSON & NDJSON Viewer".to_owned());
         ctx.send_viewport_cmd(egui::ViewportCommand::Title(title));
     }
 
-    /// Forward `event` to the active plugin pane, refresh `ui_output`, and
-    /// update the sidebar. Sets `window_state.error` on failure.
     fn dispatch_plugin_event(&mut self, event: crate::plugin::render_node::UiEvent) {
-        if let Some(pane) = self.window_state.active_plugin_pane.as_mut() {
-            match pane.loader.handle_event(event) {
-                Ok(new_output) => {
-                    pane.ui_output = new_output;
-                    if let Ok(sidebar) = pane.loader.render_sidebar() {
-                        self.window_state.plugin_sidebar_output = sidebar;
+        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+            if let Some(pane) = tab.active_plugin_pane.as_mut() {
+                match pane.loader.handle_event(event) {
+                    Ok(new_output) => {
+                        pane.ui_output = new_output;
+                        if let Ok(sidebar) = pane.loader.render_sidebar() {
+                            tab.plugin_sidebar_output = sidebar;
+                        }
                     }
-                }
-                Err(e) => {
-                    self.window_state.error = Some(crate::error::ThothError::Unknown {
-                        message: e.to_string(),
-                    });
+                    Err(e) => {
+                        tab.error = Some(crate::error::ThothError::Unknown {
+                            message: e.to_string(),
+                        });
+                    }
                 }
             }
         }
@@ -631,12 +591,14 @@ impl ThothApp {
     fn poll_plugin_http_results(&mut self, ctx: &egui::Context) {
         use crate::plugin::render_node::UiEvent;
 
-        // Collect all pending results first so we can drop the pane borrow
-        // before calling dispatch_plugin_event (which also borrows self).
         let (http_events, retry_requests, needs_repaint) = {
-            let Some(pane) = self.window_state.active_plugin_pane.as_mut() else {
+            let Some(tab) = self.window_state.tab_manager.active_tab_mut() else {
                 return;
             };
+            let Some(pane) = tab.active_plugin_pane.as_mut() else {
+                return;
+            };
+
             let http_events: Vec<UiEvent> = pane
                 .loader
                 .drain_http_results()
@@ -656,8 +618,6 @@ impl ThothApp {
                             .to_string()
                         }
                         Err(msg) => {
-                            // Use a structured code for consent so plugins can
-                            // detect it reliably without string-matching the message.
                             let code = if msg.contains("waiting for user consent") {
                                 "consent_pending"
                             } else {
@@ -683,13 +643,12 @@ impl ThothApp {
             self.dispatch_plugin_event(event);
         }
 
-        // Re-dispatch any requests the user approved via consent notifications.
         for (request_id, req) in retry_requests {
-            if let Some(pane) = self.window_state.active_plugin_pane.as_mut() {
-                pane.loader.dispatch_approved_request(request_id, req);
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                if let Some(pane) = tab.active_plugin_pane.as_mut() {
+                    pane.loader.dispatch_approved_request(request_id, req);
+                }
             }
-            // Notify the plugin so it can switch its spinner text from
-            // "Waiting for consent" to "Sending request…".
             self.dispatch_plugin_event(UiEvent {
                 widget_id: "consent-approved".to_string(),
                 kind: "notify".to_string(),
@@ -703,22 +662,31 @@ impl ThothApp {
         }
     }
 
-    /// Render toolbar
     fn render_toolbar(&mut self, ui: &mut egui::Ui) {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
-        // Render toolbar using ContextComponent trait with one-way binding
-        let can_go_back = self.window_state.navigation_history.can_go_back();
-        let can_go_forward = self.window_state.navigation_history.can_go_forward();
+        let (file_type, file_path_opt, can_go_back, can_go_forward) =
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                let back = tab.navigation_history.can_go_back();
+                let fwd = tab.navigation_history.can_go_forward();
+                (tab.file_type, tab.file_path.clone(), back, fwd)
+            } else {
+                (
+                    crate::file::lazy_loader::FileKind::default(),
+                    None,
+                    false,
+                    false,
+                )
+            };
 
         let output = self.window_state.toolbar.render(
             ui,
             components::toolbar::ToolbarProps {
-                file_type: &self.window_state.file_type,
+                file_type: &file_type,
                 dark_mode: self.settings.dark_mode,
                 shortcuts: &self.settings.shortcuts,
-                file_path: self.window_state.file_path.as_deref(),
+                file_path: file_path_opt.as_deref(),
                 is_fullscreen: ui
                     .ctx()
                     .input(|i: &egui::InputState| i.viewport().fullscreen.unwrap_or(false)),
@@ -728,11 +696,11 @@ impl ThothApp {
             },
         );
 
-        // Handle events emitted by the toolbar (bottom-to-top communication)
+        let nav_capacity = self.settings.performance.navigation_history_size;
+
         for event in output.events {
             match event {
                 components::toolbar::ToolbarEvent::FileOpen { path, file_type } => {
-                    // Add to recent files
                     if let Some(path_str) = path.to_str() {
                         self.persistent_state.add_recent_file(
                             path_str.to_string(),
@@ -740,14 +708,17 @@ impl ThothApp {
                         );
                         let _ = self.persistent_state.save();
                     }
-
-                    self.window_state.file_path = Some(path);
-                    self.window_state.file_type = file_type;
-                    self.window_state.error = None;
+                    let id = self.window_state.tab_manager.open_file(path, nav_capacity);
+                    if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&id) {
+                        tab.file_type = file_type;
+                        tab.error = None;
+                    }
                 }
                 components::toolbar::ToolbarEvent::FileClear => {
-                    self.window_state.file_path = None;
-                    self.window_state.error = None;
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.file_path = None;
+                        tab.error = None;
+                    }
                 }
                 components::toolbar::ToolbarEvent::NewWindow => {
                     self.create_new_window();
@@ -757,26 +728,26 @@ impl ThothApp {
                     self.settings_changed = true;
                 }
                 components::toolbar::ToolbarEvent::OpenSettings => {
-                    // Open settings in a new window
                     self.open_settings_window(ui.ctx());
                 }
                 components::toolbar::ToolbarEvent::NavigateBack => {
-                    // Navigate back in history
-                    if let Some(path) = self.window_state.navigation_history.back() {
-                        self.window_state.central_panel.navigate_to_path(path);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(path) = tab.navigation_history.back() {
+                            tab.central_panel.navigate_to_path(path);
+                        }
                     }
                 }
                 components::toolbar::ToolbarEvent::NavigateForward => {
-                    // Navigate forward in history
-                    if let Some(path) = self.window_state.navigation_history.forward() {
-                        self.window_state.central_panel.navigate_to_path(path);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(path) = tab.navigation_history.forward() {
+                            tab.central_panel.navigate_to_path(path);
+                        }
                     }
                 }
             }
         }
     }
 
-    /// Save settings if they have changed
     fn save_settings_if_changed(&mut self) {
         if self.settings_changed {
             if let Err(e) = self.settings.save() {
@@ -786,59 +757,80 @@ impl ThothApp {
         }
     }
 
-    /// Render status bar
     fn render_status_bar(&mut self, ui: &mut egui::Ui) {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
-        // Determine status based on search state
-        let search = &self.window_state.search_engine_state.search;
-        let status = if search.scanning {
+        let (file_path_opt, file_type, total_items, error_present, search_scanning, _search_results_len, filtered_count, selected_path) =
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                let search = &tab.search_engine_state.search;
+                let scanning = search.scanning;
+                let results_len = search.results.len();
+                let query_non_empty = !search.query.is_empty();
+                let filtered = if query_non_empty && results_len > 0 {
+                    Some(results_len)
+                } else {
+                    None
+                };
+                let sel_path = tab.central_panel.get_selected_path().cloned();
+                (
+                    tab.file_path.clone(),
+                    tab.file_type,
+                    tab.total_items,
+                    tab.error.is_some(),
+                    scanning,
+                    results_len,
+                    filtered,
+                    sel_path,
+                )
+            } else {
+                (
+                    None,
+                    crate::file::lazy_loader::FileKind::default(),
+                    0,
+                    false,
+                    false,
+                    0,
+                    None,
+                    None,
+                )
+            };
+
+        let status = if search_scanning {
             components::status_bar::StatusBarStatus::Searching
-        } else if !search.query.is_empty() && !search.results.is_empty() {
+        } else if filtered_count.is_some() {
             components::status_bar::StatusBarStatus::Filtered
-        } else if self.window_state.error.is_some() {
+        } else if error_present {
             components::status_bar::StatusBarStatus::Error
         } else {
             components::status_bar::StatusBarStatus::Ready
         };
 
-        // Get item counts from window state
-        let item_count = self.window_state.total_items;
-        let filtered_count = if !search.results.is_empty() {
-            Some(search.results.len())
-        } else {
-            None
-        };
-
-        // Get selected path for breadcrumbs
-        let selected_path = self.window_state.central_panel.get_selected_path();
-
         let status_bar_output = self.window_state.status_bar.render(
             ui,
             components::status_bar::StatusBarProps {
-                file_path: self.window_state.file_path.as_deref(),
-                file_type: &self.window_state.file_type,
-                item_count,
+                file_path: file_path_opt.as_deref(),
+                file_type: &file_type,
+                item_count: total_items,
                 filtered_count,
                 status,
-                selected_path: selected_path.as_ref().map(|s| s.as_str()),
+                selected_path: selected_path.as_deref(),
             },
         );
 
-        // Handle status bar events
         for event in status_bar_output.events {
             match event {
                 components::status_bar::StatusBarEvent::NavigateToPath(path) => {
-                    // Track in navigation history before navigating
-                    self.window_state.navigation_history.push(path.clone());
-                    self.window_state.central_panel.navigate_to_path(path);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.navigation_history.push(path.clone());
+                        tab.central_panel.navigate_to_path(path);
+                    }
                 }
             }
         }
     }
 
-    /// Render central panel and handle events
+    /// Render the DockArea that hosts all open tabs.
     fn render_central_panel(
         &mut self,
         ui: &mut egui::Ui,
@@ -847,97 +839,106 @@ impl ThothApp {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
-        // Track path selection changes for navigation history
-        let previous_path = self.window_state.central_panel.get_selected_path().cloned();
+        let nav_capacity = self.settings.performance.navigation_history_size;
+        let focused_id = self.window_state.tab_manager.active_tab_id();
 
-        // Render central panel using ContextComponent trait with one-way binding
-        let output = self.window_state.central_panel.render(
-            ui,
-            CentralPanelProps {
-                file_path: &self.window_state.file_path,
-                file_type: self.window_state.file_type,
-                error: &self.window_state.error,
-                search_message,
-                cache_size: self.settings.performance.cache_size,
-                syntax_highlighting: self.settings.viewer.syntax_highlighting,
-                plugin_ui: self
-                    .window_state
-                    .active_plugin_pane
-                    .as_ref()
-                    .map(|p| &p.ui_output),
-            },
-        );
+        let colors = ui
+            .ctx()
+            .memory(|m| m.data.get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors")));
 
-        // After rendering, check if path changed and add to navigation history
-        let current_path = self.window_state.central_panel.get_selected_path();
-        if current_path != previous_path.as_ref() {
-            if let Some(path) = current_path {
-                self.window_state.navigation_history.push(path.clone());
-            }
+        let dock_style = build_dock_style(ui.style(), colors);
+
+        let (dock_state, tabs) = self.window_state.tab_manager.borrow_parts();
+
+        let mut viewer = crate::app::tab_manager::ThothTabViewer {
+            tabs,
+            settings: &self.settings,
+            persistent_state: &mut self.persistent_state,
+            nav_capacity,
+            search_msg: search_message.zip(focused_id).map(|(msg, id)| (id, msg)),
+            events: Vec::new(),
+            colors,
+        };
+
+        egui_dock::DockArea::new(dock_state)
+            .style(dock_style)
+            .show_inside(ui, &mut viewer);
+
+        // Drain and process events emitted during rendering.
+        let events: Vec<TabEvent> = viewer.events.drain(..).collect();
+        for event in events {
+            self.handle_tab_event(event, nav_capacity);
         }
+    }
 
-        // Handle events emitted by the central panel (bottom-to-top communication)
-        for event in output.events {
-            match event {
-                components::central_panel::CentralPanelEvent::FileOpened {
-                    path,
-                    file_type,
-                    total_items,
-                } => {
-                    // Add to recent files
-                    if let Some(path_str) = path.to_str() {
-                        self.persistent_state.add_recent_file(
-                            path_str.to_string(),
-                            self.settings.performance.max_recent_files,
-                        );
-                        let _ = self.persistent_state.save();
-                    }
-
-                    self.window_state.file_path = Some(path);
-                    self.window_state.file_type = file_type;
-                    self.window_state.total_items = total_items;
-                    // Clear any plugin pane so the file viewer takes over.
-                    self.window_state.active_plugin_pane = None;
-                    self.window_state.plugin_sidebar_output = None;
-
-                    // Apply pending navigation if exists
-                    if let Some(pending_path) = self.window_state.pending_navigation.take() {
-                        self.window_state
-                            .central_panel
-                            .navigate_to_path(pending_path);
+    fn handle_tab_event(&mut self, event: TabEvent, nav_capacity: usize) {
+        match event {
+            TabEvent::FileOpened {
+                tab_id,
+                path,
+                file_type,
+                total_items,
+            } => {
+                if let Some(path_str) = path.to_str() {
+                    self.persistent_state.add_recent_file(
+                        path_str.to_string(),
+                        self.settings.performance.max_recent_files,
+                    );
+                    let _ = self.persistent_state.save();
+                }
+                if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
+                    tab.file_path = Some(path);
+                    tab.file_type = file_type;
+                    tab.total_items = total_items;
+                    tab.active_plugin_pane = None;
+                    tab.plugin_sidebar_output = None;
+                    if let Some(pending_path) = tab.pending_navigation.take() {
+                        tab.central_panel.navigate_to_path(pending_path);
                     }
                 }
-                components::central_panel::CentralPanelEvent::FileOpenError(msg) => {
-                    self.window_state.error = Some(msg);
+            }
+            TabEvent::FileOpenError { tab_id, error } => {
+                if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
+                    tab.error = Some(error);
                 }
-                components::central_panel::CentralPanelEvent::FileClosed => {
-                    self.window_state.file_path = None;
-                    self.window_state.total_items = 0;
+            }
+            TabEvent::FileClosed { tab_id } => {
+                if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
+                    tab.file_path = None;
+                    tab.total_items = 0;
                 }
-                components::central_panel::CentralPanelEvent::FileTypeChanged(file_type) => {
-                    self.window_state.file_type = file_type;
+            }
+            TabEvent::FileTypeChanged { tab_id, file_type } => {
+                if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
+                    tab.file_type = file_type;
                 }
-                components::central_panel::CentralPanelEvent::ErrorCleared => {
-                    self.window_state.error = None;
+            }
+            TabEvent::ErrorCleared { tab_id } => {
+                if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
+                    tab.error = None;
                 }
-                components::central_panel::CentralPanelEvent::PluginUiEvent(evt) => {
-                    self.dispatch_plugin_event(evt);
+            }
+            TabEvent::PluginUiEvent { event, .. } => {
+                self.dispatch_plugin_event(event);
+            }
+            TabEvent::NavigationPush { tab_id, path } => {
+                if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
+                    tab.navigation_history.push(path);
                 }
+            }
+            TabEvent::TabClosed(id) => {
+                self.window_state.tab_manager.ensure_non_empty(nav_capacity);
+                let _ = id;
             }
         }
     }
 
-    /// Render sidebar and handle its events
     fn render_sidebar(&mut self, ui: &mut egui::Ui) -> Option<crate::search::SearchMessage> {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
         use crate::components::traits::ContextComponent;
 
-        // Determine if search should receive focus
-        // Focus when:
-        // 1. Section changed to Search (from a different section)
-        // 2. OR sidebar was just expanded with Search section (reopening)
         let section_changed_to_search = self.window_state.sidebar_selected_section
             == Some(components::sidebar::SidebarSection::Search)
             && self.window_state.previous_sidebar_section
@@ -950,104 +951,102 @@ impl ThothApp {
 
         let focus_search = section_changed_to_search || sidebar_reopened_with_search;
 
-        // Collect data-source plugins before constructing SidebarProps so the
-        // Vec<&Plugin> lives long enough for the borrow in the struct literal.
         let ds_plugins: Vec<&crate::plugin::Plugin> = PLUGIN_MANAGER
             .get()
             .and_then(|m| m.as_ref())
             .map(|m| m.get_data_source_plugins())
             .unwrap_or_default();
 
-        // Build plugin sidebar info if there's an active plugin pane with sidebar content.
-        // Capture owned strings so they outlive the borrows in SidebarProps.
-        let plugin_sidebar_strings: Option<(String, String, Option<String>)> = self
-            .window_state
-            .active_plugin_pane
+        // Snapshot per-tab data we need for SidebarProps (avoids complex lifetime issues).
+        let (current_file_path, search_state_clone, active_datasource_plugin_id) =
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                (
+                    tab.file_path.clone(),
+                    tab.search_engine_state.search.clone(),
+                    tab.active_plugin_pane
+                        .as_ref()
+                        .map(|p| p.plugin_id.clone()),
+                )
+            } else {
+                (None, crate::search::Search::default(), None)
+            };
+
+        let plugin_sidebar_strings: Option<(String, String, Option<String>)> = active_datasource_plugin_id
             .as_ref()
-            .and_then(|pane| {
+            .and_then(|plugin_id| {
                 PLUGIN_MANAGER
                     .get()
                     .and_then(|m| m.as_ref())
-                    .and_then(|m| m.registry.get_by_id(&pane.plugin_id))
+                    .and_then(|m| m.registry.get_by_id(plugin_id))
                     .map(|p| (p.id.clone(), p.name.clone(), p.icon.clone()))
             });
-        let plugin_sidebar_prop: Option<components::sidebar::PluginSidebarInfo<'_>> = match (
-            &plugin_sidebar_strings,
-            &self.window_state.plugin_sidebar_output,
-        ) {
-            (Some((id, name, icon)), Some(output)) => {
-                Some(components::sidebar::PluginSidebarInfo {
-                    plugin_id: id.as_str(),
-                    plugin_name: name.as_str(),
-                    icon: icon.as_deref(),
-                    output,
-                })
-            }
-            _ => None,
-        };
 
-        // Render sidebar
+        let plugin_sidebar_output = self
+            .window_state
+            .tab_manager
+            .active_tab_mut()
+            .and_then(|tab| tab.plugin_sidebar_output.clone());
+
+        let plugin_sidebar_prop: Option<components::sidebar::PluginSidebarInfo<'_>> =
+            match (&plugin_sidebar_strings, &plugin_sidebar_output) {
+                (Some((id, name, icon)), Some(output)) => {
+                    Some(components::sidebar::PluginSidebarInfo {
+                        plugin_id: id.as_str(),
+                        plugin_name: name.as_str(),
+                        icon: icon.as_deref(),
+                        output,
+                    })
+                }
+                _ => None,
+            };
+
+        let search_history = current_file_path
+            .as_ref()
+            .and_then(|p| p.to_str())
+            .and_then(|path_str| {
+                super::persistent_state::PersistentState::load_search_history(path_str).ok()
+            });
+
         let output = self.window_state.sidebar.render(
             ui,
             components::sidebar::SidebarProps {
                 recent_files: self.persistent_state.get_recent_files(),
                 bookmarks: self.persistent_state.get_bookmarks(),
-                current_file_path: self
-                    .window_state
-                    .file_path
-                    .as_ref()
-                    .and_then(|path| path.to_str()),
+                current_file_path: current_file_path.as_ref().and_then(|p| p.to_str()),
                 expanded: self.window_state.sidebar_expanded,
                 sidebar_width: self.persistent_state.get_sidebar_width(),
                 selected_section: self.window_state.sidebar_selected_section.clone(),
                 focus_search,
-                search_state: &self.window_state.search_engine_state.search,
-                search_history: self
-                    .window_state
-                    .file_path
-                    .as_ref()
-                    .and_then(|path| path.to_str())
-                    .and_then(|path_str| {
-                        super::persistent_state::PersistentState::load_search_history(path_str).ok()
-                    })
-                    .as_ref(),
+                search_state: &search_state_clone,
+                search_history: search_history.as_ref(),
                 data_source_plugins: &ds_plugins,
-                active_datasource_plugin_id: self
-                    .window_state
-                    .active_plugin_pane
-                    .as_ref()
-                    .map(|p| p.plugin_id.as_str()),
+                active_datasource_plugin_id: active_datasource_plugin_id.as_deref(),
                 plugin_sidebar: plugin_sidebar_prop,
             },
         );
 
-        // Update previous states after rendering so focus_search is only true for one frame
         if focus_search {
             self.window_state.previous_sidebar_section =
                 self.window_state.sidebar_selected_section.clone();
         }
         self.window_state.previous_sidebar_expanded = self.window_state.sidebar_expanded;
 
-        // Handle sidebar events
+        let nav_capacity = self.settings.performance.navigation_history_size;
+
         for event in output.events {
             match event {
                 components::sidebar::SidebarEvent::OpenFile(file_path) => {
-                    // Open the file by setting the path
                     let path = std::path::PathBuf::from(&file_path);
-                    self.window_state.file_path = Some(path);
-                    self.window_state.error = None;
+                    self.window_state.tab_manager.open_file(path, nav_capacity);
                 }
                 components::sidebar::SidebarEvent::RemoveRecentFile(file_path) => {
-                    // Remove from recent files
                     self.persistent_state.remove_recent_file(&file_path);
                     if let Err(e) = self.persistent_state.save() {
                         eprintln!("Failed to save recent files: {}", e);
                     }
                 }
                 components::sidebar::SidebarEvent::OpenFilePicker => {
-                    // Open file picker dialog
                     if let Some(path) = pick_file(self.settings.plugins.enabled) {
-                        // Add to recent files
                         if let Some(path_str) = path.to_str() {
                             self.persistent_state.add_recent_file(
                                 path_str.to_string(),
@@ -1055,29 +1054,28 @@ impl ThothApp {
                             );
                             let _ = self.persistent_state.save();
                         }
-
-                        self.window_state.file_path = Some(path);
-                        self.window_state.error = None;
+                        self.window_state.tab_manager.open_file(path, nav_capacity);
                     }
                 }
                 components::sidebar::SidebarEvent::SectionToggled(section) => {
                     if let components::sidebar::SidebarSection::DataSource { ref plugin_id } =
                         section
                     {
-                        let same_plugin_active = self
-                            .window_state
-                            .active_plugin_pane
-                            .as_ref()
-                            .is_some_and(|p| &p.plugin_id == plugin_id);
+                        let same_plugin_active =
+                            self.window_state.tab_manager.active_tab_mut().is_some_and(|tab| {
+                                tab.active_plugin_pane
+                                    .as_ref()
+                                    .is_some_and(|p| &p.plugin_id == plugin_id)
+                            });
 
                         if same_plugin_active {
-                            // Clicking the active plugin's icon again closes it.
-                            self.window_state.active_plugin_pane = None;
-                            self.window_state.plugin_sidebar_output = None;
+                            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                                tab.active_plugin_pane = None;
+                                tab.plugin_sidebar_output = None;
+                            }
                             self.window_state.sidebar_expanded = false;
                             self.window_state.sidebar_selected_section = None;
                         } else {
-                            // Open: create a loader, call render_ui(), store in active_plugin_pane.
                             if let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) {
                                 if let Some(plugin) = manager.registry.get_by_id(plugin_id) {
                                     use crate::plugin::network_policy::NetworkPolicy;
@@ -1093,38 +1091,45 @@ impl ThothApp {
                                         &user_policy,
                                     );
                                     match manager.open_data_source(plugin_id, policy) {
-                                        Ok(loader) => {
-                                            match loader.render_ui() {
-                                                Ok(ui_output) => {
-                                                    self.window_state.file_path = None;
-                                                    // Fetch initial sidebar output
-                                                    let sidebar_output =
-                                                        loader.render_sidebar().ok().flatten();
-                                                    let has_sidebar = sidebar_output.is_some();
-                                                    self.window_state.plugin_sidebar_output =
-                                                        sidebar_output;
-                                                    self.window_state.active_plugin_pane =
+                                        Ok(loader) => match loader.render_ui() {
+                                            Ok(ui_output) => {
+                                                let sidebar_output =
+                                                    loader.render_sidebar().ok().flatten();
+                                                let has_sidebar = sidebar_output.is_some();
+                                                if let Some(tab) = self
+                                                    .window_state
+                                                    .tab_manager
+                                                    .active_tab_mut()
+                                                {
+                                                    tab.file_path = None;
+                                                    tab.plugin_sidebar_output = sidebar_output;
+                                                    tab.active_plugin_pane =
                                                         Some(crate::state::ActivePluginPane {
                                                             plugin_id: plugin_id.clone(),
                                                             display_url: String::new(),
                                                             ui_output,
                                                             loader,
                                                         });
-                                                    // Open sidebar to plugin section if it has content, otherwise close it
-                                                    if has_sidebar {
-                                                        self.window_state.sidebar_expanded = true;
-                                                        self.window_state.sidebar_selected_section =
-                                                            Some(components::sidebar::SidebarSection::PluginSidebar {
-                                                                plugin_id: plugin_id.clone(),
-                                                            });
-                                                    } else {
-                                                        self.window_state.sidebar_expanded = false;
-                                                        self.window_state
-                                                            .sidebar_selected_section = None;
-                                                    }
                                                 }
-                                                Err(e) => {
-                                                    self.window_state.error =
+                                                if has_sidebar {
+                                                    self.window_state.sidebar_expanded = true;
+                                                    self.window_state.sidebar_selected_section =
+                                                        Some(components::sidebar::SidebarSection::PluginSidebar {
+                                                            plugin_id: plugin_id.clone(),
+                                                        });
+                                                } else {
+                                                    self.window_state.sidebar_expanded = false;
+                                                    self.window_state.sidebar_selected_section =
+                                                        None;
+                                                }
+                                            }
+                                            Err(e) => {
+                                                if let Some(tab) = self
+                                                    .window_state
+                                                    .tab_manager
+                                                    .active_tab_mut()
+                                                {
+                                                    tab.error =
                                                         Some(crate::error::ThothError::Unknown {
                                                             message: format!(
                                                                 "Plugin UI error: {e}"
@@ -1132,19 +1137,27 @@ impl ThothApp {
                                                         });
                                                 }
                                             }
-                                        }
+                                        },
                                         Err(e) => {
-                                            self.window_state.error =
-                                                Some(crate::error::ThothError::Unknown {
-                                                    message: format!("Failed to load plugin: {e}"),
-                                                });
+                                            if let Some(tab) = self
+                                                .window_state
+                                                .tab_manager
+                                                .active_tab_mut()
+                                            {
+                                                tab.error = Some(
+                                                    crate::error::ThothError::Unknown {
+                                                        message: format!(
+                                                            "Failed to load plugin: {e}"
+                                                        ),
+                                                    },
+                                                );
+                                            }
                                         }
                                     }
                                 }
                             }
                         }
                     } else {
-                        // Toggle logic: if clicking same section while expanded, collapse; otherwise open to that section
                         let is_plugin_sidebar = matches!(
                             section,
                             components::sidebar::SidebarSection::PluginSidebar { .. }
@@ -1160,15 +1173,17 @@ impl ThothApp {
                                 self.window_state.sidebar_selected_section.clone();
                             self.window_state.sidebar_expanded = true;
                             self.window_state.sidebar_selected_section = Some(section);
-                            // Don't close the plugin pane when switching to its own sidebar
                             if !is_plugin_sidebar {
-                                self.window_state.active_plugin_pane = None;
-                                self.window_state.plugin_sidebar_output = None;
+                                if let Some(tab) =
+                                    self.window_state.tab_manager.active_tab_mut()
+                                {
+                                    tab.active_plugin_pane = None;
+                                    tab.plugin_sidebar_output = None;
+                                }
                             }
                         }
                     }
 
-                    // Save sidebar state if remember_sidebar_state is enabled
                     if self.settings.ui.remember_sidebar_state {
                         self.persistent_state
                             .set_sidebar_expanded(self.window_state.sidebar_expanded);
@@ -1176,100 +1191,92 @@ impl ThothApp {
                     }
                 }
                 components::sidebar::SidebarEvent::WidthChanged(new_width) => {
-                    // Save the new sidebar width
                     self.persistent_state.set_sidebar_width(new_width);
                     let _ = self.persistent_state.save();
                 }
                 components::sidebar::SidebarEvent::Search(msg) => {
-                    // Save search query to history
-                    if let Some(file_path) = &self.window_state.file_path {
-                        if let Some(path_str) = file_path.to_str() {
-                            if let Some(entry) = msg.history_entry() {
-                                let _ = super::persistent_state::PersistentState::add_search_query(
-                                    path_str, entry,
-                                );
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(file_path) = &tab.file_path {
+                            if let Some(path_str) = file_path.to_str() {
+                                if let Some(entry) = msg.history_entry() {
+                                    let _ =
+                                        super::persistent_state::PersistentState::add_search_query(
+                                            path_str, entry,
+                                        );
+                                }
                             }
                         }
                     }
-                    // Handle search from sidebar
                     return Some(msg);
                 }
                 components::sidebar::SidebarEvent::NavigateToSearchResult { record_index } => {
-                    // Navigate to the selected search result in the main view
-                    self.window_state
-                        .central_panel
-                        .navigate_to_record(record_index);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.central_panel.navigate_to_record(record_index);
+                    }
                 }
                 components::sidebar::SidebarEvent::ClearSearchHistory => {
-                    // Clear search history for the current file
-                    if let Some(file_path) = &self.window_state.file_path {
-                        if let Some(path_str) = file_path.to_str() {
-                            let _ = super::persistent_state::PersistentState::clear_search_history(
-                                path_str,
-                            );
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        if let Some(file_path) = &tab.file_path {
+                            if let Some(path_str) = file_path.to_str() {
+                                let _ =
+                                    super::persistent_state::PersistentState::clear_search_history(
+                                        path_str,
+                                    );
+                            }
                         }
                     }
                 }
                 components::sidebar::SidebarEvent::NavigateToBookmark { file_path, path } => {
-                    // Check if we need to open a different file
                     let current_file = self
                         .window_state
-                        .file_path
-                        .as_ref()
-                        .and_then(|p| p.to_str());
+                        .tab_manager
+                        .active_tab_mut()
+                        .and_then(|tab| tab.file_path.as_ref().and_then(|p| p.to_str()).map(|s| s.to_string()));
 
-                    if current_file != Some(file_path.as_str()) {
-                        // Open the bookmarked file
+                    if current_file.as_deref() != Some(file_path.as_str()) {
                         let path_buf = std::path::PathBuf::from(&file_path);
-                        self.window_state.file_path = Some(path_buf);
-                        self.window_state.error = None;
-
-                        // Store pending navigation to apply after file loads
-                        self.window_state.pending_navigation = Some(path.clone());
-
-                        // Add to recent files
+                        let id = self.window_state.tab_manager.open_file(path_buf, nav_capacity);
+                        if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&id) {
+                            tab.error = None;
+                            tab.pending_navigation = Some(path.clone());
+                        }
                         self.persistent_state.add_recent_file(
                             file_path.clone(),
                             self.settings.performance.max_recent_files,
                         );
                         let _ = self.persistent_state.save();
                     } else {
-                        // Navigate immediately if same file
-                        // Track in navigation history before navigating
-                        self.window_state.navigation_history.push(path.clone());
-                        self.window_state.central_panel.navigate_to_path(path);
+                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                            tab.navigation_history.push(path.clone());
+                            tab.central_panel.navigate_to_path(path);
+                        }
                     }
                 }
                 components::sidebar::SidebarEvent::RemoveBookmark(index) => {
-                    // Remove the bookmark
                     self.persistent_state.remove_bookmark(index);
                     if let Err(e) = self.persistent_state.save() {
                         eprintln!("Failed to save bookmarks: {}", e);
                     }
                 }
                 components::sidebar::SidebarEvent::JumpToPath(path) => {
-                    // Jump to the specified path in the current file
-                    // Track in navigation history before navigating
-                    self.window_state.navigation_history.push(path.clone());
-                    self.window_state.central_panel.navigate_to_path(path);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.navigation_history.push(path.clone());
+                        tab.central_panel.navigate_to_path(path);
+                    }
                 }
-                components::sidebar::SidebarEvent::DataSourceQueryResult { .. } => {
-                    // No-op: data-source plugins now interact entirely through the main pane
-                    // via ActivePluginPane. This event is no longer used in the primary path.
-                }
+                components::sidebar::SidebarEvent::DataSourceQueryResult { .. } => {}
                 components::sidebar::SidebarEvent::DataSourceConsentNeeded(consent_request) => {
-                    // TODO: Show a consent dialog asking the user to approve/deny the domain
-                    // For now, just log it
                     eprintln!(
                         "Data source plugin {} requests consent for domain: {}",
                         consent_request.plugin_id, consent_request.domain
                     );
                 }
                 components::sidebar::SidebarEvent::DataSourceError(err) => {
-                    // Display the error in the error modal
-                    self.window_state.error = Some(crate::error::ThothError::Unknown {
-                        message: format!("Data source error: {}", err),
-                    });
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.error = Some(crate::error::ThothError::Unknown {
+                            message: format!("Data source error: {}", err),
+                        });
+                    }
                 }
                 components::sidebar::SidebarEvent::DataSourceLoading(is_loading) => {
                     if is_loading {
@@ -1289,9 +1296,14 @@ impl ThothApp {
         use crate::components::traits::StatefulComponent;
         use crate::error::RecoveryAction;
 
-        // Only render if there's an error
-        if let Some(error) = &self.window_state.error {
-            // Create a temporary UI to pass to the modal
+        let error = self
+            .window_state
+            .tab_manager
+            .active_tab_mut()
+            .and_then(|t| t.error.as_ref())
+            .cloned();
+
+        if let Some(error) = error {
             let mut output = None;
             egui::Area::new("error_modal_area".into())
                 .movable(false)
@@ -1299,54 +1311,118 @@ impl ThothApp {
                 .show(ctx, |ui| {
                     output = Some(self.window_state.error_modal.render(
                         ui,
-                        components::error_modal::ErrorModalProps { error, open: true },
+                        components::error_modal::ErrorModalProps { error: &error, open: true },
                     ));
                 });
 
             let Some(output) = output else { return };
 
-            // Handle error modal events and recovery actions
             for event in output.events {
                 match event {
                     components::error_modal::ErrorModalEvent::Close => {
-                        self.window_state.error = None;
+                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                            tab.error = None;
+                        }
                     }
                     components::error_modal::ErrorModalEvent::Retry => {
-                        // Clear error and retry the operation
-                        // For file operations, trigger a reload by clearing and restoring the path
-                        if let Some(path) = self.window_state.file_path.take() {
-                            self.window_state.error = None;
-                            // Setting the path again triggers the reload logic in central_panel
-                            self.window_state.file_path = Some(path);
-                        } else {
-                            self.window_state.error = None;
+                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                            let path = tab.file_path.take();
+                            tab.error = None;
+                            tab.file_path = path;
                         }
                     }
                     components::error_modal::ErrorModalEvent::Reset => {
-                        // Reset to initial state
-                        self.window_state.error = None;
-                        self.window_state.file_path = None;
-                        self.window_state.total_items = 0;
-                        self.window_state.search_engine_state.search =
-                            crate::search::Search::default();
+                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                            tab.error = None;
+                            tab.file_path = None;
+                            tab.total_items = 0;
+                            tab.search_engine_state.search = crate::search::Search::default();
+                        }
                     }
                 }
             }
 
-            // Handle automatic recovery actions
             if let Some(recovery_action) = output.recovery_action {
                 match recovery_action {
                     RecoveryAction::ClearError => {
-                        self.window_state.error = None;
+                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                            tab.error = None;
+                        }
                     }
                     RecoveryAction::Reset => {
-                        self.window_state.error = None;
-                        self.window_state.file_path = None;
-                        self.window_state.total_items = 0;
+                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                            tab.error = None;
+                            tab.file_path = None;
+                            tab.total_items = 0;
+                        }
                     }
                     _ => {}
                 }
             }
         }
     }
+}
+
+/// Build a Catppuccin-themed `egui_dock::Style` from the current theme colors.
+/// Falls back to the egui-derived defaults when colors are unavailable.
+fn build_dock_style(
+    egui_style: &egui::Style,
+    colors: Option<crate::theme::ThemeColors>,
+) -> egui_dock::Style {
+    let mut style = egui_dock::Style::from_egui(egui_style);
+
+    let Some(c) = colors else {
+        return style;
+    };
+
+    let zero_rounding = egui_dock::egui::CornerRadius::ZERO;
+
+    // ── Tab bar ──────────────────────────────────────────────────────────────
+    style.tab_bar.bg_fill = c.bg_sunken;
+    style.tab_bar.height = 35.0;
+    style.tab_bar.hline_color = c.surface;
+
+    // ── Tab body (content area) ───────────────────────────────────────────────
+    style.tab.tab_body.bg_fill = c.bg;
+    style.tab.tab_body.inner_margin = egui::Margin::ZERO;
+    style.tab.tab_body.stroke = egui::Stroke::NONE;
+
+    // ── Active tab ───────────────────────────────────────────────────────────
+    style.tab.active.bg_fill = c.bg;
+    style.tab.active.text_color = c.fg;
+    style.tab.active.outline_color = c.accent; // overridden per-tab by tab_style_override
+    style.tab.active.corner_radius = zero_rounding;
+
+    // ── Focused tab (same as active but in the focused leaf) ─────────────────
+    style.tab.focused.bg_fill = c.bg;
+    style.tab.focused.text_color = c.fg;
+    style.tab.focused.outline_color = c.accent;
+    style.tab.focused.corner_radius = zero_rounding;
+
+    // ── Inactive tab ─────────────────────────────────────────────────────────
+    style.tab.inactive.bg_fill = c.bg_sunken;
+    style.tab.inactive.text_color = c.fg_muted;
+    style.tab.inactive.outline_color = egui::Color32::TRANSPARENT;
+    style.tab.inactive.corner_radius = zero_rounding;
+
+    // ── Hovered tab ──────────────────────────────────────────────────────────
+    style.tab.hovered.bg_fill = c.surface;
+    style.tab.hovered.text_color = c.fg;
+    style.tab.hovered.outline_color = egui::Color32::TRANSPARENT;
+    style.tab.hovered.corner_radius = zero_rounding;
+
+    // ── KB-focus variants (match their non-kb counterparts) ──────────────────
+    style.tab.inactive_with_kb_focus = style.tab.inactive.clone();
+    style.tab.active_with_kb_focus = style.tab.active.clone();
+    style.tab.focused_with_kb_focus = style.tab.focused.clone();
+
+    style.tab.hline_below_active_tab_name = false;
+
+    // ── Separator between split panes ─────────────────────────────────────────
+    style.separator.width = 4.0;
+    style.separator.color_idle = c.surface;
+    style.separator.color_hovered = c.accent;
+    style.separator.color_dragged = c.accent;
+
+    style
 }

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -22,6 +22,7 @@ pub struct ThothApp {
     clipboard_text: Option<String>,
     settings_changed: bool,
     session_dirty: bool,
+    show_update_consent: bool,
     /// Plugin IDs from the persisted session that couldn't be restored yet because
     /// PLUGIN_MANAGER was still initializing on the background thread. Drained each
     /// frame once the manager becomes available.
@@ -79,6 +80,7 @@ impl ThothApp {
             clipboard_text: None,
             settings_changed: false,
             session_dirty: false,
+            show_update_consent: false,
             pending_plugin_restores,
             session_restore_active_index,
         }
@@ -169,7 +171,14 @@ impl App for ThothApp {
         let should_show_updates =
             UpdateHandler::handle_update_messages(&mut self.update_state, ctx);
 
-        if should_show_updates && !self.settings_dialog.open {
+        if should_show_updates {
+            self.show_update_consent = true;
+            UpdateHandler::post_update_notification(&self.update_state);
+        }
+
+        if crate::OPEN_UPDATES_REQUESTED.swap(false, std::sync::atomic::Ordering::Relaxed)
+            && !self.settings_dialog.open
+        {
             self.settings_dialog.open_updates(&self.settings);
         }
 
@@ -328,6 +337,7 @@ impl App for ThothApp {
         }
 
         self.render_error_modal(&ctx);
+        self.render_update_consent_modal(ui);
 
         if let Some(new_settings) = settings::Settings::take_if_dirty(&ctx) {
             self.apply_new_settings(new_settings);
@@ -922,21 +932,21 @@ impl ThothApp {
             .into_iter()
             .filter_map(|id| {
                 let tab = self.window_state.tab_manager.tabs.get(&id)?;
-                let entry = if let Some(ref path) = tab.file_path {
-                    Some(PersistedTab {
+                let entry = tab
+                    .file_path
+                    .as_ref()
+                    .map(|path| PersistedTab {
                         kind: PersistedTabKind::File {
                             path: path.to_string_lossy().into_owned(),
                         },
                     })
-                } else if let Some(ref pane) = tab.active_plugin_pane {
-                    Some(PersistedTab {
-                        kind: PersistedTabKind::Plugin {
-                            plugin_id: pane.plugin_id.clone(),
-                        },
-                    })
-                } else {
-                    None // Empty / welcome tabs are not persisted.
-                };
+                    .or_else(|| {
+                        tab.active_plugin_pane.as_ref().map(|pane| PersistedTab {
+                            kind: PersistedTabKind::Plugin {
+                                plugin_id: pane.plugin_id.clone(),
+                            },
+                        })
+                    });
                 if entry.is_some() {
                     if Some(id) == active_id {
                         active_tab_index = persisted_index;
@@ -1578,6 +1588,21 @@ impl ThothApp {
                     _ => {}
                 }
             }
+        }
+    }
+
+    fn render_update_consent_modal(&mut self, ui: &mut egui::Ui) {
+        use super::update_handler::ConsentAction;
+        match UpdateHandler::render_consent_modal(ui, &self.update_state, self.show_update_consent)
+        {
+            Some(ConsentAction::RemindLater) => self.show_update_consent = false,
+            Some(ConsentAction::UpdateNow) => {
+                self.show_update_consent = false;
+                if !self.settings_dialog.open {
+                    self.settings_dialog.open_updates(&self.settings);
+                }
+            }
+            None => {}
         }
     }
 }

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -778,10 +778,13 @@ impl ThothApp {
                         tab.error = None;
                     }
                 }
-                components::toolbar::ToolbarEvent::FileClear => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        tab.file_path = None;
-                        tab.error = None;
+                components::toolbar::ToolbarEvent::CloseTab => {
+                    let was_empty = self.window_state.tab_manager.close_active_tab();
+                    let now_empty = self.window_state.tab_manager.tabs.is_empty();
+                    if was_empty && now_empty {
+                        ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                    } else {
+                        self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                     }
                     self.session_dirty = true;
                 }
@@ -840,9 +843,12 @@ impl ThothApp {
                 }
                 MenuAction::NewWindow => self.create_new_window(),
                 MenuAction::CloseTab => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        tab.file_path = None;
-                        tab.error = None;
+                    let was_empty = self.window_state.tab_manager.close_active_tab();
+                    let now_empty = self.window_state.tab_manager.tabs.is_empty();
+                    if was_empty && now_empty {
+                        ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                    } else {
+                        self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                     }
                     self.session_dirty = true;
                 }
@@ -987,7 +993,6 @@ impl ThothApp {
         if !self.session_dirty {
             return;
         }
-        self.session_dirty = false;
 
         use crate::app::persistent_state::{PersistedTab, PersistedTabKind};
 
@@ -1029,6 +1034,8 @@ impl ThothApp {
         self.persistent_state.set_open_tabs(tabs, active_tab_index);
         if let Err(e) = self.persistent_state.save() {
             eprintln!("Failed to save tab session: {e}");
+        } else {
+            self.session_dirty = false;
         }
     }
 

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -833,7 +833,9 @@ impl ThothApp {
             .ctx()
             .memory(|m| m.data.get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors")));
 
-        let dock_style = build_dock_style(ui.style(), colors);
+        let dock_style = colors
+            .map(|c| c.dock_style(ui.style()))
+            .unwrap_or_else(|| egui_dock::Style::from_egui(ui.style()));
 
         let (dock_state, tabs) = self.window_state.tab_manager.borrow_parts();
 
@@ -1341,68 +1343,4 @@ impl ThothApp {
             }
         }
     }
-}
-
-/// Build a Catppuccin-themed `egui_dock::Style` from the current theme colors.
-/// Falls back to the egui-derived defaults when colors are unavailable.
-fn build_dock_style(
-    egui_style: &egui::Style,
-    colors: Option<crate::theme::ThemeColors>,
-) -> egui_dock::Style {
-    let mut style = egui_dock::Style::from_egui(egui_style);
-
-    let Some(c) = colors else {
-        return style;
-    };
-
-    let zero_rounding = egui_dock::egui::CornerRadius::ZERO;
-
-    // ── Tab bar ──────────────────────────────────────────────────────────────
-    style.tab_bar.bg_fill = c.bg_sunken;
-    style.tab_bar.height = 35.0;
-    style.tab_bar.hline_color = c.surface;
-
-    // ── Tab body (content area) ───────────────────────────────────────────────
-    style.tab.tab_body.bg_fill = c.bg;
-    style.tab.tab_body.inner_margin = egui::Margin::ZERO;
-    style.tab.tab_body.stroke = egui::Stroke::NONE;
-
-    // ── Active tab ───────────────────────────────────────────────────────────
-    style.tab.active.bg_fill = c.bg;
-    style.tab.active.text_color = c.fg;
-    style.tab.active.outline_color = c.accent; // overridden per-tab by tab_style_override
-    style.tab.active.corner_radius = zero_rounding;
-
-    // ── Focused tab (same as active but in the focused leaf) ─────────────────
-    style.tab.focused.bg_fill = c.bg;
-    style.tab.focused.text_color = c.fg;
-    style.tab.focused.outline_color = c.accent;
-    style.tab.focused.corner_radius = zero_rounding;
-
-    // ── Inactive tab ─────────────────────────────────────────────────────────
-    style.tab.inactive.bg_fill = c.bg_sunken;
-    style.tab.inactive.text_color = c.fg_muted;
-    style.tab.inactive.outline_color = egui::Color32::TRANSPARENT;
-    style.tab.inactive.corner_radius = zero_rounding;
-
-    // ── Hovered tab ──────────────────────────────────────────────────────────
-    style.tab.hovered.bg_fill = c.surface;
-    style.tab.hovered.text_color = c.fg;
-    style.tab.hovered.outline_color = egui::Color32::TRANSPARENT;
-    style.tab.hovered.corner_radius = zero_rounding;
-
-    // ── KB-focus variants (match their non-kb counterparts) ──────────────────
-    style.tab.inactive_with_kb_focus = style.tab.inactive.clone();
-    style.tab.active_with_kb_focus = style.tab.active.clone();
-    style.tab.focused_with_kb_focus = style.tab.focused.clone();
-
-    style.tab.hline_below_active_tab_name = false;
-
-    // ── Separator between split panes ─────────────────────────────────────────
-    style.separator.width = 4.0;
-    style.separator.color_idle = c.surface;
-    style.separator.color_hovered = c.accent;
-    style.separator.color_dragged = c.accent;
-
-    style
 }

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -357,18 +357,6 @@ impl ThothApp {
                         self.window_state.tab_manager.open_file(path, nav_capacity);
                     }
                 }
-                ShortcutAction::ClearFile => {
-                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                        if tab.file_path.is_some() {
-                            tab.file_path = None;
-                            tab.error = None;
-                        } else {
-                            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
-                        }
-                    } else {
-                        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
-                    }
-                }
                 ShortcutAction::NewWindow => {
                     self.create_new_window();
                 }
@@ -503,18 +491,26 @@ impl ThothApp {
                         }
                 }
                 ShortcutAction::CloseTab => {
-                    if let Some(id) = self.window_state.tab_manager.active_tab_id() {
-                        self.window_state.tab_manager.tabs.remove(&id);
-                        self.window_state
-                            .tab_manager
-                            .ensure_non_empty(nav_capacity);
+                    let was_empty = self.window_state.tab_manager.close_active_tab();
+                    let now_empty = self.window_state.tab_manager.tabs.is_empty();
+                    if was_empty && now_empty {
+                        // Last tab was already the welcome screen — close the window.
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                    } else {
+                        self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                     }
+                }
+                ShortcutAction::NewTab => {
+                    self.window_state.tab_manager.open_new_tab(nav_capacity);
                 }
                 ShortcutAction::NextTab => {
                     self.window_state.tab_manager.cycle_tab(1);
                 }
                 ShortcutAction::PrevTab => {
                     self.window_state.tab_manager.cycle_tab(-1);
+                }
+                ShortcutAction::SwitchToTab(idx) => {
+                    self.window_state.tab_manager.switch_to_tab_by_index(idx);
                 }
             }
         }
@@ -570,8 +566,11 @@ impl ThothApp {
                 let _ = self.persistent_state.save();
             }
 
-            self.window_state.file_path = Some(path);
-            self.window_state.error = None;
+            let nav_capacity = self.settings.performance.navigation_history_size;
+            self.window_state.tab_manager.open_file(path, nav_capacity);
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                tab.error = None;
+            }
         }
     }
 
@@ -849,12 +848,24 @@ impl ThothApp {
             colors,
         };
 
-        egui_dock::DockArea::new(dock_state)
-            .style(dock_style)
-            .show_inside(ui, &mut viewer);
+        // Use a smaller font for tab labels (egui_dock hardcodes TextStyle::Button).
+        // Scoped so nothing outside the DockArea is affected.
+        let events = ui
+            .scope(|ui| {
+                ui.style_mut().text_styles.insert(
+                    egui::TextStyle::Button,
+                    egui::FontId::new(12.0, egui::FontFamily::Proportional),
+                );
+                egui_dock::DockArea::new(dock_state)
+                    .style(dock_style)
+                    .show_leaf_collapse_buttons(false)
+                    .show_inside(ui, &mut viewer);
+                viewer.events.drain(..).collect::<Vec<_>>()
+            })
+            .inner;
 
         // Drain and process events emitted during rendering.
-        let events: Vec<TabEvent> = viewer.events.drain(..).collect();
+        let events: Vec<TabEvent> = events;
         for event in events {
             self.handle_tab_event(event, nav_capacity);
         }
@@ -918,6 +929,17 @@ impl ThothApp {
             TabEvent::TabClosed(id) => {
                 self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                 let _ = id;
+            }
+            TabEvent::OpenFilePicker => {
+                let nav_cap = self.settings.performance.navigation_history_size;
+                if let Some(path) = pick_file(self.settings.plugins.enabled) {
+                    self.window_state.tab_manager.open_file(path, nav_cap);
+                }
+            }
+            TabEvent::OpenRecentFile(path) => {
+                self.window_state
+                    .tab_manager
+                    .open_file(path, nav_capacity);
             }
         }
     }

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -35,11 +35,7 @@ pub struct ThothApp {
 }
 
 impl ThothApp {
-    pub fn new(
-        settings: settings::Settings,
-        file_to_open: Option<PathBuf>,
-        cc: &eframe::CreationContext<'_>,
-    ) -> Self {
+    pub fn new(settings: settings::Settings, file_to_open: Option<PathBuf>) -> Self {
         let persistent_state = PersistentState::default();
 
         let mut window_state = state::WindowState::default();
@@ -51,41 +47,34 @@ impl ThothApp {
         let nav_capacity = settings.performance.navigation_history_size;
         window_state.tab_manager = crate::app::TabManager::new(nav_capacity);
 
-        let (pending_plugin_restores, session_restore_active_index) = if let Some(path) = file_to_open {
-            // A file was passed via CLI / OS file association — open it directly,
-            // skipping session restore so the user sees exactly what they asked for.
-            window_state.tab_manager.open_file(path, nav_capacity);
-            (Vec::new(), None)
-        } else {
-            // Restore the previous session (file tabs whose paths still exist, plugin tabs
-            // that can be re-instantiated). Plugin tabs that can't be opened yet (because
-            // PLUGIN_MANAGER is still initializing on a background thread) are returned
-            // here and retried via poll_pending_plugin_restores() each frame.
-            let (deferred, active_index) = Self::restore_tab_session(
-                &mut window_state.tab_manager,
-                &persistent_state,
-                &settings,
-            );
-            // Switch to the previously-active tab immediately if there are no deferred
-            // plugins; otherwise defer until poll_pending_plugin_restores() finishes.
-            let restore_index = if deferred.is_empty() {
-                window_state.tab_manager.switch_to_tab_by_index(active_index);
-                None
+        let (pending_plugin_restores, session_restore_active_index) =
+            if let Some(path) = file_to_open {
+                // A file was passed via CLI / OS file association — open it directly,
+                // skipping session restore so the user sees exactly what they asked for.
+                window_state.tab_manager.open_file(path, nav_capacity);
+                (Vec::new(), None)
             } else {
-                Some(active_index)
+                // Restore the previous session (file tabs whose paths still exist, plugin tabs
+                // that can be re-instantiated). Plugin tabs that can't be opened yet (because
+                // PLUGIN_MANAGER is still initializing on a background thread) are returned
+                // here and retried via poll_pending_plugin_restores() each frame.
+                let (deferred, active_index) = Self::restore_tab_session(
+                    &mut window_state.tab_manager,
+                    &persistent_state,
+                    &settings,
+                );
+                // Switch to the previously-active tab immediately if there are no deferred
+                // plugins; otherwise defer until poll_pending_plugin_restores() finishes.
+                let restore_index = if deferred.is_empty() {
+                    window_state
+                        .tab_manager
+                        .switch_to_tab_by_index(active_index);
+                    None
+                } else {
+                    Some(active_index)
+                };
+                (deferred, restore_index)
             };
-            (deferred, restore_index)
-        };
-
-        // Set up native menu bar (macOS/Windows); Linux uses egui menu in toolbar.
-        use raw_window_handle::HasWindowHandle as _;
-        let native_menu = cc
-            .window_handle()
-            .ok()
-            .map(|h| h.as_raw())
-            .and_then(|raw| {
-                crate::platform::native_menu::setup(raw, &settings.shortcuts)
-            });
 
         Self {
             settings,
@@ -97,10 +86,19 @@ impl ThothApp {
             settings_changed: false,
             session_dirty: false,
             show_update_consent: false,
-            _native_menu: native_menu,
+            _native_menu: None,
             pending_plugin_restores,
             session_restore_active_index,
         }
+    }
+
+    pub fn setup_native_menu(&mut self, cc: &eframe::CreationContext<'_>) {
+        use raw_window_handle::HasWindowHandle as _;
+        self._native_menu = cc
+            .window_handle()
+            .ok()
+            .map(|h| h.as_raw())
+            .and_then(|raw| crate::platform::native_menu::setup(raw, &self.settings.shortcuts));
     }
 
     pub fn create_new_window(&mut self) {
@@ -130,21 +128,22 @@ impl ThothApp {
         }
 
         if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-            && let Some(pane) = tab.active_plugin_pane.as_mut() {
-                let updated = self
-                    .settings
-                    .plugins
-                    .plugin_settings
-                    .get(&pane.plugin_id)
-                    .cloned()
-                    .unwrap_or_default();
-                if let Err(e) = pane.loader.on_setting_change(&updated) {
-                    eprintln!(
-                        "Failed to notify plugin '{}' of setting change: {e}",
-                        pane.plugin_id
-                    );
-                }
+            && let Some(pane) = tab.active_plugin_pane.as_mut()
+        {
+            let updated = self
+                .settings
+                .plugins
+                .plugin_settings
+                .get(&pane.plugin_id)
+                .cloned()
+                .unwrap_or_default();
+            if let Err(e) = pane.loader.on_setting_change(&updated) {
+                eprintln!(
+                    "Failed to notify plugin '{}' of setting change: {e}",
+                    pane.plugin_id
+                );
             }
+        }
 
         let plugins_changed = self.settings.plugins.enabled != prev_plugins_enabled
             || self.settings.plugins.disabled_plugin_ids != prev_disabled_plugin_ids;
@@ -200,9 +199,10 @@ impl App for ThothApp {
         }
 
         if let Some(nm) = NOTIFICATION_MANAGER.get()
-            && let Ok(mut nm) = nm.lock() {
-                nm.show_notifications(ctx);
-            }
+            && let Ok(mut nm) = nm.lock()
+        {
+            nm.show_notifications(ctx);
+        }
 
         // Restore plugin tabs that were deferred at startup (PLUGIN_MANAGER not ready yet).
         self.poll_pending_plugin_restores();
@@ -240,24 +240,24 @@ impl App for ThothApp {
         let sidebar_msg = self.render_sidebar(ui);
 
         // Handle search messages from sidebar against the active tab.
-        let (msg_to_central, search_error) = if let Some(tab) =
-            self.window_state.tab_manager.active_tab_mut()
-        {
-            SearchHandler::handle_search_messages(
-                sidebar_msg,
-                &mut tab.search_engine_state,
-                &tab.file_path,
-                &tab.file_type,
-                &ctx,
-            )
-        } else {
-            (None, None)
-        };
+        let (msg_to_central, search_error) =
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                SearchHandler::handle_search_messages(
+                    sidebar_msg,
+                    &mut tab.search_engine_state,
+                    &tab.file_path,
+                    &tab.file_type,
+                    &ctx,
+                )
+            } else {
+                (None, None)
+            };
 
         if let Some(error) = search_error
-            && let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                tab.error = Some(error);
-            }
+            && let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+        {
+            tab.error = Some(error);
+        }
 
         let shortcut_actions =
             ShortcutHandler::handle_shortcuts(ui.ctx(), &self.settings.shortcuts);
@@ -454,15 +454,17 @@ impl ThothApp {
                 ShortcutAction::PrevMatch => {}
                 ShortcutAction::NavBack => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                        && let Some(path) = tab.navigation_history.back() {
-                            tab.central_panel.navigate_to_path(path);
-                        }
+                        && let Some(path) = tab.navigation_history.back()
+                    {
+                        tab.central_panel.navigate_to_path(path);
+                    }
                 }
                 ShortcutAction::NavForward => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                        && let Some(path) = tab.navigation_history.forward() {
-                            tab.central_panel.navigate_to_path(path);
-                        }
+                        && let Some(path) = tab.navigation_history.forward()
+                    {
+                        tab.central_panel.navigate_to_path(path);
+                    }
                 }
                 ShortcutAction::Escape => {
                     if self.window_state.sidebar_expanded {
@@ -475,11 +477,15 @@ impl ThothApp {
                     }
                 }
                 ShortcutAction::ToggleBookmark => {
-                    let info = self.window_state.tab_manager.active_tab_mut().and_then(|tab| {
-                        let path = tab.central_panel.get_selected_path()?.clone();
-                        let file_path = tab.file_path.as_ref()?.to_str()?.to_string();
-                        Some((path, file_path))
-                    });
+                    let info = self
+                        .window_state
+                        .tab_manager
+                        .active_tab_mut()
+                        .and_then(|tab| {
+                            let path = tab.central_panel.get_selected_path()?.clone();
+                            let file_path = tab.file_path.as_ref()?.to_str()?.to_string();
+                            Some((path, file_path))
+                        });
                     if let Some((selected_path, file_path_str)) = info {
                         self.persistent_state
                             .toggle_bookmark(selected_path, file_path_str);
@@ -530,27 +536,31 @@ impl ThothApp {
                 }
                 ShortcutAction::CopyKey => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                        && let Some(text) = tab.central_panel.copy_selected_key() {
-                            self.clipboard_text = Some(text);
-                        }
+                        && let Some(text) = tab.central_panel.copy_selected_key()
+                    {
+                        self.clipboard_text = Some(text);
+                    }
                 }
                 ShortcutAction::CopyValue => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                        && let Some(text) = tab.central_panel.copy_selected_value() {
-                            self.clipboard_text = Some(text);
-                        }
+                        && let Some(text) = tab.central_panel.copy_selected_value()
+                    {
+                        self.clipboard_text = Some(text);
+                    }
                 }
                 ShortcutAction::CopyObject => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                        && let Some(text) = tab.central_panel.copy_selected_object() {
-                            self.clipboard_text = Some(text);
-                        }
+                        && let Some(text) = tab.central_panel.copy_selected_object()
+                    {
+                        self.clipboard_text = Some(text);
+                    }
                 }
                 ShortcutAction::CopyPath => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                        && let Some(text) = tab.central_panel.copy_selected_path() {
-                            self.clipboard_text = Some(text);
-                        }
+                        && let Some(text) = tab.central_panel.copy_selected_path()
+                    {
+                        self.clipboard_text = Some(text);
+                    }
                 }
                 ShortcutAction::CloseTab => {
                     let was_empty = self.window_state.tab_manager.close_active_tab();
@@ -595,21 +605,22 @@ impl ThothApp {
 
     fn dispatch_plugin_event(&mut self, event: crate::plugin::render_node::UiEvent) {
         if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-            && let Some(pane) = tab.active_plugin_pane.as_mut() {
-                match pane.loader.handle_event(event) {
-                    Ok(new_output) => {
-                        pane.ui_output = new_output;
-                        if let Ok(sidebar) = pane.loader.render_sidebar() {
-                            tab.plugin_sidebar_output = sidebar;
-                        }
-                    }
-                    Err(e) => {
-                        tab.error = Some(crate::error::ThothError::Unknown {
-                            message: e.to_string(),
-                        });
+            && let Some(pane) = tab.active_plugin_pane.as_mut()
+        {
+            match pane.loader.handle_event(event) {
+                Ok(new_output) => {
+                    pane.ui_output = new_output;
+                    if let Ok(sidebar) = pane.loader.render_sidebar() {
+                        tab.plugin_sidebar_output = sidebar;
                     }
                 }
+                Err(e) => {
+                    tab.error = Some(crate::error::ThothError::Unknown {
+                        message: e.to_string(),
+                    });
+                }
             }
+        }
     }
 
     /// Drain OS-dispatched file open requests (e.g. macOS Apple Events) and
@@ -698,9 +709,10 @@ impl ThothApp {
 
         for (request_id, req) in retry_requests {
             if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                && let Some(pane) = tab.active_plugin_pane.as_mut() {
-                    pane.loader.dispatch_approved_request(request_id, req);
-                }
+                && let Some(pane) = tab.active_plugin_pane.as_mut()
+            {
+                pane.loader.dispatch_approved_request(request_id, req);
+            }
             self.dispatch_plugin_event(UiEvent {
                 widget_id: "consent-approved".to_string(),
                 kind: "notify".to_string(),
@@ -785,15 +797,17 @@ impl ThothApp {
                 }
                 components::toolbar::ToolbarEvent::NavigateBack => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                        && let Some(path) = tab.navigation_history.back() {
-                            tab.central_panel.navigate_to_path(path);
-                        }
+                        && let Some(path) = tab.navigation_history.back()
+                    {
+                        tab.central_panel.navigate_to_path(path);
+                    }
                 }
                 components::toolbar::ToolbarEvent::NavigateForward => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                        && let Some(path) = tab.navigation_history.forward() {
-                            tab.central_panel.navigate_to_path(path);
-                        }
+                        && let Some(path) = tab.navigation_history.forward()
+                    {
+                        tab.central_panel.navigate_to_path(path);
+                    }
                 }
             }
         }
@@ -817,10 +831,7 @@ impl ThothApp {
                             );
                             let _ = self.persistent_state.save();
                         }
-                        let id = self
-                            .window_state
-                            .tab_manager
-                            .open_file(path, nav_capacity);
+                        let id = self.window_state.tab_manager.open_file(path, nav_capacity);
                         if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&id) {
                             tab.file_type = file_type;
                             tab.error = None;
@@ -1025,40 +1036,48 @@ impl ThothApp {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
-        let (file_path_opt, file_type, total_items, error_present, search_scanning, _search_results_len, filtered_count, selected_path) =
-            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                let search = &tab.search_engine_state.search;
-                let scanning = search.scanning;
-                let results_len = search.results.len();
-                let query_non_empty = !search.query.is_empty();
-                let filtered = if query_non_empty && results_len > 0 {
-                    Some(results_len)
-                } else {
-                    None
-                };
-                let sel_path = tab.central_panel.get_selected_path().cloned();
-                (
-                    tab.file_path.clone(),
-                    tab.file_type,
-                    tab.total_items,
-                    tab.error.is_some(),
-                    scanning,
-                    results_len,
-                    filtered,
-                    sel_path,
-                )
+        let (
+            file_path_opt,
+            file_type,
+            total_items,
+            error_present,
+            search_scanning,
+            _search_results_len,
+            filtered_count,
+            selected_path,
+        ) = if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+            let search = &tab.search_engine_state.search;
+            let scanning = search.scanning;
+            let results_len = search.results.len();
+            let query_non_empty = !search.query.is_empty();
+            let filtered = if query_non_empty && results_len > 0 {
+                Some(results_len)
             } else {
-                (
-                    None,
-                    crate::file::lazy_loader::FileKind::default(),
-                    0,
-                    false,
-                    false,
-                    0,
-                    None,
-                    None,
-                )
+                None
             };
+            let sel_path = tab.central_panel.get_selected_path().cloned();
+            (
+                tab.file_path.clone(),
+                tab.file_type,
+                tab.total_items,
+                tab.error.is_some(),
+                scanning,
+                results_len,
+                filtered,
+                sel_path,
+            )
+        } else {
+            (
+                None,
+                crate::file::lazy_loader::FileKind::default(),
+                0,
+                false,
+                false,
+                0,
+                None,
+                None,
+            )
+        };
 
         let status = if search_scanning {
             components::status_bar::StatusBarStatus::Searching
@@ -1106,9 +1125,10 @@ impl ThothApp {
         let nav_capacity = self.settings.performance.navigation_history_size;
         let focused_id = self.window_state.tab_manager.active_tab_id();
 
-        let colors = ui
-            .ctx()
-            .memory(|m| m.data.get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors")));
+        let colors = ui.ctx().memory(|m| {
+            m.data
+                .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
+        });
 
         let dock_style = colors
             .map(|c| c.dock_style(ui.style()))
@@ -1218,9 +1238,7 @@ impl ThothApp {
                 }
             }
             TabEvent::OpenRecentFile(path) => {
-                self.window_state
-                    .tab_manager
-                    .open_file(path, nav_capacity);
+                self.window_state.tab_manager.open_file(path, nav_capacity);
             }
         }
     }
@@ -1255,17 +1273,14 @@ impl ThothApp {
                 (
                     tab.file_path.clone(),
                     tab.search_engine_state.search.clone(),
-                    tab.active_plugin_pane
-                        .as_ref()
-                        .map(|p| p.plugin_id.clone()),
+                    tab.active_plugin_pane.as_ref().map(|p| p.plugin_id.clone()),
                 )
             } else {
                 (None, crate::search::Search::default(), None)
             };
 
-        let plugin_sidebar_strings: Option<(String, String, Option<String>)> = active_datasource_plugin_id
-            .as_ref()
-            .and_then(|plugin_id| {
+        let plugin_sidebar_strings: Option<(String, String, Option<String>)> =
+            active_datasource_plugin_id.as_ref().and_then(|plugin_id| {
                 PLUGIN_MANAGER
                     .get()
                     .and_then(|m| m.as_ref())
@@ -1353,8 +1368,11 @@ impl ThothApp {
                     if let components::sidebar::SidebarSection::DataSource { ref plugin_id } =
                         section
                     {
-                        let same_plugin_active =
-                            self.window_state.tab_manager.active_tab_mut().is_some_and(|tab| {
+                        let same_plugin_active = self
+                            .window_state
+                            .tab_manager
+                            .active_tab_mut()
+                            .is_some_and(|tab| {
                                 tab.active_plugin_pane
                                     .as_ref()
                                     .is_some_and(|p| &p.plugin_id == plugin_id)
@@ -1370,85 +1388,73 @@ impl ThothApp {
                             self.session_dirty = true;
                         } else {
                             if let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref())
-                                && let Some(plugin) = manager.registry.get_by_id(plugin_id) {
-                                    use crate::plugin::network_policy::NetworkPolicy;
-                                    let user_policy = self
-                                        .settings
-                                        .plugins
-                                        .network_policies
-                                        .get(plugin_id)
-                                        .cloned()
-                                        .unwrap_or_default();
-                                    let policy = NetworkPolicy::from_plugin_and_settings(
-                                        &plugin.network.clone().unwrap_or_default(),
-                                        &user_policy,
-                                    );
-                                    match manager.open_data_source(plugin_id, policy) {
-                                        Ok(loader) => match loader.render_ui() {
-                                            Ok(ui_output) => {
-                                                let sidebar_output =
-                                                    loader.render_sidebar().ok().flatten();
-                                                let has_sidebar = sidebar_output.is_some();
-                                                if let Some(tab) = self
-                                                    .window_state
-                                                    .tab_manager
-                                                    .active_tab_mut()
-                                                {
-                                                    tab.file_path = None;
-                                                    tab.plugin_sidebar_output = sidebar_output;
-                                                    tab.active_plugin_pane =
-                                                        Some(crate::state::ActivePluginPane {
-                                                            plugin_id: plugin_id.clone(),
-                                                            display_url: String::new(),
-                                                            ui_output,
-                                                            loader,
-                                                        });
-                                                    self.session_dirty = true;
-                                                }
-                                                if has_sidebar {
-                                                    self.window_state.sidebar_expanded = true;
-                                                    self.window_state.sidebar_selected_section =
+                                && let Some(plugin) = manager.registry.get_by_id(plugin_id)
+                            {
+                                use crate::plugin::network_policy::NetworkPolicy;
+                                let user_policy = self
+                                    .settings
+                                    .plugins
+                                    .network_policies
+                                    .get(plugin_id)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                let policy = NetworkPolicy::from_plugin_and_settings(
+                                    &plugin.network.clone().unwrap_or_default(),
+                                    &user_policy,
+                                );
+                                match manager.open_data_source(plugin_id, policy) {
+                                    Ok(loader) => match loader.render_ui() {
+                                        Ok(ui_output) => {
+                                            let sidebar_output =
+                                                loader.render_sidebar().ok().flatten();
+                                            let has_sidebar = sidebar_output.is_some();
+                                            if let Some(tab) =
+                                                self.window_state.tab_manager.active_tab_mut()
+                                            {
+                                                tab.file_path = None;
+                                                tab.plugin_sidebar_output = sidebar_output;
+                                                tab.active_plugin_pane =
+                                                    Some(crate::state::ActivePluginPane {
+                                                        plugin_id: plugin_id.clone(),
+                                                        display_url: String::new(),
+                                                        ui_output,
+                                                        loader,
+                                                    });
+                                                self.session_dirty = true;
+                                            }
+                                            if has_sidebar {
+                                                self.window_state.sidebar_expanded = true;
+                                                self.window_state.sidebar_selected_section =
                                                         Some(components::sidebar::SidebarSection::PluginSidebar {
                                                             plugin_id: plugin_id.clone(),
                                                         });
-                                                } else {
-                                                    self.window_state.sidebar_expanded = false;
-                                                    self.window_state.sidebar_selected_section =
-                                                        None;
-                                                }
+                                            } else {
+                                                self.window_state.sidebar_expanded = false;
+                                                self.window_state.sidebar_selected_section = None;
                                             }
-                                            Err(e) => {
-                                                if let Some(tab) = self
-                                                    .window_state
-                                                    .tab_manager
-                                                    .active_tab_mut()
-                                                {
-                                                    tab.error =
-                                                        Some(crate::error::ThothError::Unknown {
-                                                            message: format!(
-                                                                "Plugin UI error: {e}"
-                                                            ),
-                                                        });
-                                                }
-                                            }
-                                        },
+                                        }
                                         Err(e) => {
-                                            if let Some(tab) = self
-                                                .window_state
-                                                .tab_manager
-                                                .active_tab_mut()
+                                            if let Some(tab) =
+                                                self.window_state.tab_manager.active_tab_mut()
                                             {
-                                                tab.error = Some(
-                                                    crate::error::ThothError::Unknown {
-                                                        message: format!(
-                                                            "Failed to load plugin: {e}"
-                                                        ),
-                                                    },
-                                                );
+                                                tab.error =
+                                                    Some(crate::error::ThothError::Unknown {
+                                                        message: format!("Plugin UI error: {e}"),
+                                                    });
                                             }
+                                        }
+                                    },
+                                    Err(e) => {
+                                        if let Some(tab) =
+                                            self.window_state.tab_manager.active_tab_mut()
+                                        {
+                                            tab.error = Some(crate::error::ThothError::Unknown {
+                                                message: format!("Failed to load plugin: {e}"),
+                                            });
                                         }
                                     }
                                 }
+                            }
                         }
                     } else {
                         let is_plugin_sidebar = matches!(
@@ -1467,12 +1473,11 @@ impl ThothApp {
                             self.window_state.sidebar_expanded = true;
                             self.window_state.sidebar_selected_section = Some(section);
                             if !is_plugin_sidebar
-                                && let Some(tab) =
-                                    self.window_state.tab_manager.active_tab_mut()
-                                {
-                                    tab.active_plugin_pane = None;
-                                    tab.plugin_sidebar_output = None;
-                                }
+                                && let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                            {
+                                tab.active_plugin_pane = None;
+                                tab.plugin_sidebar_output = None;
+                            }
                         }
                     }
 
@@ -1489,13 +1494,13 @@ impl ThothApp {
                 components::sidebar::SidebarEvent::Search(msg) => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
                         && let Some(file_path) = &tab.file_path
-                            && let Some(path_str) = file_path.to_str()
-                                && let Some(entry) = msg.history_entry() {
-                                    let _ =
-                                        super::persistent_state::PersistentState::add_search_query(
-                                            path_str, entry,
-                                        );
-                                }
+                        && let Some(path_str) = file_path.to_str()
+                        && let Some(entry) = msg.history_entry()
+                    {
+                        let _ = super::persistent_state::PersistentState::add_search_query(
+                            path_str, entry,
+                        );
+                    }
                     return Some(msg);
                 }
                 components::sidebar::SidebarEvent::NavigateToSearchResult { record_index } => {
@@ -1506,23 +1511,31 @@ impl ThothApp {
                 components::sidebar::SidebarEvent::ClearSearchHistory => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
                         && let Some(file_path) = &tab.file_path
-                            && let Some(path_str) = file_path.to_str() {
-                                let _ =
-                                    super::persistent_state::PersistentState::clear_search_history(
-                                        path_str,
-                                    );
-                            }
+                        && let Some(path_str) = file_path.to_str()
+                    {
+                        let _ = super::persistent_state::PersistentState::clear_search_history(
+                            path_str,
+                        );
+                    }
                 }
                 components::sidebar::SidebarEvent::NavigateToBookmark { file_path, path } => {
-                    let current_file = self
-                        .window_state
-                        .tab_manager
-                        .active_tab_mut()
-                        .and_then(|tab| tab.file_path.as_ref().and_then(|p| p.to_str()).map(|s| s.to_string()));
+                    let current_file =
+                        self.window_state
+                            .tab_manager
+                            .active_tab_mut()
+                            .and_then(|tab| {
+                                tab.file_path
+                                    .as_ref()
+                                    .and_then(|p| p.to_str())
+                                    .map(|s| s.to_string())
+                            });
 
                     if current_file.as_deref() != Some(file_path.as_str()) {
                         let path_buf = std::path::PathBuf::from(&file_path);
-                        let id = self.window_state.tab_manager.open_file(path_buf, nav_capacity);
+                        let id = self
+                            .window_state
+                            .tab_manager
+                            .open_file(path_buf, nav_capacity);
                         if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&id) {
                             tab.error = None;
                             tab.pending_navigation = Some(path.clone());
@@ -1601,7 +1614,10 @@ impl ThothApp {
                 .show(ctx, |ui| {
                     output = Some(self.window_state.error_modal.render(
                         ui,
-                        components::error_modal::ErrorModalProps { error: &error, open: true },
+                        components::error_modal::ErrorModalProps {
+                            error: &error,
+                            open: true,
+                        },
                     ));
                 });
 

--- a/src/app/update_handler.rs
+++ b/src/app/update_handler.rs
@@ -158,17 +158,16 @@ impl UpdateHandler {
             return None;
         }
 
-        let (current_version, latest_version) =
-            if let update::UpdateState::UpdateAvailable {
-                ref current_version,
-                ref latest_version,
-                ..
-            } = update_state.update_status.state
-            {
-                (current_version.clone(), latest_version.clone())
-            } else {
-                return None;
-            };
+        let (current_version, latest_version) = if let update::UpdateState::UpdateAvailable {
+            ref current_version,
+            ref latest_version,
+            ..
+        } = update_state.update_status.state
+        {
+            (current_version.clone(), latest_version.clone())
+        } else {
+            return None;
+        };
 
         use crate::components::{
             traits::StatelessComponent,
@@ -194,17 +193,16 @@ impl UpdateHandler {
 
     /// Post (or refresh) the pinned update-available notification with an "Update Now" action.
     pub fn post_update_notification(update_state: &state::ApplicationUpdateState) {
-        let (current_version, latest_version) =
-            if let update::UpdateState::UpdateAvailable {
-                ref current_version,
-                ref latest_version,
-                ..
-            } = update_state.update_status.state
-            {
-                (current_version.clone(), latest_version.clone())
-            } else {
-                return;
-            };
+        let (current_version, latest_version) = if let update::UpdateState::UpdateAvailable {
+            ref current_version,
+            ref latest_version,
+            ..
+        } = update_state.update_status.state
+        {
+            (current_version.clone(), latest_version.clone())
+        } else {
+            return;
+        };
 
         crate::notification::NotificationManager::notify(
             crate::notification::Notification::new(
@@ -217,8 +215,7 @@ impl UpdateHandler {
             .with_action(
                 "Update Now",
                 std::sync::Arc::new(|| {
-                    crate::OPEN_UPDATES_REQUESTED
-                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                    crate::OPEN_UPDATES_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
                 }),
             )
             .pinned(),

--- a/src/app/update_handler.rs
+++ b/src/app/update_handler.rs
@@ -1,6 +1,11 @@
 use crate::{error::ThothError, settings, state, update};
 use eframe::egui;
 
+pub enum ConsentAction {
+    UpdateNow,
+    RemindLater,
+}
+
 /// Handles all update-related logic
 pub struct UpdateHandler;
 
@@ -23,18 +28,18 @@ impl UpdateHandler {
         update_state.update_status.last_check = Some(chrono::Utc::now());
     }
 
-    /// Process incoming update messages
-    /// Returns true if settings panel should be shown
+    /// Process incoming update messages.
+    /// Returns `true` once when a new update is detected (first time only per session).
     pub fn handle_update_messages(
         update_state: &mut state::ApplicationUpdateState,
         ctx: &egui::Context,
     ) -> bool {
-        let mut should_show_settings = false;
+        let mut update_detected = false;
         while let Ok(msg) = update_state.update_manager.receiver().try_recv() {
             match msg {
                 update::manager::UpdateMessage::UpdateCheckComplete(result) => {
                     if Self::handle_check_complete(result, update_state) {
-                        should_show_settings = true;
+                        update_detected = true;
                     }
                 }
                 update::manager::UpdateMessage::DownloadProgress(progress) => {
@@ -49,7 +54,7 @@ impl UpdateHandler {
             }
             ctx.request_repaint();
         }
-        should_show_settings
+        update_detected
     }
 
     // Private helper methods
@@ -57,7 +62,7 @@ impl UpdateHandler {
         result: Result<Vec<update::ReleaseInfo>, ThothError>,
         update_state: &mut state::ApplicationUpdateState,
     ) -> bool {
-        let mut should_show_settings = false;
+        let mut update_detected = false;
 
         match result {
             Ok(releases) => {
@@ -71,14 +76,16 @@ impl UpdateHandler {
                             releases: newer_releases,
                         };
 
-                        // Auto-open settings panel on first update notification
                         if !update_state.update_notification_shown {
-                            should_show_settings = true;
+                            update_detected = true;
                             update_state.update_notification_shown = true;
                         }
                     }
                 } else {
                     update_state.update_status.state = update::UpdateState::Idle;
+                    crate::notification::NotificationManager::remove_notification(
+                        "thoth_update_available",
+                    );
                 }
             }
             Err(e) => {
@@ -86,7 +93,7 @@ impl UpdateHandler {
             }
         }
 
-        should_show_settings
+        update_detected
     }
 
     fn handle_download_progress(
@@ -138,5 +145,83 @@ impl UpdateHandler {
                 update_state.update_status.state = update::UpdateState::Error(e);
             }
         }
+    }
+
+    /// Render the update consent modal. Returns the action the user chose, or `None` if the
+    /// modal is not visible (no update available or already dismissed for this session).
+    pub fn render_consent_modal(
+        ui: &mut egui::Ui,
+        update_state: &state::ApplicationUpdateState,
+        show_consent: bool,
+    ) -> Option<ConsentAction> {
+        if !show_consent {
+            return None;
+        }
+
+        let (current_version, latest_version) =
+            if let update::UpdateState::UpdateAvailable {
+                ref current_version,
+                ref latest_version,
+                ..
+            } = update_state.update_status.state
+            {
+                (current_version.clone(), latest_version.clone())
+            } else {
+                return None;
+            };
+
+        use crate::components::{
+            traits::StatelessComponent,
+            update_consent_modal::{UpdateConsentModal, UpdateConsentModalProps},
+        };
+
+        let out = UpdateConsentModal::render(
+            ui,
+            UpdateConsentModalProps {
+                current_version: &current_version,
+                latest_version: &latest_version,
+            },
+        );
+
+        if out.update_now {
+            Some(ConsentAction::UpdateNow)
+        } else if out.remind_later {
+            Some(ConsentAction::RemindLater)
+        } else {
+            None
+        }
+    }
+
+    /// Post (or refresh) the pinned update-available notification with an "Update Now" action.
+    pub fn post_update_notification(update_state: &state::ApplicationUpdateState) {
+        let (current_version, latest_version) =
+            if let update::UpdateState::UpdateAvailable {
+                ref current_version,
+                ref latest_version,
+                ..
+            } = update_state.update_status.state
+            {
+                (current_version.clone(), latest_version.clone())
+            } else {
+                return;
+            };
+
+        crate::notification::NotificationManager::notify(
+            crate::notification::Notification::new(
+                "Update Available",
+                &format!("v{current_version} → v{latest_version}"),
+            )
+            .with_id("thoth_update_available")
+            .with_kind(crate::notification::NotificationKind::Update)
+            .with_toast(false)
+            .with_action(
+                "Update Now",
+                std::sync::Arc::new(|| {
+                    crate::OPEN_UPDATES_REQUESTED
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                }),
+            )
+            .pinned(),
+        );
     }
 }

--- a/src/components/bookmarks.rs
+++ b/src/components/bookmarks.rs
@@ -130,14 +130,13 @@ impl StatefulComponent for Bookmarks {
                     },
                 );
 
-                if let Some(item_idx) = output.row_clicked {
-                    if let Some(b) = props.bookmarks.get(item_idx) {
+                if let Some(item_idx) = output.row_clicked
+                    && let Some(b) = props.bookmarks.get(item_idx) {
                         events.push(BookmarksEvent::NavigateToBookmark {
                             file_path: b.file_path.clone(),
                             path: b.path.clone(),
                         });
                     }
-                }
             });
 
         BookmarksOutput { events }

--- a/src/components/bookmarks.rs
+++ b/src/components/bookmarks.rs
@@ -133,12 +133,13 @@ impl StatefulComponent for Bookmarks {
                 );
 
                 if let Some(item_idx) = output.row_clicked
-                    && let Some(b) = props.bookmarks.get(item_idx) {
-                        events.push(BookmarksEvent::NavigateToBookmark {
-                            file_path: b.file_path.clone(),
-                            path: b.path.clone(),
-                        });
-                    }
+                    && let Some(b) = props.bookmarks.get(item_idx)
+                {
+                    events.push(BookmarksEvent::NavigateToBookmark {
+                        file_path: b.file_path.clone(),
+                        path: b.path.clone(),
+                    });
+                }
             });
 
         BookmarksOutput { events }

--- a/src/components/bookmarks.rs
+++ b/src/components/bookmarks.rs
@@ -114,6 +114,7 @@ impl StatefulComponent for Bookmarks {
                             badge: None,
                             postfix: None,
                             selected: false,
+                            accent: None,
                             tags: &[],
                         }
                     })
@@ -127,6 +128,7 @@ impl StatefulComponent for Bookmarks {
                         shrink_to_fit: false,
                         show_separators: true,
                         compact: false,
+                        max_height: None,
                     },
                 );
 

--- a/src/components/central_panel.rs
+++ b/src/components/central_panel.rs
@@ -188,12 +188,16 @@ impl CentralPanel {
             }
 
             if self.loaded_path.is_none() {
-                use crate::components::welcome::{WelcomePanel, WelcomeEvent};
+                use crate::components::welcome::{WelcomeEvent, WelcomePanel};
                 let welcome_events = WelcomePanel::render(ui, props.recent_files, props.colors);
                 for evt in welcome_events {
                     match evt {
-                        WelcomeEvent::OpenFilePicker => events.push(CentralPanelEvent::OpenFilePicker),
-                        WelcomeEvent::OpenRecentFile(path) => events.push(CentralPanelEvent::OpenRecentFile(path)),
+                        WelcomeEvent::OpenFilePicker => {
+                            events.push(CentralPanelEvent::OpenFilePicker)
+                        }
+                        WelcomeEvent::OpenRecentFile(path) => {
+                            events.push(CentralPanelEvent::OpenRecentFile(path))
+                        }
                     }
                 }
                 return;

--- a/src/components/central_panel.rs
+++ b/src/components/central_panel.rs
@@ -17,6 +17,10 @@ pub struct CentralPanelProps<'a> {
     pub syntax_highlighting: bool,
     /// When `Some`, render this interactive `UiNode` tree from the plugin instead of the file viewer.
     pub plugin_ui: Option<&'a UiOutput>,
+    /// Recent files passed down for the Welcome screen shown on empty tabs.
+    pub recent_files: &'a [String],
+    /// Current theme colors forwarded to the Welcome screen.
+    pub colors: Option<crate::theme::ThemeColors>,
 }
 
 /// Events emitted by the central panel (bottom-to-top communication)
@@ -32,6 +36,10 @@ pub enum CentralPanelEvent {
     ErrorCleared,
     /// A widget interaction from the active plugin pane — forward to the loader.
     PluginUiEvent(UiEvent),
+    /// User clicked "Open file…" on the Welcome screen.
+    OpenFilePicker,
+    /// User clicked a recent file on the Welcome screen.
+    OpenRecentFile(PathBuf),
 }
 
 pub struct CentralPanelOutput {
@@ -180,7 +188,14 @@ impl CentralPanel {
             }
 
             if self.loaded_path.is_none() {
-                ui.label("Open a JSON/NDJSON file from the top bar to begin.");
+                use crate::components::welcome::{WelcomePanel, WelcomeEvent};
+                let welcome_events = WelcomePanel::render(ui, props.recent_files, props.colors);
+                for evt in welcome_events {
+                    match evt {
+                        WelcomeEvent::OpenFilePicker => events.push(CentralPanelEvent::OpenFilePicker),
+                        WelcomeEvent::OpenRecentFile(path) => events.push(CentralPanelEvent::OpenRecentFile(path)),
+                    }
+                }
                 return;
             }
 

--- a/src/components/common/json_tree.rs
+++ b/src/components/common/json_tree.rs
@@ -103,9 +103,10 @@ impl StatelessComponent for JsonTree {
             });
 
         if let Some(path) = toggle_path
-            && !expanded.0.remove(&path) {
-                expanded.0.insert(path);
-            }
+            && !expanded.0.remove(&path)
+        {
+            expanded.0.insert(path);
+        }
 
         ui.ctx().data_mut(|d| {
             d.insert_temp(mem_id, expanded);

--- a/src/components/common/json_tree.rs
+++ b/src/components/common/json_tree.rs
@@ -102,11 +102,10 @@ impl StatelessComponent for JsonTree {
                 }
             });
 
-        if let Some(path) = toggle_path {
-            if !expanded.0.remove(&path) {
+        if let Some(path) = toggle_path
+            && !expanded.0.remove(&path) {
                 expanded.0.insert(path);
             }
-        }
 
         ui.ctx().data_mut(|d| {
             d.insert_temp(mem_id, expanded);

--- a/src/components/common/list.rs
+++ b/src/components/common/list.rs
@@ -207,406 +207,382 @@ impl StatelessComponent for List {
             scroll = scroll.max_height(h);
         }
         scroll.show_viewport(ui, |ui, viewport| {
-                ui.set_min_height(total_h);
+            ui.set_min_height(total_h);
 
-                let start = offsets
-                    .partition_point(|&y| y < viewport.min.y)
-                    .saturating_sub(1);
-                let end = offsets.partition_point(|&y| y <= viewport.max.y).min(n);
+            let start = offsets
+                .partition_point(|&y| y < viewport.min.y)
+                .saturating_sub(1);
+            let end = offsets.partition_point(|&y| y <= viewport.max.y).min(n);
 
-                if offsets[start] > 0.0 {
-                    ui.add_space(offsets[start]);
-                }
+            if offsets[start] > 0.0 {
+                ui.add_space(offsets[start]);
+            }
 
-                for idx in start..end {
-                    let item = &props.items[idx];
-                    // Key off scroll_id, not ui.id(), so items in sibling lists
-                    // (same parent UI) never share hover-state storage keys.
-                    let item_id = scroll_id.with(idx);
-                    let row_h = item_height(item, compact);
+            for idx in start..end {
+                let item = &props.items[idx];
+                // Key off scroll_id, not ui.id(), so items in sibling lists
+                // (same parent UI) never share hover-state storage keys.
+                let item_id = scroll_id.with(idx);
+                let row_h = item_height(item, compact);
 
-                    let was_hovered = ui
-                        .ctx()
-                        .memory(|m| m.data.get_temp::<bool>(item_id).unwrap_or(false));
+                let was_hovered = ui
+                    .ctx()
+                    .memory(|m| m.data.get_temp::<bool>(item_id).unwrap_or(false));
 
-                    let mut postfix_btn_clicked = false;
+                let mut postfix_btn_clicked = false;
 
-                    // Reserve a paint slot BEFORE the row content so the
-                    // background is always drawn behind badges and icons.
-                    // painter.set() fills it in after we know the rect + state.
-                    let bg_slot = ui.painter().add(egui::Shape::Noop);
+                // Reserve a paint slot BEFORE the row content so the
+                // background is always drawn behind badges and icons.
+                // painter.set() fills it in after we know the rect + state.
+                let bg_slot = ui.painter().add(egui::Shape::Noop);
 
-                    let row_resp = ui
-                        .push_id(item_id, |ui| {
-                            let avail_width = ui.available_width();
-                            let alloc = ui.allocate_ui(egui::vec2(avail_width, row_h), |ui| {
-                                ui.horizontal(|ui| {
-                                        ui.set_min_width(ui.available_width());
-                                        ui.set_min_height(row_h);
+                let row_resp = ui
+                    .push_id(item_id, |ui| {
+                        let avail_width = ui.available_width();
+                        let alloc = ui.allocate_ui(egui::vec2(avail_width, row_h), |ui| {
+                            ui.horizontal(|ui| {
+                                ui.set_min_width(ui.available_width());
+                                ui.set_min_height(row_h);
 
-                                        // ── Prefix ───────────────────────────────
-                                        match &item.prefix {
-                                            Some(ListItemPrefix::Icon { glyph, color }) => {
-                                                ui.add_space(8.0);
-                                                let c = color.unwrap_or(colors.fg_muted);
-                                                ui.label(icon_rich_text(glyph, 13.0).color(c));
-                                                ui.add_space(4.0);
-                                            }
-                                            Some(ListItemPrefix::IconTile { glyph, color }) => {
-                                                ui.add_space(8.0);
-                                                let tile_bg_slot =
-                                                    ui.painter().add(egui::Shape::Noop);
-                                                let (rect, _) = ui.allocate_exact_size(
-                                                    egui::vec2(32.0, 32.0),
-                                                    egui::Sense::hover(),
-                                                );
-                                                ui.painter().text(
-                                                    rect.center(),
-                                                    egui::Align2::CENTER_CENTER,
-                                                    *glyph,
-                                                    phosphor_font_id(14.0),
-                                                    *color,
-                                                );
-                                                ui.painter().set(
-                                                    tile_bg_slot,
-                                                    egui::Shape::rect_filled(
-                                                        rect,
-                                                        7.0,
-                                                        color.linear_multiply(0.15),
-                                                    ),
-                                                );
-                                                ui.add_space(8.0);
-                                            }
-                                            Some(ListItemPrefix::IconFile { path }) => {
-                                                ui.add_space(8.0);
-                                                let (rect, _) = ui.allocate_exact_size(
-                                                    Vec2::new(48.0, 48.0),
-                                                    Sense::hover(),
-                                                );
-                                                if let Some(texture) =
-                                                    super::helpers::load_icon_texture(
-                                                        ui.ctx(),
-                                                        path,
-                                                        "list_icon",
-                                                    )
-                                                {
-                                                    ui.put(
-                                                        rect,
-                                                        egui::Image::new(&texture)
-                                                            .fit_to_exact_size(rect.size())
-                                                            .corner_radius(CornerRadius::same(10)),
+                                // ── Prefix ───────────────────────────────
+                                match &item.prefix {
+                                    Some(ListItemPrefix::Icon { glyph, color }) => {
+                                        ui.add_space(8.0);
+                                        let c = color.unwrap_or(colors.fg_muted);
+                                        ui.label(icon_rich_text(glyph, 13.0).color(c));
+                                        ui.add_space(4.0);
+                                    }
+                                    Some(ListItemPrefix::IconTile { glyph, color }) => {
+                                        ui.add_space(8.0);
+                                        let tile_bg_slot = ui.painter().add(egui::Shape::Noop);
+                                        let (rect, _) = ui.allocate_exact_size(
+                                            egui::vec2(32.0, 32.0),
+                                            egui::Sense::hover(),
+                                        );
+                                        ui.painter().text(
+                                            rect.center(),
+                                            egui::Align2::CENTER_CENTER,
+                                            *glyph,
+                                            phosphor_font_id(14.0),
+                                            *color,
+                                        );
+                                        ui.painter().set(
+                                            tile_bg_slot,
+                                            egui::Shape::rect_filled(
+                                                rect,
+                                                7.0,
+                                                color.linear_multiply(0.15),
+                                            ),
+                                        );
+                                        ui.add_space(8.0);
+                                    }
+                                    Some(ListItemPrefix::IconFile { path }) => {
+                                        ui.add_space(8.0);
+                                        let (rect, _) = ui.allocate_exact_size(
+                                            Vec2::new(48.0, 48.0),
+                                            Sense::hover(),
+                                        );
+                                        if let Some(texture) = super::helpers::load_icon_texture(
+                                            ui.ctx(),
+                                            path,
+                                            "list_icon",
+                                        ) {
+                                            ui.put(
+                                                rect,
+                                                egui::Image::new(&texture)
+                                                    .fit_to_exact_size(rect.size())
+                                                    .corner_radius(CornerRadius::same(10)),
+                                            );
+                                        }
+                                        ui.add_space(8.0);
+                                    }
+                                    None => {}
+                                }
+
+                                // ── Content + postfix + actions ──────────
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        // Postfix (always visible)
+                                        if let Some(postfix) = &item.postfix {
+                                            match postfix {
+                                                ListItemPostfix::Badge { text, bg, fg } => {
+                                                    ui.add_space(6.0);
+                                                    let badge_bg_slot =
+                                                        ui.painter().add(egui::Shape::Noop);
+                                                    let galley = ui.painter().layout_no_wrap(
+                                                        text.to_string(),
+                                                        egui::FontId::proportional(10.0),
+                                                        *fg,
+                                                    );
+                                                    let pad_x = 6.0_f32;
+                                                    let pad_y = 2.0_f32;
+                                                    let badge_size = egui::vec2(
+                                                        galley.size().x + pad_x * 2.0,
+                                                        galley.size().y + pad_y * 2.0,
+                                                    );
+                                                    let (rect, _) = ui.allocate_exact_size(
+                                                        badge_size,
+                                                        egui::Sense::hover(),
+                                                    );
+                                                    if ui.is_rect_visible(rect) {
+                                                        ui.painter().galley(
+                                                            rect.min + egui::vec2(pad_x, pad_y),
+                                                            galley,
+                                                            *fg,
+                                                        );
+                                                        ui.painter().set(
+                                                            badge_bg_slot,
+                                                            egui::Shape::rect_filled(
+                                                                rect,
+                                                                u8::MAX,
+                                                                *bg,
+                                                            ),
+                                                        );
+                                                    }
+                                                }
+                                                ListItemPostfix::ActionButton(props) => {
+                                                    ui.add_space(8.0);
+                                                    let out = Button::render(ui, props.clone());
+                                                    if out.clicked {
+                                                        postfix_btn_clicked = true;
+                                                    }
+                                                }
+                                                ListItemPostfix::IconButton(props) => {
+                                                    ui.add_space(8.0);
+                                                    let out = IconButton::render(
+                                                        ui,
+                                                        IconButtonProps { ..*props },
+                                                    );
+                                                    if out.clicked {
+                                                        postfix_btn_clicked = true;
+                                                    }
+                                                }
+                                                ListItemPostfix::ProgressBar(pct) => {
+                                                    ui.add_space(8.0);
+                                                    let (track, _) = ui.allocate_exact_size(
+                                                        egui::vec2(80.0, 4.0),
+                                                        egui::Sense::hover(),
+                                                    );
+                                                    ui.painter().rect_filled(
+                                                        track,
+                                                        2.0,
+                                                        colors.surface,
+                                                    );
+                                                    let fill = egui::Rect::from_min_size(
+                                                        track.min,
+                                                        egui::vec2(
+                                                            track.width() * (*pct as f32 / 100.0),
+                                                            4.0,
+                                                        ),
+                                                    );
+                                                    ui.painter().rect_filled(
+                                                        fill,
+                                                        2.0,
+                                                        colors.info,
                                                     );
                                                 }
-                                                ui.add_space(8.0);
                                             }
-                                            None => {}
                                         }
 
-                                        // ── Content + postfix + actions ──────────
-                                        ui.with_layout(
-                                            egui::Layout::right_to_left(egui::Align::Center),
+                                        // Title + badge + description.
+                                        // Explicitly bounded to the remaining width so the
+                                        // postfix always has its own reserved space at the end.
+                                        let content_w = ui.available_width();
+                                        ui.allocate_ui_with_layout(
+                                            egui::vec2(content_w, row_h),
+                                            egui::Layout::top_down(egui::Align::LEFT),
                                             |ui| {
-                                                // Postfix (always visible)
-                                                if let Some(postfix) = &item.postfix {
-                                                    match postfix {
-                                                        ListItemPostfix::Badge { text, bg, fg } => {
-                                                            ui.add_space(6.0);
-                                                            let badge_bg_slot =
-                                                                ui.painter().add(egui::Shape::Noop);
+                                                // Vertically centre content within row_h.
+                                                let title_h: f32 = 15.0;
+                                                let two_line = item
+                                                    .description
+                                                    .is_some_and(|d| d.contains('\n'));
+                                                let desc_h: f32 = if two_line {
+                                                    2.0 + 13.0 + 5.0 + 13.0
+                                                } else if item.description.is_some() {
+                                                    2.0 + 13.0
+                                                } else {
+                                                    0.0
+                                                };
+                                                let tags_h: f32 = if item.tags.is_empty() {
+                                                    0.0
+                                                } else {
+                                                    ROW_H_TAGS_ADD
+                                                };
+                                                let content_h = title_h + desc_h + tags_h;
+                                                let pad = (row_h - content_h).max(0.0) / 2.0;
+                                                if pad > 0.0 {
+                                                    ui.add_space(pad);
+                                                }
+                                                ui.horizontal(|ui| {
+                                                    ui.spacing_mut().item_spacing.x = 5.0;
+                                                    if let Some(badge) = &item.badge {
+                                                        let text_w = badge.text.len() as f32 * 6.0;
+                                                        let badge_size =
+                                                            egui::vec2(text_w + 8.0, 14.0);
+                                                        let (badge_rect, _) = ui
+                                                            .allocate_exact_size(
+                                                                badge_size,
+                                                                egui::Sense::hover(),
+                                                            );
+                                                        ui.painter().rect_filled(
+                                                            badge_rect,
+                                                            3.0,
+                                                            badge.color,
+                                                        );
+                                                        ui.painter().text(
+                                                            badge_rect.center(),
+                                                            egui::Align2::CENTER_CENTER,
+                                                            badge.text,
+                                                            egui::FontId::proportional(10.0),
+                                                            badge.text_color,
+                                                        );
+                                                    }
+                                                    // Compact nav rows: dim inactive,
+                                                    // brighten active — matches design's
+                                                    // overlay1 vs text color distinction.
+                                                    let title_color = if compact && !item.selected {
+                                                        colors.fg_muted
+                                                    } else {
+                                                        colors.fg
+                                                    };
+                                                    let title_rt = egui::RichText::new(item.title)
+                                                        .size(12.0)
+                                                        .color(title_color);
+                                                    ui.add(
+                                                        egui::Label::new(
+                                                            if item.selected && compact {
+                                                                title_rt.strong()
+                                                            } else {
+                                                                title_rt
+                                                            },
+                                                        )
+                                                        .truncate(),
+                                                    );
+                                                });
+                                                if let Some(desc) = item.description {
+                                                    let mut parts = desc.splitn(2, '\n');
+                                                    if let Some(first) = parts.next() {
+                                                        ui.add(
+                                                            egui::Label::new(
+                                                                egui::RichText::new(first)
+                                                                    .size(11.0)
+                                                                    .color(colors.fg_muted),
+                                                            )
+                                                            .truncate(),
+                                                        );
+                                                    }
+                                                    if let Some(second) = parts.next() {
+                                                        ui.add_space(3.0);
+                                                        ui.add(
+                                                            egui::Label::new(
+                                                                egui::RichText::new(second)
+                                                                    .size(11.0)
+                                                                    .color(colors.fg_muted),
+                                                            )
+                                                            .truncate(),
+                                                        );
+                                                    }
+                                                }
+                                                if !item.tags.is_empty() {
+                                                    ui.add_space(4.0);
+                                                    ui.horizontal_wrapped(|ui| {
+                                                        ui.spacing_mut().item_spacing.x = 4.0;
+                                                        ui.spacing_mut().item_spacing.y = 2.0;
+                                                        for tag in item.tags {
                                                             let galley =
                                                                 ui.painter().layout_no_wrap(
-                                                                    text.to_string(),
+                                                                    tag.to_string(),
                                                                     egui::FontId::proportional(
                                                                         10.0,
                                                                     ),
-                                                                    *fg,
+                                                                    colors.fg_muted,
                                                                 );
-                                                            let pad_x = 6.0_f32;
+                                                            let pad_x = 5.0_f32;
                                                             let pad_y = 2.0_f32;
-                                                            let badge_size = egui::vec2(
+                                                            let tag_size = egui::vec2(
                                                                 galley.size().x + pad_x * 2.0,
                                                                 galley.size().y + pad_y * 2.0,
                                                             );
                                                             let (rect, _) = ui.allocate_exact_size(
-                                                                badge_size,
+                                                                tag_size,
                                                                 egui::Sense::hover(),
                                                             );
                                                             if ui.is_rect_visible(rect) {
+                                                                ui.painter().rect_filled(
+                                                                    rect,
+                                                                    3.0,
+                                                                    colors.bg_sunken,
+                                                                );
                                                                 ui.painter().galley(
                                                                     rect.min
                                                                         + egui::vec2(pad_x, pad_y),
                                                                     galley,
-                                                                    *fg,
-                                                                );
-                                                                ui.painter().set(
-                                                                    badge_bg_slot,
-                                                                    egui::Shape::rect_filled(
-                                                                        rect,
-                                                                        u8::MAX,
-                                                                        *bg,
-                                                                    ),
+                                                                    colors.fg_muted,
                                                                 );
                                                             }
                                                         }
-                                                        ListItemPostfix::ActionButton(props) => {
-                                                            ui.add_space(8.0);
-                                                            let out =
-                                                                Button::render(ui, props.clone());
-                                                            if out.clicked {
-                                                                postfix_btn_clicked = true;
-                                                            }
-                                                        }
-                                                        ListItemPostfix::IconButton(props) => {
-                                                            ui.add_space(8.0);
-                                                            let out = IconButton::render(
-                                                                ui,
-                                                                IconButtonProps { ..*props },
-                                                            );
-                                                            if out.clicked {
-                                                                postfix_btn_clicked = true;
-                                                            }
-                                                        }
-                                                        ListItemPostfix::ProgressBar(pct) => {
-                                                            ui.add_space(8.0);
-                                                            let (track, _) = ui
-                                                                .allocate_exact_size(
-                                                                    egui::vec2(80.0, 4.0),
-                                                                    egui::Sense::hover(),
-                                                                );
-                                                            ui.painter().rect_filled(
-                                                                track,
-                                                                2.0,
-                                                                colors.surface,
-                                                            );
-                                                            let fill = egui::Rect::from_min_size(
-                                                                track.min,
-                                                                egui::vec2(
-                                                                    track.width()
-                                                                        * (*pct as f32 / 100.0),
-                                                                    4.0,
-                                                                ),
-                                                            );
-                                                            ui.painter().rect_filled(
-                                                                fill,
-                                                                2.0,
-                                                                colors.info,
-                                                            );
-                                                        }
-                                                    }
+                                                    });
                                                 }
-
-                                                // Title + badge + description.
-                                                // Explicitly bounded to the remaining width so the
-                                                // postfix always has its own reserved space at the end.
-                                                let content_w = ui.available_width();
-                                                ui.allocate_ui_with_layout(
-                                                    egui::vec2(content_w, row_h),
-                                                    egui::Layout::top_down(egui::Align::LEFT),
-                                                    |ui| {
-                                                        // Vertically centre content within row_h.
-                                                        let title_h: f32 = 15.0;
-                                                        let two_line = item
-                                                            .description
-                                                            .is_some_and(|d| d.contains('\n'));
-                                                        let desc_h: f32 = if two_line {
-                                                            2.0 + 13.0 + 5.0 + 13.0
-                                                        } else if item.description.is_some() {
-                                                            2.0 + 13.0
-                                                        } else {
-                                                            0.0
-                                                        };
-                                                        let tags_h: f32 = if item.tags.is_empty() {
-                                                            0.0
-                                                        } else {
-                                                            ROW_H_TAGS_ADD
-                                                        };
-                                                        let content_h = title_h + desc_h + tags_h;
-                                                        let pad =
-                                                            (row_h - content_h).max(0.0) / 2.0;
-                                                        if pad > 0.0 {
-                                                            ui.add_space(pad);
-                                                        }
-                                                        ui.horizontal(|ui| {
-                                                            ui.spacing_mut().item_spacing.x = 5.0;
-                                                            if let Some(badge) = &item.badge {
-                                                                let text_w =
-                                                                    badge.text.len() as f32 * 6.0;
-                                                                let badge_size =
-                                                                    egui::vec2(text_w + 8.0, 14.0);
-                                                                let (badge_rect, _) = ui
-                                                                    .allocate_exact_size(
-                                                                        badge_size,
-                                                                        egui::Sense::hover(),
-                                                                    );
-                                                                ui.painter().rect_filled(
-                                                                    badge_rect,
-                                                                    3.0,
-                                                                    badge.color,
-                                                                );
-                                                                ui.painter().text(
-                                                                    badge_rect.center(),
-                                                                    egui::Align2::CENTER_CENTER,
-                                                                    badge.text,
-                                                                    egui::FontId::proportional(
-                                                                        10.0,
-                                                                    ),
-                                                                    badge.text_color,
-                                                                );
-                                                            }
-                                                            // Compact nav rows: dim inactive,
-                                                            // brighten active — matches design's
-                                                            // overlay1 vs text color distinction.
-                                                            let title_color =
-                                                                if compact && !item.selected {
-                                                                    colors.fg_muted
-                                                                } else {
-                                                                    colors.fg
-                                                                };
-                                                            let title_rt =
-                                                                egui::RichText::new(item.title)
-                                                                    .size(12.0)
-                                                                    .color(title_color);
-                                                            ui.add(
-                                                                egui::Label::new(
-                                                                    if item.selected && compact {
-                                                                        title_rt.strong()
-                                                                    } else {
-                                                                        title_rt
-                                                                    },
-                                                                )
-                                                                .truncate(),
-                                                            );
-                                                        });
-                                                        if let Some(desc) = item.description {
-                                                            let mut parts = desc.splitn(2, '\n');
-                                                            if let Some(first) = parts.next() {
-                                                                ui.add(
-                                                                    egui::Label::new(
-                                                                        egui::RichText::new(first)
-                                                                            .size(11.0)
-                                                                            .color(colors.fg_muted),
-                                                                    )
-                                                                    .truncate(),
-                                                                );
-                                                            }
-                                                            if let Some(second) = parts.next() {
-                                                                ui.add_space(3.0);
-                                                                ui.add(
-                                                                    egui::Label::new(
-                                                                        egui::RichText::new(second)
-                                                                            .size(11.0)
-                                                                            .color(colors.fg_muted),
-                                                                    )
-                                                                    .truncate(),
-                                                                );
-                                                            }
-                                                        }
-                                                        if !item.tags.is_empty() {
-                                                            ui.add_space(4.0);
-                                                            ui.horizontal_wrapped(|ui| {
-                                                                ui.spacing_mut().item_spacing.x =
-                                                                    4.0;
-                                                                ui.spacing_mut().item_spacing.y =
-                                                                    2.0;
-                                                                for tag in item.tags {
-                                                                    let galley = ui
-                                                                        .painter()
-                                                                        .layout_no_wrap(
-                                                                        tag.to_string(),
-                                                                        egui::FontId::proportional(
-                                                                            10.0,
-                                                                        ),
-                                                                        colors.fg_muted,
-                                                                    );
-                                                                    let pad_x = 5.0_f32;
-                                                                    let pad_y = 2.0_f32;
-                                                                    let tag_size = egui::vec2(
-                                                                        galley.size().x
-                                                                            + pad_x * 2.0,
-                                                                        galley.size().y
-                                                                            + pad_y * 2.0,
-                                                                    );
-                                                                    let (rect, _) = ui
-                                                                        .allocate_exact_size(
-                                                                            tag_size,
-                                                                            egui::Sense::hover(),
-                                                                        );
-                                                                    if ui.is_rect_visible(rect) {
-                                                                        ui.painter().rect_filled(
-                                                                            rect,
-                                                                            3.0,
-                                                                            colors.bg_sunken,
-                                                                        );
-                                                                        ui.painter().galley(
-                                                                            rect.min
-                                                                                + egui::vec2(
-                                                                                    pad_x, pad_y,
-                                                                                ),
-                                                                            galley,
-                                                                            colors.fg_muted,
-                                                                        );
-                                                                    }
-                                                                }
-                                                            });
-                                                        }
-                                                    },
-                                                );
                                             },
                                         );
-                                    });
+                                    },
+                                );
                             });
-                            alloc.response
-                        })
-                        .inner;
+                        });
+                        alloc.response
+                    })
+                    .inner;
 
-                    let is_hovered = ui.rect_contains_pointer(row_resp.rect);
-                    if is_hovered {
-                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
-                    }
-                    ui.ctx()
-                        .memory_mut(|m| m.data.insert_temp(item_id, is_hovered));
+                let is_hovered = ui.rect_contains_pointer(row_resp.rect);
+                if is_hovered {
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                }
+                ui.ctx()
+                    .memory_mut(|m| m.data.insert_temp(item_id, is_hovered));
 
-                    // ── Row background — painted into the pre-reserved slot ──
-                    // Because bg_slot was inserted before the row content, this
-                    // always renders behind badges, icons, and text.
-                    let is_hovering = is_hovered || was_hovered;
-                    let bg_shape = if item.selected && is_hovering {
-                        egui::Shape::rect_filled(row_resp.rect, 3.0, colors.surface_raised)
-                    } else if item.selected || is_hovering {
-                        egui::Shape::rect_filled(row_resp.rect, 3.0, colors.sidebar_hover)
-                    } else {
-                        egui::Shape::Noop
-                    };
-                    ui.painter().set(bg_slot, bg_shape);
+                // ── Row background — painted into the pre-reserved slot ──
+                // Because bg_slot was inserted before the row content, this
+                // always renders behind badges, icons, and text.
+                let is_hovering = is_hovered || was_hovered;
+                let bg_shape = if item.selected && is_hovering {
+                    egui::Shape::rect_filled(row_resp.rect, 3.0, colors.surface_raised)
+                } else if item.selected || is_hovering {
+                    egui::Shape::rect_filled(row_resp.rect, 3.0, colors.sidebar_hover)
+                } else {
+                    egui::Shape::Noop
+                };
+                ui.painter().set(bg_slot, bg_shape);
 
-                    // Left accent border — driven by the `accent` prop, not `selected`,
-                    // so callers control both color and presence independently.
-                    if let Some(accent_color) = item.accent
-                        && !compact
-                    {
-                        let border = egui::Rect::from_min_size(
-                            row_resp.rect.min,
-                            egui::vec2(2.0, row_resp.rect.height()),
-                        );
-                        ui.painter().rect_filled(border, 0.0, accent_color);
-                    }
-
-                    if postfix_btn_clicked {
-                        postfix_clicked = Some(idx);
-                    } else if is_hovered && ui.input(|i| i.pointer.primary_clicked()) {
-                        row_clicked = Some(idx);
-                    }
-
-                    if show_sep && idx + 1 < n {
-                        ui.separator();
-                    }
+                // Left accent border — driven by the `accent` prop, not `selected`,
+                // so callers control both color and presence independently.
+                if let Some(accent_color) = item.accent
+                    && !compact
+                {
+                    let border = egui::Rect::from_min_size(
+                        row_resp.rect.min,
+                        egui::vec2(2.0, row_resp.rect.height()),
+                    );
+                    ui.painter().rect_filled(border, 0.0, accent_color);
                 }
 
-                let remaining = total_h - offsets[end];
-                if remaining > 0.0 {
-                    ui.add_space(remaining);
+                if postfix_btn_clicked {
+                    postfix_clicked = Some(idx);
+                } else if is_hovered && ui.input(|i| i.pointer.primary_clicked()) {
+                    row_clicked = Some(idx);
                 }
-            });
+
+                if show_sep && idx + 1 < n {
+                    ui.separator();
+                }
+            }
+
+            let remaining = total_h - offsets[end];
+            if remaining > 0.0 {
+                ui.add_space(remaining);
+            }
+        });
 
         ListOutput {
             row_clicked,

--- a/src/components/common/list.rs
+++ b/src/components/common/list.rs
@@ -114,6 +114,10 @@ pub struct ListItem<'a> {
     pub postfix: Option<ListItemPostfix<'a>>,
     /// Persistent highlight — used for active/selected state (e.g. category strip).
     pub selected: bool,
+    /// Optional left accent border color. Pass `Some(color)` to draw a 2 px strip
+    /// on the left edge in the given color (e.g. per-notification-kind color).
+    /// Drawn for non-compact rows only; independent of `selected`.
+    pub accent: Option<egui::Color32>,
     /// Optional category/tag pills rendered below the description row.
     pub tags: &'a [&'a str],
 }
@@ -139,6 +143,10 @@ pub struct ListProps<'a> {
     /// Use compact 26 px rows — no description or tile prefix support.
     /// Intended for navigation / category strips.
     pub compact: bool,
+    /// Cap the scroll area at this height (px) and scroll beyond it.
+    /// `None` (default) lets the list grow to fit all its content.
+    /// Pass `Some(h)` for large or lazily-loaded lists (e.g. search results).
+    pub max_height: Option<f32>,
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -192,10 +200,13 @@ impl StatelessComponent for List {
         // in the same parent UI get different scroll IDs and different item IDs.
         let scroll_id = ui.next_auto_id();
 
-        egui::ScrollArea::vertical()
+        let mut scroll = egui::ScrollArea::vertical()
             .id_salt(scroll_id)
-            .auto_shrink([false, props.shrink_to_fit])
-            .show_viewport(ui, |ui, viewport| {
+            .auto_shrink([false, props.shrink_to_fit]);
+        if let Some(h) = props.max_height {
+            scroll = scroll.max_height(h);
+        }
+        scroll.show_viewport(ui, |ui, viewport| {
                 ui.set_min_height(total_h);
 
                 let start = offsets
@@ -560,26 +571,24 @@ impl StatelessComponent for List {
                     // always renders behind badges, icons, and text.
                     let is_hovering = is_hovered || was_hovered;
                     let bg_shape = if item.selected && is_hovering {
-                        // Selected + hovered: slightly brighter than selected alone.
                         egui::Shape::rect_filled(row_resp.rect, 3.0, colors.surface_raised)
-                    } else if item.selected {
-                        egui::Shape::rect_filled(row_resp.rect, 3.0, colors.surface_active)
-                    } else if is_hovering {
-                        // Subtle hover — uses the theme's sidebar_hover token which is
-                        // a catppuccin overlay color at low alpha (~0x33).
+                    } else if item.selected || is_hovering {
                         egui::Shape::rect_filled(row_resp.rect, 3.0, colors.sidebar_hover)
                     } else {
                         egui::Shape::Noop
                     };
                     ui.painter().set(bg_slot, bg_shape);
 
-                    // Left accent border for selected non-compact rows.
-                    if item.selected && !compact {
+                    // Left accent border — driven by the `accent` prop, not `selected`,
+                    // so callers control both color and presence independently.
+                    if let Some(accent_color) = item.accent
+                        && !compact
+                    {
                         let border = egui::Rect::from_min_size(
                             row_resp.rect.min,
                             egui::vec2(2.0, row_resp.rect.height()),
                         );
-                        ui.painter().rect_filled(border, 0.0, colors.accent);
+                        ui.painter().rect_filled(border, 0.0, accent_color);
                     }
 
                     if postfix_btn_clicked {

--- a/src/components/common/typography.rs
+++ b/src/components/common/typography.rs
@@ -9,6 +9,9 @@ pub enum TypographyVariant {
     /// Sidebar panel section titles: 11 px · semi-bold · `sidebar_header`.
     /// Use for "SEARCH", "RECENT FILES", etc.
     PanelHeader,
+    /// Content-area section divider labels: 12 px · bold · `fg`.
+    /// Use for "Start", "Recent", "Tips" and other in-page section titles.
+    SectionHeader,
     /// Settings group card labels: 11 px · semi-bold · `fg_muted`.
     /// Use for group headings above setting cards.
     GroupLabel,
@@ -72,6 +75,7 @@ impl Typography {
     ) -> (f32, egui::Color32, bool, bool) {
         match variant {
             TypographyVariant::PanelHeader => (11.0, colors.sidebar_header, true, false),
+            TypographyVariant::SectionHeader => (12.0, colors.fg, true, false),
             TypographyVariant::GroupLabel => (11.0, colors.fg_muted, true, false),
             TypographyVariant::Title => (14.0, colors.fg, true, false),
             TypographyVariant::Heading => (16.0, colors.fg, true, false),

--- a/src/components/data_source_panel.rs
+++ b/src/components/data_source_panel.rs
@@ -88,11 +88,10 @@ impl StatefulComponent for DataSourcePanel {
 
         for evt in ui_events {
             // Track URL changes so QueryResult has a readable display_url.
-            if evt.widget_id == "url" && evt.kind == "change" {
-                if let Ok(url) = serde_json::from_str::<String>(&evt.value) {
+            if evt.widget_id == "url" && evt.kind == "change"
+                && let Ok(url) = serde_json::from_str::<String>(&evt.value) {
                     self.last_url = url;
                 }
-            }
 
             // Forward event to plugin; update cached tree on success.
             match self.loader.as_mut().unwrap().handle_event(evt.clone()) {

--- a/src/components/data_source_panel.rs
+++ b/src/components/data_source_panel.rs
@@ -88,10 +88,12 @@ impl StatefulComponent for DataSourcePanel {
 
         for evt in ui_events {
             // Track URL changes so QueryResult has a readable display_url.
-            if evt.widget_id == "url" && evt.kind == "change"
-                && let Ok(url) = serde_json::from_str::<String>(&evt.value) {
-                    self.last_url = url;
-                }
+            if evt.widget_id == "url"
+                && evt.kind == "change"
+                && let Ok(url) = serde_json::from_str::<String>(&evt.value)
+            {
+                self.last_url = url;
+            }
 
             // Forward event to plugin; update cached tree on success.
             match self.loader.as_mut().unwrap().handle_event(evt.clone()) {

--- a/src/components/drag_and_drop.rs
+++ b/src/components/drag_and_drop.rs
@@ -9,24 +9,22 @@ impl app::ThothApp {
             for file in &hovering_files {
                 if let Some(path) = &file.path {
                     use std::fmt::Write as _;
-                    if let Err(e) = write!(text, "\n{}", path.display()) {
-                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                    if let Err(e) = write!(text, "\n{}", path.display())
+                        && let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
                             tab.error = Some(crate::error::ThothError::UIRenderError {
                                 component: "DragAndDrop".to_string(),
                                 reason: format!("Failed to format file path: {e}"),
                             });
                         }
-                    }
                 } else if !file.mime.is_empty() {
                     use std::fmt::Write as _;
-                    if let Err(e) = write!(text, "\n{}", file.mime) {
-                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                    if let Err(e) = write!(text, "\n{}", file.mime)
+                        && let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
                             tab.error = Some(crate::error::ThothError::UIRenderError {
                                 component: "DragAndDrop".to_string(),
                                 reason: format!("Failed to format MIME type: {e}"),
                             });
                         }
-                    }
                 }
             }
 

--- a/src/components/drag_and_drop.rs
+++ b/src/components/drag_and_drop.rs
@@ -10,21 +10,23 @@ impl app::ThothApp {
                 if let Some(path) = &file.path {
                     use std::fmt::Write as _;
                     if let Err(e) = write!(text, "\n{}", path.display())
-                        && let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                            tab.error = Some(crate::error::ThothError::UIRenderError {
-                                component: "DragAndDrop".to_string(),
-                                reason: format!("Failed to format file path: {e}"),
-                            });
-                        }
+                        && let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                    {
+                        tab.error = Some(crate::error::ThothError::UIRenderError {
+                            component: "DragAndDrop".to_string(),
+                            reason: format!("Failed to format file path: {e}"),
+                        });
+                    }
                 } else if !file.mime.is_empty() {
                     use std::fmt::Write as _;
                     if let Err(e) = write!(text, "\n{}", file.mime)
-                        && let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                            tab.error = Some(crate::error::ThothError::UIRenderError {
-                                component: "DragAndDrop".to_string(),
-                                reason: format!("Failed to format MIME type: {e}"),
-                            });
-                        }
+                        && let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+                    {
+                        tab.error = Some(crate::error::ThothError::UIRenderError {
+                            component: "DragAndDrop".to_string(),
+                            reason: format!("Failed to format MIME type: {e}"),
+                        });
+                    }
                 }
             }
 
@@ -61,11 +63,10 @@ impl app::ThothApp {
                         }
                         Err(_) => {
                             if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                                tab.error =
-                                    Some(crate::error::ThothError::InvalidFileType {
-                                        path: path.clone(),
-                                        expected: "JSON or NDJSON".to_string(),
-                                    });
+                                tab.error = Some(crate::error::ThothError::InvalidFileType {
+                                    path: path.clone(),
+                                    expected: "JSON or NDJSON".to_string(),
+                                });
                             }
                         }
                     }

--- a/src/components/drag_and_drop.rs
+++ b/src/components/drag_and_drop.rs
@@ -1,13 +1,8 @@
-use crate::{
-    app,
-    file::{detect_file_type::sniff_file_type, lazy_loader::FileKind},
-};
-use eframe::egui::{self};
+use crate::{app, file::detect_file_type::sniff_file_type};
+use eframe::egui;
 
 impl app::ThothApp {
     pub fn handle_file_drop(&mut self, ctx: &egui::Context) {
-        // -------- Drag & Drop (hover preview + accept drop) --------
-        // Show overlay when hovering files
         let hovering_files = ctx.input(|i| i.raw.hovered_files.clone());
         if !hovering_files.is_empty() {
             let mut text = String::from("Drop file to open:\n");
@@ -15,18 +10,22 @@ impl app::ThothApp {
                 if let Some(path) = &file.path {
                     use std::fmt::Write as _;
                     if let Err(e) = write!(text, "\n{}", path.display()) {
-                        self.window_state.error = Some(crate::error::ThothError::UIRenderError {
-                            component: "DragAndDrop".to_string(),
-                            reason: format!("Failed to format file path: {e}"),
-                        });
+                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                            tab.error = Some(crate::error::ThothError::UIRenderError {
+                                component: "DragAndDrop".to_string(),
+                                reason: format!("Failed to format file path: {e}"),
+                            });
+                        }
                     }
                 } else if !file.mime.is_empty() {
                     use std::fmt::Write as _;
                     if let Err(e) = write!(text, "\n{}", file.mime) {
-                        self.window_state.error = Some(crate::error::ThothError::UIRenderError {
-                            component: "DragAndDrop".to_string(),
-                            reason: format!("Failed to format MIME type: {e}"),
-                        });
+                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                            tab.error = Some(crate::error::ThothError::UIRenderError {
+                                component: "DragAndDrop".to_string(),
+                                reason: format!("Failed to format MIME type: {e}"),
+                            });
+                        }
                     }
                 }
             }
@@ -46,28 +45,33 @@ impl app::ThothApp {
             );
         }
 
-        // Handle dropped files (take first valid JSON/NDJSON)
         let dropped_files = ctx.input(|i| i.raw.dropped_files.clone());
         if !dropped_files.is_empty() {
+            let nav_capacity = self.settings.performance.navigation_history_size;
             for file in dropped_files {
                 if let Some(path) = file.path {
                     match sniff_file_type(&path) {
                         Ok(detected) => {
+                            use crate::file::lazy_loader::FileKind;
                             let ft: FileKind = detected.into();
-                            self.window_state.file_type = ft;
-                            self.window_state.file_path = Some(path);
-                            self.window_state.error = None;
-                            self.window_state.toolbar.previous_file_type = ft;
+                            let id = self.window_state.tab_manager.open_file(path, nav_capacity);
+                            if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&id) {
+                                tab.file_type = ft;
+                                tab.error = None;
+                                self.window_state.toolbar.previous_file_type = ft;
+                            }
                         }
                         Err(_) => {
-                            self.window_state.error =
-                                Some(crate::error::ThothError::InvalidFileType {
-                                    path: path.clone(),
-                                    expected: "JSON or NDJSON".to_string(),
-                                });
+                            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                                tab.error =
+                                    Some(crate::error::ThothError::InvalidFileType {
+                                        path: path.clone(),
+                                        expected: "JSON or NDJSON".to_string(),
+                                    });
+                            }
                         }
                     }
-                    break; // only process first dropped file
+                    break;
                 }
             }
         }

--- a/src/components/drag_and_drop.rs
+++ b/src/components/drag_and_drop.rs
@@ -70,7 +70,6 @@ impl app::ThothApp {
                             }
                         }
                     }
-                    break;
                 }
             }
         }

--- a/src/components/file_viewer/json_tree_viewer.rs
+++ b/src/components/file_viewer/json_tree_viewer.rs
@@ -455,12 +455,14 @@ impl JsonTreeViewer {
         }
 
         // Set target row for search navigation (persists across frames)
-        if *should_scroll_to_selection && is_search_navigation
+        if *should_scroll_to_selection
+            && is_search_navigation
             && let Some(selected_path) = selected.as_ref()
-                && let Some(row_idx) = self.rows.iter().position(|r| r.path == *selected_path) {
-                    self.search_target_row = Some(row_idx);
-                    *should_scroll_to_selection = false;
-                }
+            && let Some(row_idx) = self.rows.iter().position(|r| r.path == *selected_path)
+        {
+            self.search_target_row = Some(row_idx);
+            *should_scroll_to_selection = false;
+        }
 
         let scroll_area = egui::ScrollArea::both()
             .auto_shrink([false, false])
@@ -477,18 +479,19 @@ impl JsonTreeViewer {
 
             // Handle keyboard navigation
             if let Some(selected_path) = selected.as_ref()
-                && let Some(row_idx) = self.rows.iter().position(|r| r.path == *selected_path) {
-                    // Only use scroll_to_selection for keyboard navigation (not search)
-                    if !is_search_navigation {
-                        scroll_to_selection(
-                            ui,
-                            &row_range,
-                            row_idx,
-                            row_height,
-                            should_scroll_to_selection,
-                        );
-                    }
+                && let Some(row_idx) = self.rows.iter().position(|r| r.path == *selected_path)
+            {
+                // Only use scroll_to_selection for keyboard navigation (not search)
+                if !is_search_navigation {
+                    scroll_to_selection(
+                        ui,
+                        &row_range,
+                        row_idx,
+                        row_height,
+                        should_scroll_to_selection,
+                    );
                 }
+            }
 
             // Get indent guide color from theme
             let guide_color = ui.ctx().memory(|mem| {
@@ -700,23 +703,24 @@ impl ContextMenuHandler for JsonTreeViewer {
         loader: &mut FileType,
     ) -> Option<String> {
         if let Some(path) = selected
-            && let Ok((root_idx, rel)) = split_root_rel(path) {
-                // Try to get from cache first
-                let value = if let Some(v) = cache.get(&root_idx) {
-                    v.clone()
-                } else {
-                    // Load from file
-                    match loader.get(root_idx) {
-                        Ok(v) => {
-                            cache.put(root_idx, v.clone());
-                            v
-                        }
-                        Err(_) => return None,
+            && let Ok((root_idx, rel)) = split_root_rel(path)
+        {
+            // Try to get from cache first
+            let value = if let Some(v) = cache.get(&root_idx) {
+                v.clone()
+            } else {
+                // Load from file
+                match loader.get(root_idx) {
+                    Ok(v) => {
+                        cache.put(root_idx, v.clone());
+                        v
                     }
-                };
+                    Err(_) => return None,
+                }
+            };
 
-                return get_object_string(value, rel).ok();
-            }
+            return get_object_string(value, rel).ok();
+        }
         None
     }
 

--- a/src/components/file_viewer/json_tree_viewer.rs
+++ b/src/components/file_viewer/json_tree_viewer.rs
@@ -455,14 +455,12 @@ impl JsonTreeViewer {
         }
 
         // Set target row for search navigation (persists across frames)
-        if *should_scroll_to_selection && is_search_navigation {
-            if let Some(selected_path) = selected.as_ref() {
-                if let Some(row_idx) = self.rows.iter().position(|r| r.path == *selected_path) {
+        if *should_scroll_to_selection && is_search_navigation
+            && let Some(selected_path) = selected.as_ref()
+                && let Some(row_idx) = self.rows.iter().position(|r| r.path == *selected_path) {
                     self.search_target_row = Some(row_idx);
                     *should_scroll_to_selection = false;
                 }
-            }
-        }
 
         let scroll_area = egui::ScrollArea::both()
             .auto_shrink([false, false])
@@ -478,8 +476,8 @@ impl JsonTreeViewer {
             }
 
             // Handle keyboard navigation
-            if let Some(selected_path) = selected.as_ref() {
-                if let Some(row_idx) = self.rows.iter().position(|r| r.path == *selected_path) {
+            if let Some(selected_path) = selected.as_ref()
+                && let Some(row_idx) = self.rows.iter().position(|r| r.path == *selected_path) {
                     // Only use scroll_to_selection for keyboard navigation (not search)
                     if !is_search_navigation {
                         scroll_to_selection(
@@ -491,7 +489,6 @@ impl JsonTreeViewer {
                         );
                     }
                 }
-            }
 
             // Get indent guide color from theme
             let guide_color = ui.ctx().memory(|mem| {
@@ -702,8 +699,8 @@ impl ContextMenuHandler for JsonTreeViewer {
         cache: &mut LruCache<usize, Value>,
         loader: &mut FileType,
     ) -> Option<String> {
-        if let Some(path) = selected {
-            if let Ok((root_idx, rel)) = split_root_rel(path) {
+        if let Some(path) = selected
+            && let Ok((root_idx, rel)) = split_root_rel(path) {
                 // Try to get from cache first
                 let value = if let Some(v) = cache.get(&root_idx) {
                     v.clone()
@@ -720,7 +717,6 @@ impl ContextMenuHandler for JsonTreeViewer {
 
                 return get_object_string(value, rel).ok();
             }
-        }
         None
     }
 

--- a/src/components/file_viewer/mod.rs
+++ b/src/components/file_viewer/mod.rs
@@ -166,17 +166,16 @@ impl FileViewer {
         // Delegate to the viewer's navigate_to_root implementation and rebuild if needed
         if let Some(viewer) = self.viewer.as_mut() {
             let needs_rebuild = viewer.as_viewer_mut().navigate_to_root(root_index);
-            if needs_rebuild
-                && let Some(loader) = self.loader.as_mut() {
-                    // Rebuild view immediately so rows are ready for scrolling
-                    let total_len = loader.len();
-                    viewer.as_viewer_mut().rebuild_view(
-                        &self.state.visible_roots,
-                        &mut self.cache,
-                        loader,
-                        total_len,
-                    );
-                }
+            if needs_rebuild && let Some(loader) = self.loader.as_mut() {
+                // Rebuild view immediately so rows are ready for scrolling
+                let total_len = loader.len();
+                viewer.as_viewer_mut().rebuild_view(
+                    &self.state.visible_roots,
+                    &mut self.cache,
+                    loader,
+                    total_len,
+                );
+            }
             return needs_rebuild;
         }
 
@@ -303,17 +302,16 @@ impl FileViewer {
     pub fn expand_selected_node(&mut self) -> bool {
         if let Some(viewer) = self.viewer.as_mut() {
             let result = viewer.as_viewer_mut().expand_selected(&self.state.selected);
-            if result
-                && let Some(loader) = self.loader.as_mut() {
-                    // Rebuild if needed
-                    let total_len = loader.len();
-                    viewer.as_viewer_mut().rebuild_view(
-                        &self.state.visible_roots,
-                        &mut self.cache,
-                        loader,
-                        total_len,
-                    );
-                }
+            if result && let Some(loader) = self.loader.as_mut() {
+                // Rebuild if needed
+                let total_len = loader.len();
+                viewer.as_viewer_mut().rebuild_view(
+                    &self.state.visible_roots,
+                    &mut self.cache,
+                    loader,
+                    total_len,
+                );
+            }
             return result;
         }
         false
@@ -326,17 +324,16 @@ impl FileViewer {
             let result = viewer
                 .as_viewer_mut()
                 .collapse_selected(&self.state.selected);
-            if result
-                && let Some(loader) = self.loader.as_mut() {
-                    // Rebuild if needed
-                    let total_len = loader.len();
-                    viewer.as_viewer_mut().rebuild_view(
-                        &self.state.visible_roots,
-                        &mut self.cache,
-                        loader,
-                        total_len,
-                    );
-                }
+            if result && let Some(loader) = self.loader.as_mut() {
+                // Rebuild if needed
+                let total_len = loader.len();
+                viewer.as_viewer_mut().rebuild_view(
+                    &self.state.visible_roots,
+                    &mut self.cache,
+                    loader,
+                    total_len,
+                );
+            }
             return result;
         }
         false
@@ -346,17 +343,16 @@ impl FileViewer {
     pub fn expand_all_nodes(&mut self) -> bool {
         if let Some(viewer) = self.viewer.as_mut() {
             let result = viewer.as_viewer_mut().expand_all();
-            if result
-                && let Some(loader) = self.loader.as_mut() {
-                    // Rebuild if needed
-                    let total_len = loader.len();
-                    viewer.as_viewer_mut().rebuild_view(
-                        &self.state.visible_roots,
-                        &mut self.cache,
-                        loader,
-                        total_len,
-                    );
-                }
+            if result && let Some(loader) = self.loader.as_mut() {
+                // Rebuild if needed
+                let total_len = loader.len();
+                viewer.as_viewer_mut().rebuild_view(
+                    &self.state.visible_roots,
+                    &mut self.cache,
+                    loader,
+                    total_len,
+                );
+            }
             return result;
         }
         false
@@ -366,17 +362,16 @@ impl FileViewer {
     pub fn collapse_all_nodes(&mut self) -> bool {
         if let Some(viewer) = self.viewer.as_mut() {
             let result = viewer.as_viewer_mut().collapse_all();
-            if result
-                && let Some(loader) = self.loader.as_mut() {
-                    // Rebuild if needed
-                    let total_len = loader.len();
-                    viewer.as_viewer_mut().rebuild_view(
-                        &self.state.visible_roots,
-                        &mut self.cache,
-                        loader,
-                        total_len,
-                    );
-                }
+            if result && let Some(loader) = self.loader.as_mut() {
+                // Rebuild if needed
+                let total_len = loader.len();
+                viewer.as_viewer_mut().rebuild_view(
+                    &self.state.visible_roots,
+                    &mut self.cache,
+                    loader,
+                    total_len,
+                );
+            }
             return result;
         }
         false
@@ -388,10 +383,10 @@ impl FileViewer {
             && let Some(new_selection) = viewer
                 .as_viewer_mut()
                 .move_selection_up(&self.state.selected)
-            {
-                self.state.selected = Some(new_selection);
-                self.state.should_scroll_to_selection = true;
-            }
+        {
+            self.state.selected = Some(new_selection);
+            self.state.should_scroll_to_selection = true;
+        }
     }
 
     /// Move selection down to next item (for keyboard shortcuts)
@@ -400,10 +395,10 @@ impl FileViewer {
             && let Some(new_selection) = viewer
                 .as_viewer_mut()
                 .move_selection_down(&self.state.selected)
-            {
-                self.state.selected = Some(new_selection);
-                self.state.should_scroll_to_selection = true;
-            }
+        {
+            self.state.selected = Some(new_selection);
+            self.state.should_scroll_to_selection = true;
+        }
     }
 
     // ========================================================================

--- a/src/components/file_viewer/mod.rs
+++ b/src/components/file_viewer/mod.rs
@@ -166,8 +166,8 @@ impl FileViewer {
         // Delegate to the viewer's navigate_to_root implementation and rebuild if needed
         if let Some(viewer) = self.viewer.as_mut() {
             let needs_rebuild = viewer.as_viewer_mut().navigate_to_root(root_index);
-            if needs_rebuild {
-                if let Some(loader) = self.loader.as_mut() {
+            if needs_rebuild
+                && let Some(loader) = self.loader.as_mut() {
                     // Rebuild view immediately so rows are ready for scrolling
                     let total_len = loader.len();
                     viewer.as_viewer_mut().rebuild_view(
@@ -177,7 +177,6 @@ impl FileViewer {
                         total_len,
                     );
                 }
-            }
             return needs_rebuild;
         }
 
@@ -304,8 +303,8 @@ impl FileViewer {
     pub fn expand_selected_node(&mut self) -> bool {
         if let Some(viewer) = self.viewer.as_mut() {
             let result = viewer.as_viewer_mut().expand_selected(&self.state.selected);
-            if result {
-                if let Some(loader) = self.loader.as_mut() {
+            if result
+                && let Some(loader) = self.loader.as_mut() {
                     // Rebuild if needed
                     let total_len = loader.len();
                     viewer.as_viewer_mut().rebuild_view(
@@ -315,7 +314,6 @@ impl FileViewer {
                         total_len,
                     );
                 }
-            }
             return result;
         }
         false
@@ -328,8 +326,8 @@ impl FileViewer {
             let result = viewer
                 .as_viewer_mut()
                 .collapse_selected(&self.state.selected);
-            if result {
-                if let Some(loader) = self.loader.as_mut() {
+            if result
+                && let Some(loader) = self.loader.as_mut() {
                     // Rebuild if needed
                     let total_len = loader.len();
                     viewer.as_viewer_mut().rebuild_view(
@@ -339,7 +337,6 @@ impl FileViewer {
                         total_len,
                     );
                 }
-            }
             return result;
         }
         false
@@ -349,8 +346,8 @@ impl FileViewer {
     pub fn expand_all_nodes(&mut self) -> bool {
         if let Some(viewer) = self.viewer.as_mut() {
             let result = viewer.as_viewer_mut().expand_all();
-            if result {
-                if let Some(loader) = self.loader.as_mut() {
+            if result
+                && let Some(loader) = self.loader.as_mut() {
                     // Rebuild if needed
                     let total_len = loader.len();
                     viewer.as_viewer_mut().rebuild_view(
@@ -360,7 +357,6 @@ impl FileViewer {
                         total_len,
                     );
                 }
-            }
             return result;
         }
         false
@@ -370,8 +366,8 @@ impl FileViewer {
     pub fn collapse_all_nodes(&mut self) -> bool {
         if let Some(viewer) = self.viewer.as_mut() {
             let result = viewer.as_viewer_mut().collapse_all();
-            if result {
-                if let Some(loader) = self.loader.as_mut() {
+            if result
+                && let Some(loader) = self.loader.as_mut() {
                     // Rebuild if needed
                     let total_len = loader.len();
                     viewer.as_viewer_mut().rebuild_view(
@@ -381,7 +377,6 @@ impl FileViewer {
                         total_len,
                     );
                 }
-            }
             return result;
         }
         false
@@ -389,28 +384,26 @@ impl FileViewer {
 
     /// Move selection up to previous item (for keyboard shortcuts)
     pub fn move_selection_up(&mut self) {
-        if let Some(viewer) = self.viewer.as_mut() {
-            if let Some(new_selection) = viewer
+        if let Some(viewer) = self.viewer.as_mut()
+            && let Some(new_selection) = viewer
                 .as_viewer_mut()
                 .move_selection_up(&self.state.selected)
             {
                 self.state.selected = Some(new_selection);
                 self.state.should_scroll_to_selection = true;
             }
-        }
     }
 
     /// Move selection down to next item (for keyboard shortcuts)
     pub fn move_selection_down(&mut self) {
-        if let Some(viewer) = self.viewer.as_mut() {
-            if let Some(new_selection) = viewer
+        if let Some(viewer) = self.viewer.as_mut()
+            && let Some(new_selection) = viewer
                 .as_viewer_mut()
                 .move_selection_down(&self.state.selected)
             {
                 self.state.selected = Some(new_selection);
                 self.state.should_scroll_to_selection = true;
             }
-        }
     }
 
     // ========================================================================

--- a/src/components/file_viewer/plugin_table_viewer.rs
+++ b/src/components/file_viewer/plugin_table_viewer.rs
@@ -58,11 +58,12 @@ impl FileFormatViewer for PluginTableViewer {
                 // Plugin didn't provide headers — derive them from the keys of
                 // the first record so the table has something to render.
                 if let Ok(first) = loader.get(0)
-                    && let Some(obj) = first.as_object() {
-                        let mut keys: Vec<String> = obj.keys().cloned().collect();
-                        keys.sort(); // deterministic column order
-                        self.headers = keys;
-                    }
+                    && let Some(obj) = first.as_object()
+                {
+                    let mut keys: Vec<String> = obj.keys().cloned().collect();
+                    keys.sort(); // deterministic column order
+                    self.headers = keys;
+                }
             }
         }
 

--- a/src/components/file_viewer/plugin_table_viewer.rs
+++ b/src/components/file_viewer/plugin_table_viewer.rs
@@ -57,13 +57,12 @@ impl FileFormatViewer for PluginTableViewer {
             } else if total_len > 0 {
                 // Plugin didn't provide headers — derive them from the keys of
                 // the first record so the table has something to render.
-                if let Ok(first) = loader.get(0) {
-                    if let Some(obj) = first.as_object() {
+                if let Ok(first) = loader.get(0)
+                    && let Some(obj) = first.as_object() {
                         let mut keys: Vec<String> = obj.keys().cloned().collect();
                         keys.sort(); // deterministic column order
                         self.headers = keys;
                     }
-                }
             }
         }
 

--- a/src/components/marketplace/list.rs
+++ b/src/components/marketplace/list.rs
@@ -229,9 +229,10 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
     );
 
     if let Some(idx) = cat_out.row_clicked
-        && let Some(cat) = cat_defs.get(idx) {
-            state.selected_category = cat.id.clone();
-        }
+        && let Some(cat) = cat_defs.get(idx)
+    {
+        state.selected_category = cat.id.clone();
+    }
 
     ui.separator();
 
@@ -409,35 +410,37 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
     );
 
     if let Some(idx) = list_output.row_clicked
-        && let Some(row) = rows.get(idx) {
-            state.selected_id = Some(row.id.clone());
-        }
+        && let Some(row) = rows.get(idx)
+    {
+        state.selected_id = Some(row.id.clone());
+    }
 
     if let Some(item_idx) = list_output.postfix_clicked
-        && let Some(row) = rows.get(item_idx) {
-            state.selected_id = Some(row.id.clone());
-            match &row.install_state {
-                InstallState::NotInstalled | InstallState::Update => {
-                    if let Some(plugin) = state.plugins.iter().find(|p| p.id == row.id) {
-                        let slot = plugin.download_and_install(ui.ctx().clone());
-                        state.install_handles.insert(row.id.clone(), slot);
-                        state
-                            .install_states
-                            .insert(row.id.clone(), InstallState::Installing(0));
-                    }
-                }
-                InstallState::Disabled => {
+        && let Some(row) = rows.get(item_idx)
+    {
+        state.selected_id = Some(row.id.clone());
+        match &row.install_state {
+            InstallState::NotInstalled | InstallState::Update => {
+                if let Some(plugin) = state.plugins.iter().find(|p| p.id == row.id) {
+                    let slot = plugin.download_and_install(ui.ctx().clone());
+                    state.install_handles.insert(row.id.clone(), slot);
                     state
                         .install_states
-                        .insert(row.id.clone(), InstallState::Installed);
+                        .insert(row.id.clone(), InstallState::Installing(0));
                 }
-                InstallState::Failed(_) | InstallState::Installing(_) => {
-                    state.install_handles.remove(&row.id);
-                    state.install_states.remove(&row.id);
-                }
-                _ => {}
             }
+            InstallState::Disabled => {
+                state
+                    .install_states
+                    .insert(row.id.clone(), InstallState::Installed);
+            }
+            InstallState::Failed(_) | InstallState::Installing(_) => {
+                state.install_handles.remove(&row.id);
+                state.install_states.remove(&row.id);
+            }
+            _ => {}
         }
+    }
 }
 
 pub(super) fn count_filtered(state: &MarketplaceUiState) -> usize {

--- a/src/components/marketplace/list.rs
+++ b/src/components/marketplace/list.rs
@@ -226,11 +226,10 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
         },
     );
 
-    if let Some(idx) = cat_out.row_clicked {
-        if let Some(cat) = cat_defs.get(idx) {
+    if let Some(idx) = cat_out.row_clicked
+        && let Some(cat) = cat_defs.get(idx) {
             state.selected_category = cat.id.clone();
         }
-    }
 
     ui.separator();
 
@@ -405,14 +404,13 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
         },
     );
 
-    if let Some(idx) = list_output.row_clicked {
-        if let Some(row) = rows.get(idx) {
+    if let Some(idx) = list_output.row_clicked
+        && let Some(row) = rows.get(idx) {
             state.selected_id = Some(row.id.clone());
         }
-    }
 
-    if let Some(item_idx) = list_output.postfix_clicked {
-        if let Some(row) = rows.get(item_idx) {
+    if let Some(item_idx) = list_output.postfix_clicked
+        && let Some(row) = rows.get(item_idx) {
             state.selected_id = Some(row.id.clone());
             match &row.install_state {
                 InstallState::NotInstalled | InstallState::Update => {
@@ -436,7 +434,6 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                 _ => {}
             }
         }
-    }
 }
 
 pub(super) fn count_filtered(state: &MarketplaceUiState) -> usize {

--- a/src/components/marketplace/list.rs
+++ b/src/components/marketplace/list.rs
@@ -210,6 +210,7 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                     None
                 },
                 selected: is_active,
+                accent: None,
                 tags: &[],
             }
         })
@@ -223,6 +224,7 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
             shrink_to_fit: true,
             show_separators: false,
             compact: true,
+            max_height: None,
         },
     );
 
@@ -388,6 +390,7 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                 badge: None,
                 postfix,
                 selected: row.is_selected,
+                accent: None,
                 tags: &row.tag_labels,
             }
         })
@@ -401,6 +404,7 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
             shrink_to_fit: false,
             show_separators: true,
             compact: false,
+            max_height: None,
         },
     );
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -30,4 +30,5 @@ pub mod settings_dialog;
 pub mod sidebar;
 pub mod status_bar;
 pub mod toolbar;
+pub mod update_consent_modal;
 pub mod welcome;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -30,3 +30,4 @@ pub mod settings_dialog;
 pub mod sidebar;
 pub mod status_bar;
 pub mod toolbar;
+pub mod welcome;

--- a/src/components/recent_files.rs
+++ b/src/components/recent_files.rs
@@ -75,6 +75,7 @@ impl StatefulComponent for RecentFiles {
                                 selected: false,
                             })),
                             selected: false,
+                            accent: None,
                         }
                     })
                     .collect();
@@ -87,6 +88,7 @@ impl StatefulComponent for RecentFiles {
                         shrink_to_fit: false,
                         show_separators: true,
                         compact: false,
+                        max_height: None,
                     },
                 );
 

--- a/src/components/recent_files.rs
+++ b/src/components/recent_files.rs
@@ -90,17 +90,15 @@ impl StatefulComponent for RecentFiles {
                     },
                 );
 
-                if let Some(item_idx) = output.postfix_clicked {
-                    if let Some(path) = props.recent_files.get(item_idx) {
+                if let Some(item_idx) = output.postfix_clicked
+                    && let Some(path) = props.recent_files.get(item_idx) {
                         events.push(RecentFilesEvent::RemoveFile(path.clone()));
                     }
-                }
 
-                if let Some(item_idx) = output.row_clicked {
-                    if let Some(path) = props.recent_files.get(item_idx) {
+                if let Some(item_idx) = output.row_clicked
+                    && let Some(path) = props.recent_files.get(item_idx) {
                         events.push(RecentFilesEvent::OpenFile(path.clone()));
                     }
-                }
                 ui.add_space(8.0);
 
                 let button_response = Button::render(

--- a/src/components/recent_files.rs
+++ b/src/components/recent_files.rs
@@ -93,14 +93,16 @@ impl StatefulComponent for RecentFiles {
                 );
 
                 if let Some(item_idx) = output.postfix_clicked
-                    && let Some(path) = props.recent_files.get(item_idx) {
-                        events.push(RecentFilesEvent::RemoveFile(path.clone()));
-                    }
+                    && let Some(path) = props.recent_files.get(item_idx)
+                {
+                    events.push(RecentFilesEvent::RemoveFile(path.clone()));
+                }
 
                 if let Some(item_idx) = output.row_clicked
-                    && let Some(path) = props.recent_files.get(item_idx) {
-                        events.push(RecentFilesEvent::OpenFile(path.clone()));
-                    }
+                    && let Some(path) = props.recent_files.get(item_idx)
+                {
+                    events.push(RecentFilesEvent::OpenFile(path.clone()));
+                }
                 ui.add_space(8.0);
 
                 let button_response = Button::render(

--- a/src/components/search.rs
+++ b/src/components/search.rs
@@ -172,8 +172,8 @@ impl StatefulComponent for Search {
         ui.add_space(8.0);
 
         // Display search history if no active search and history exists
-        if props.search_state.query.is_empty() {
-            if let Some(history) = props.search_history {
+        if props.search_state.query.is_empty()
+            && let Some(history) = props.search_history {
                 let queries: Vec<String> = history
                     .iter()
                     .map(|e| decode_history_entry(e).1)
@@ -234,8 +234,8 @@ impl StatefulComponent for Search {
                         },
                     );
 
-                    if let Some(idx) = output.row_clicked {
-                        if let Some(q) = queries.get(idx) {
+                    if let Some(idx) = output.row_clicked
+                        && let Some(q) = queries.get(idx) {
                             self.search_query = q.clone();
                             let query_mode = detect_query_mode(q);
                             if let Some(msg) =
@@ -244,10 +244,8 @@ impl StatefulComponent for Search {
                                 events.push(SearchEvent::Search(msg));
                             }
                         }
-                    }
                 }
             }
-        }
 
         ui.separator();
         ui.add_space(8.0);
@@ -314,13 +312,12 @@ impl StatefulComponent for Search {
                                 compact: false,
                             },
                         );
-                        if let Some(idx) = output.row_clicked {
-                            if let Some(hit) = props.search_state.results.hits().get(idx) {
+                        if let Some(idx) = output.row_clicked
+                            && let Some(hit) = props.search_state.results.hits().get(idx) {
                                 events.push(SearchEvent::NavigateToResult {
                                     record_index: hit.record_index,
                                 });
                             }
-                        }
                     });
             } else {
                 Typography::body_muted(ui, "No results found");

--- a/src/components/search.rs
+++ b/src/components/search.rs
@@ -173,81 +173,83 @@ impl StatefulComponent for Search {
 
         // Display search history if no active search and history exists
         if props.search_state.query.is_empty()
-            && let Some(history) = props.search_history {
-                let queries: Vec<String> = history
+            && let Some(history) = props.search_history
+        {
+            let queries: Vec<String> = history
+                .iter()
+                .map(|e| decode_history_entry(e).1)
+                .filter(|q| !q.trim().is_empty())
+                .collect();
+
+            if !queries.is_empty() {
+                ui.separator();
+                ui.add_space(8.0);
+
+                ui.horizontal(|ui| {
+                    Typography::panel_header(ui, "RECENT SEARCHES");
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let clear_output = IconButton::render(
+                            ui,
+                            IconButtonProps {
+                                icon: egui_phosphor::regular::X,
+                                frame: false,
+                                tooltip: Some("Clear search history"),
+                                badge_color: None,
+                                size: Some(egui::vec2(16.0, 16.0)),
+                                disabled: false,
+                                icon_size: None,
+                                selected: false,
+                            },
+                        );
+                        if clear_output.clicked {
+                            events.push(SearchEvent::ClearHistory);
+                        }
+                    });
+                });
+                ui.add_space(4.0);
+
+                let items: Vec<ListItem<'_>> = queries
                     .iter()
-                    .map(|e| decode_history_entry(e).1)
-                    .filter(|q| !q.trim().is_empty())
+                    .map(|q| ListItem {
+                        title: q.as_str(),
+                        description: None,
+                        prefix: Some(crate::components::common::list::ListItemPrefix::Icon {
+                            glyph: egui_phosphor::regular::CLOCK_COUNTER_CLOCKWISE,
+                            color: None,
+                        }),
+                        badge: None,
+                        postfix: None,
+                        selected: false,
+                        accent: None,
+                        tags: &[],
+                    })
                     .collect();
 
-                if !queries.is_empty() {
-                    ui.separator();
-                    ui.add_space(8.0);
+                let output = List::render(
+                    ui,
+                    ListProps {
+                        items: &items,
+                        empty_label: None,
+                        shrink_to_fit: false,
+                        show_separators: true,
+                        compact: false,
+                        max_height: Some(300.0),
+                    },
+                );
 
-                    ui.horizontal(|ui| {
-                        Typography::panel_header(ui, "RECENT SEARCHES");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            let clear_output = IconButton::render(
-                                ui,
-                                IconButtonProps {
-                                    icon: egui_phosphor::regular::X,
-                                    frame: false,
-                                    tooltip: Some("Clear search history"),
-                                    badge_color: None,
-                                    size: Some(egui::vec2(16.0, 16.0)),
-                                    disabled: false,
-                                    icon_size: None,
-                                    selected: false,
-                                },
-                            );
-                            if clear_output.clicked {
-                                events.push(SearchEvent::ClearHistory);
-                            }
-                        });
-                    });
-                    ui.add_space(4.0);
-
-                    let items: Vec<ListItem<'_>> = queries
-                        .iter()
-                        .map(|q| ListItem {
-                            title: q.as_str(),
-                            description: None,
-                            prefix: Some(crate::components::common::list::ListItemPrefix::Icon {
-                                glyph: egui_phosphor::regular::CLOCK_COUNTER_CLOCKWISE,
-                                color: None,
-                            }),
-                            badge: None,
-                            postfix: None,
-                            selected: false,
-                            accent: None,
-                            tags: &[],
-                        })
-                        .collect();
-
-                    let output = List::render(
-                        ui,
-                        ListProps {
-                            items: &items,
-                            empty_label: None,
-                            shrink_to_fit: false,
-                            show_separators: true,
-                            compact: false,
-                            max_height: Some(300.0),
-                        },
-                    );
-
-                    if let Some(idx) = output.row_clicked
-                        && let Some(q) = queries.get(idx) {
-                            self.search_query = q.clone();
-                            let query_mode = detect_query_mode(q);
-                            if let Some(msg) =
-                                SearchMessage::create_search(q.clone(), self.match_case, query_mode)
-                            {
-                                events.push(SearchEvent::Search(msg));
-                            }
-                        }
+                if let Some(idx) = output.row_clicked
+                    && let Some(q) = queries.get(idx)
+                {
+                    self.search_query = q.clone();
+                    let query_mode = detect_query_mode(q);
+                    if let Some(msg) =
+                        SearchMessage::create_search(q.clone(), self.match_case, query_mode)
+                    {
+                        events.push(SearchEvent::Search(msg));
+                    }
                 }
             }
+        }
 
         ui.separator();
         ui.add_space(8.0);
@@ -317,11 +319,12 @@ impl StatefulComponent for Search {
                             },
                         );
                         if let Some(idx) = output.row_clicked
-                            && let Some(hit) = props.search_state.results.hits().get(idx) {
-                                events.push(SearchEvent::NavigateToResult {
-                                    record_index: hit.record_index,
-                                });
-                            }
+                            && let Some(hit) = props.search_state.results.hits().get(idx)
+                        {
+                            events.push(SearchEvent::NavigateToResult {
+                                record_index: hit.record_index,
+                            });
+                        }
                     });
             } else {
                 Typography::body_muted(ui, "No results found");

--- a/src/components/search.rs
+++ b/src/components/search.rs
@@ -219,6 +219,7 @@ impl StatefulComponent for Search {
                             badge: None,
                             postfix: None,
                             selected: false,
+                            accent: None,
                             tags: &[],
                         })
                         .collect();
@@ -231,6 +232,7 @@ impl StatefulComponent for Search {
                             shrink_to_fit: false,
                             show_separators: true,
                             compact: false,
+                            max_height: Some(300.0),
                         },
                     );
 
@@ -294,6 +296,7 @@ impl StatefulComponent for Search {
                         badge: None,
                         postfix: None,
                         selected: false,
+                        accent: None,
                         tags: &[],
                     })
                     .collect();
@@ -310,6 +313,7 @@ impl StatefulComponent for Search {
                                 shrink_to_fit: false,
                                 show_separators: true,
                                 compact: false,
+                                max_height: Some(300.0),
                             },
                         );
                         if let Some(idx) = output.row_clicked

--- a/src/components/settings_dialog/advanced.rs
+++ b/src/components/settings_dialog/advanced.rs
@@ -112,9 +112,10 @@ impl StatelessComponent for AdvancedTab {
                                 },
                             )
                             .clicked
-                                && let Ok(path) = crate::settings::Settings::settings_file_path() {
-                                    let _ = open::that(path);
-                                }
+                                && let Ok(path) = crate::settings::Settings::settings_file_path()
+                            {
+                                let _ = open::that(path);
+                            }
                         },
                     );
                 });

--- a/src/components/settings_dialog/advanced.rs
+++ b/src/components/settings_dialog/advanced.rs
@@ -112,11 +112,9 @@ impl StatelessComponent for AdvancedTab {
                                 },
                             )
                             .clicked
-                            {
-                                if let Ok(path) = crate::settings::Settings::settings_file_path() {
+                                && let Ok(path) = crate::settings::Settings::settings_file_path() {
                                     let _ = open::that(path);
                                 }
-                            }
                         },
                     );
                 });

--- a/src/components/settings_dialog/mod.rs
+++ b/src/components/settings_dialog/mod.rs
@@ -395,12 +395,13 @@ impl SettingsDialog {
                                     let path = std::path::Path::new(&location);
                                     if let Some(dir) = path.parent()
                                         && dir.exists()
-                                            && let Err(e) = std::fs::remove_dir_all(dir) {
-                                                eprintln!(
-                                                    "Failed to remove plugin directory {}: {e}",
-                                                    dir.display()
-                                                );
-                                            }
+                                        && let Err(e) = std::fs::remove_dir_all(dir)
+                                    {
+                                        eprintln!(
+                                            "Failed to remove plugin directory {}: {e}",
+                                            dir.display()
+                                        );
+                                    }
                                 }
                                 settings.plugins.disabled_plugin_ids.retain(|x| x != &id);
                             }
@@ -769,14 +770,15 @@ impl ContextComponent for SettingsDialog {
                                         },
                                     );
                                     if save_btn.clicked
-                                        && let Ok(settings) = draft_settings.lock() {
-                                            new_settings = Some(settings.clone());
-                                            NotificationManager::notify(
-                                                Notification::new("Setting saved.", "")
-                                                    .with_toast(true)
-                                                    .with_status(NotificationStatus::Completed),
-                                            );
-                                        }
+                                        && let Ok(settings) = draft_settings.lock()
+                                    {
+                                        new_settings = Some(settings.clone());
+                                        NotificationManager::notify(
+                                            Notification::new("Setting saved.", "")
+                                                .with_toast(true)
+                                                .with_status(NotificationStatus::Completed),
+                                        );
+                                    }
 
                                     ui.add_space(8.0);
 
@@ -815,9 +817,9 @@ impl ContextComponent for SettingsDialog {
                                         if reset_btn.clicked
                                             && let (Ok(mut draft), Ok(tab)) =
                                                 (draft_settings.lock(), selected_tab.lock())
-                                            {
-                                                reset_section(*tab, &mut draft);
-                                            }
+                                        {
+                                            reset_section(*tab, &mut draft);
+                                        }
                                     }
                                 },
                             );
@@ -924,9 +926,9 @@ impl ContextComponent for SettingsDialog {
                                     if btn.clicked
                                         && let Ok(path) =
                                             crate::settings::Settings::settings_file_path()
-                                        {
-                                            let _ = open::that(path);
-                                        }
+                                    {
+                                        let _ = open::that(path);
+                                    }
                                     btn.response.on_hover_text(
                                         crate::settings::Settings::settings_file_path()
                                             .map(|p| p.to_string_lossy().to_string())
@@ -1048,9 +1050,10 @@ impl ContextComponent for SettingsDialog {
                                         ctx.set_cursor_icon(egui::CursorIcon::PointingHand);
                                     }
                                     if resp.clicked()
-                                        && let Ok(mut t) = selected_tab.lock() {
-                                            *t = tab;
-                                        }
+                                        && let Ok(mut t) = selected_tab.lock()
+                                    {
+                                        *t = tab;
+                                    }
                                 }
                             });
                     });
@@ -1098,15 +1101,16 @@ impl ContextComponent for SettingsDialog {
         let mut collected_events = Vec::new();
 
         if let Ok(mut closed) = self.viewport_closed.lock()
-            && *closed {
-                self.open = false;
-                *closed = false; // Reset for next time
+            && *closed
+        {
+            self.open = false;
+            *closed = false; // Reset for next time
 
-                // Check if Apply was clicked (result will be Some)
-                if let Ok(mut viewport_result) = self.viewport_result.lock() {
-                    result = viewport_result.take();
-                }
+            // Check if Apply was clicked (result will be Some)
+            if let Ok(mut viewport_result) = self.viewport_result.lock() {
+                result = viewport_result.take();
             }
+        }
 
         // Collect any events that were generated
         if let Ok(mut events) = self.viewport_events.lock() {

--- a/src/components/settings_dialog/mod.rs
+++ b/src/components/settings_dialog/mod.rs
@@ -393,16 +393,14 @@ impl SettingsDialog {
                                     pm.registry.get_by_id(&id).and_then(|p| p.location.clone());
                                 if let Some(location) = wasm_path {
                                     let path = std::path::Path::new(&location);
-                                    if let Some(dir) = path.parent() {
-                                        if dir.exists() {
-                                            if let Err(e) = std::fs::remove_dir_all(dir) {
+                                    if let Some(dir) = path.parent()
+                                        && dir.exists()
+                                            && let Err(e) = std::fs::remove_dir_all(dir) {
                                                 eprintln!(
                                                     "Failed to remove plugin directory {}: {e}",
                                                     dir.display()
                                                 );
                                             }
-                                        }
-                                    }
                                 }
                                 settings.plugins.disabled_plugin_ids.retain(|x| x != &id);
                             }
@@ -770,8 +768,8 @@ impl ContextComponent for SettingsDialog {
                                             ..Default::default()
                                         },
                                     );
-                                    if save_btn.clicked {
-                                        if let Ok(settings) = draft_settings.lock() {
+                                    if save_btn.clicked
+                                        && let Ok(settings) = draft_settings.lock() {
                                             new_settings = Some(settings.clone());
                                             NotificationManager::notify(
                                                 Notification::new("Setting saved.", "")
@@ -779,7 +777,6 @@ impl ContextComponent for SettingsDialog {
                                                     .with_status(NotificationStatus::Completed),
                                             );
                                         }
-                                    }
 
                                     ui.add_space(8.0);
 
@@ -815,13 +812,12 @@ impl ContextComponent for SettingsDialog {
                                                 ..Default::default()
                                             },
                                         );
-                                        if reset_btn.clicked {
-                                            if let (Ok(mut draft), Ok(tab)) =
+                                        if reset_btn.clicked
+                                            && let (Ok(mut draft), Ok(tab)) =
                                                 (draft_settings.lock(), selected_tab.lock())
                                             {
                                                 reset_section(*tab, &mut draft);
                                             }
-                                        }
                                     }
                                 },
                             );
@@ -925,13 +921,12 @@ impl ContextComponent for SettingsDialog {
                                             ..Default::default()
                                         },
                                     );
-                                    if btn.clicked {
-                                        if let Ok(path) =
+                                    if btn.clicked
+                                        && let Ok(path) =
                                             crate::settings::Settings::settings_file_path()
                                         {
                                             let _ = open::that(path);
                                         }
-                                    }
                                     btn.response.on_hover_text(
                                         crate::settings::Settings::settings_file_path()
                                             .map(|p| p.to_string_lossy().to_string())
@@ -1052,11 +1047,10 @@ impl ContextComponent for SettingsDialog {
                                     if resp.hovered() {
                                         ctx.set_cursor_icon(egui::CursorIcon::PointingHand);
                                     }
-                                    if resp.clicked() {
-                                        if let Ok(mut t) = selected_tab.lock() {
+                                    if resp.clicked()
+                                        && let Ok(mut t) = selected_tab.lock() {
                                             *t = tab;
                                         }
-                                    }
                                 }
                             });
                     });
@@ -1103,8 +1097,8 @@ impl ContextComponent for SettingsDialog {
         let mut result = None;
         let mut collected_events = Vec::new();
 
-        if let Ok(mut closed) = self.viewport_closed.lock() {
-            if *closed {
+        if let Ok(mut closed) = self.viewport_closed.lock()
+            && *closed {
                 self.open = false;
                 *closed = false; // Reset for next time
 
@@ -1113,7 +1107,6 @@ impl ContextComponent for SettingsDialog {
                     result = viewport_result.take();
                 }
             }
-        }
 
         // Collect any events that were generated
         if let Ok(mut events) = self.viewport_events.lock() {

--- a/src/components/settings_dialog/plugins.rs
+++ b/src/components/settings_dialog/plugins.rs
@@ -590,15 +590,13 @@ impl PluginsTab {
                 },
             )
             .changed
-            {
-                if let Ok(value) = rate_limit_text.parse::<u32>() {
+                && let Ok(value) = rate_limit_text.parse::<u32>() {
                     policy.rate_limit_rpm = value;
                     events.push(PluginsTabEvent::UpdateNetworkPolicy {
                         plugin_id: plugin.id.clone(),
                         policy: policy.clone(),
                     });
                 }
-            }
             ui.add_space(8.0);
 
             ui.group(|ui| {

--- a/src/components/settings_dialog/shortcuts.rs
+++ b/src/components/settings_dialog/shortcuts.rs
@@ -32,8 +32,11 @@ impl StatelessComponent for ShortcutsTab {
             let font_id = egui::FontId::proportional(12.0);
             let all: &[&Shortcut] = &[
                 &sc.open_file,
-                &sc.clear_file,
                 &sc.new_window,
+                &sc.close_tab,
+                &sc.new_tab,
+                &sc.next_tab,
+                &sc.prev_tab,
                 &sc.focus_search,
                 &sc.next_match,
                 &sc.prev_match,
@@ -87,8 +90,16 @@ impl StatelessComponent for ShortcutsTab {
                 // ── File ────────────────────────────────────────────────────
                 group_rows(ui, "FILE", "sc-file", colors, |ui| {
                     shortcut_row(ui, "Open file", &sc.open_file, badge_width, colors);
-                    shortcut_row(ui, "Close file", &sc.clear_file, badge_width, colors);
                     shortcut_row(ui, "New window", &sc.new_window, badge_width, colors);
+                });
+
+                // ── Tabs ─────────────────────────────────────────────────────
+                group_rows(ui, "TABS", "sc-tabs", colors, |ui| {
+                    shortcut_row(ui, "New tab", &sc.new_tab, badge_width, colors);
+                    shortcut_row(ui, "Close tab", &sc.close_tab, badge_width, colors);
+                    shortcut_row(ui, "Next tab", &sc.next_tab, badge_width, colors);
+                    shortcut_row(ui, "Previous tab", &sc.prev_tab, badge_width, colors);
+                    static_shortcut_row(ui, "Switch to tab 1–9", "⌘1 – ⌘9", badge_width, colors);
                 });
 
                 // ── Navigation ───────────────────────────────────────────────
@@ -175,6 +186,19 @@ fn shortcut_row(
 ) {
     setting_row(ui, label, None, false, None, colors, |ui| {
         kbd_badge(ui, &shortcut.format(), badge_width, colors);
+    });
+}
+
+/// Render a shortcut row with a literal string badge (for hardcoded shortcuts like ⌘1–9).
+fn static_shortcut_row(
+    ui: &mut egui::Ui,
+    label: &str,
+    text: &str,
+    badge_width: f32,
+    colors: &ThemeColors,
+) {
+    setting_row(ui, label, None, false, None, colors, |ui| {
+        kbd_badge(ui, text, badge_width, colors);
     });
 }
 

--- a/src/components/settings_dialog/shortcuts.rs
+++ b/src/components/settings_dialog/shortcuts.rs
@@ -99,7 +99,17 @@ impl StatelessComponent for ShortcutsTab {
                     shortcut_row(ui, "Close tab", &sc.close_tab, badge_width, colors);
                     shortcut_row(ui, "Next tab", &sc.next_tab, badge_width, colors);
                     shortcut_row(ui, "Previous tab", &sc.prev_tab, badge_width, colors);
-                    static_shortcut_row(ui, "Switch to tab 1–9", "⌘1 – ⌘9", badge_width, colors);
+                    static_shortcut_row(
+                        ui,
+                        "Switch to tab 1–9",
+                        if cfg!(target_os = "macos") {
+                            "⌘1 – ⌘9"
+                        } else {
+                            "Ctrl+1 – Ctrl+9"
+                        },
+                        badge_width,
+                        colors,
+                    );
                 });
 
                 // ── Navigation ───────────────────────────────────────────────

--- a/src/components/sidebar.rs
+++ b/src/components/sidebar.rs
@@ -93,6 +93,7 @@ pub enum SidebarEvent {
     DataSourceLoading(bool),
     /// A widget interaction from the plugin's sidebar panel.
     PluginSidebarEvent(crate::plugin::render_node::UiEvent),
+    OpenSettings,
 }
 
 pub struct SidebarOutput {
@@ -342,6 +343,24 @@ impl Sidebar {
             {
                 events.push(SidebarEvent::SectionToggled(section));
             }
+        }
+
+        // Settings icon pinned to the bottom of the icon strip
+        let remaining = ui.available_height();
+        if remaining > button_size.y {
+            ui.add_space(remaining - button_size.y);
+        }
+        if IconButton::render(
+            ui,
+            sidebar_btn(
+                egui_phosphor::regular::GEAR,
+                "Settings",
+                false,
+            ),
+        )
+        .clicked
+        {
+            events.push(SidebarEvent::OpenSettings);
         }
     }
 

--- a/src/components/sidebar.rs
+++ b/src/components/sidebar.rs
@@ -352,11 +352,7 @@ impl Sidebar {
         }
         if IconButton::render(
             ui,
-            sidebar_btn(
-                egui_phosphor::regular::GEAR,
-                "Settings",
-                false,
-            ),
+            sidebar_btn(egui_phosphor::regular::GEAR, "Settings", false),
         )
         .clicked
         {

--- a/src/components/sidebar.rs
+++ b/src/components/sidebar.rs
@@ -317,39 +317,43 @@ impl Sidebar {
             events.push(SidebarEvent::SectionToggled(SidebarSection::MarketPlace));
         }
 
-        for plugin in props.data_source_plugins {
-            let section = SidebarSection::DataSource {
-                plugin_id: plugin.id.clone(),
-            };
-            let selected = props.active_datasource_plugin_id == Some(plugin.id.as_str());
-            let icon = plugin
-                .icon
-                .as_deref()
-                .unwrap_or(egui_phosphor::regular::DATABASE);
-            if IconButton::render(
-                ui,
-                IconButtonProps {
-                    icon,
-                    tooltip: Some(plugin.name.as_str()),
-                    size: Some(button_size),
-                    icon_size: Some(20.0),
-                    selected,
-                    frame: false,
-                    badge_color: None,
-                    disabled: false,
-                },
-            )
-            .clicked
-            {
-                events.push(SidebarEvent::SectionToggled(section));
-            }
-        }
+        // Plugin icons in a scroll area capped to leave room for the settings button,
+        // so settings is never pushed off screen regardless of how many plugins exist.
+        let plugins_max_h = (ui.available_height() - button_size.y).max(0.0);
+        egui::ScrollArea::vertical()
+            .id_salt("sidebar_plugin_icons")
+            .max_height(plugins_max_h)
+            .show(ui, |ui| {
+                for plugin in props.data_source_plugins {
+                    let section = SidebarSection::DataSource {
+                        plugin_id: plugin.id.clone(),
+                    };
+                    let selected = props.active_datasource_plugin_id == Some(plugin.id.as_str());
+                    let icon = plugin
+                        .icon
+                        .as_deref()
+                        .unwrap_or(egui_phosphor::regular::DATABASE);
+                    if IconButton::render(
+                        ui,
+                        IconButtonProps {
+                            icon,
+                            tooltip: Some(plugin.name.as_str()),
+                            size: Some(button_size),
+                            icon_size: Some(20.0),
+                            selected,
+                            frame: false,
+                            badge_color: None,
+                            disabled: false,
+                        },
+                    )
+                    .clicked
+                    {
+                        events.push(SidebarEvent::SectionToggled(section));
+                    }
+                }
+            });
 
-        // Settings icon pinned to the bottom of the icon strip
-        let remaining = ui.available_height();
-        if remaining > button_size.y {
-            ui.add_space(remaining - button_size.y);
-        }
+        // Settings icon always visible at the bottom of the icon strip
         if IconButton::render(
             ui,
             sidebar_btn(egui_phosphor::regular::GEAR, "Settings", false),

--- a/src/components/sidebar.rs
+++ b/src/components/sidebar.rs
@@ -353,7 +353,13 @@ impl Sidebar {
                 }
             });
 
-        // Settings icon always visible at the bottom of the icon strip
+        // Push settings to the absolute bottom of the strip
+        let remaining = ui.available_height();
+        if remaining > button_size.y {
+            ui.add_space(remaining - button_size.y);
+        }
+
+        // Settings icon pinned to the bottom of the icon strip
         if IconButton::render(
             ui,
             sidebar_btn(egui_phosphor::regular::GEAR, "Settings", false),

--- a/src/components/toolbar.rs
+++ b/src/components/toolbar.rs
@@ -214,10 +214,7 @@ impl Toolbar {
                     let new_win_shortcut = props.shortcuts.new_window.format();
 
                     ui.menu_button("File", |ui| {
-                        if ui
-                            .button(format!("Open File…  {open_shortcut}"))
-                            .clicked()
-                        {
+                        if ui.button(format!("Open File…  {open_shortcut}")).clicked() {
                             ui.close();
                             if let Some(path) = pick_file(plugins_enabled)
                                 && let Some(file_type) = infer_file_type(&path)
@@ -233,10 +230,7 @@ impl Toolbar {
                             ui.close();
                         }
                         ui.separator();
-                        if ui
-                            .button(format!("Close Tab  {close_shortcut}"))
-                            .clicked()
-                        {
+                        if ui.button(format!("Close Tab  {close_shortcut}")).clicked() {
                             pending = Some(ToolbarEvent::FileClear);
                             ui.close();
                         }
@@ -262,15 +256,16 @@ fn infer_file_type(path: &Path) -> Option<FileKind> {
             // Ask the plugin registry whether any plugin handles this extension
             // so we don't fall back to a stale file-type from the previous file.
             if let Some(Some(pm)) = crate::PLUGIN_MANAGER.get()
-                && pm.find_loader_for_extension(&ext).is_some() {
-                    return Some(
-                        if pm.plugin_has_capability(&ext, &crate::plugin::Capability::FileViewer) {
-                            FileKind::PluginTable
-                        } else {
-                            FileKind::Plugin
-                        },
-                    );
-                }
+                && pm.find_loader_for_extension(&ext).is_some()
+            {
+                return Some(
+                    if pm.plugin_has_capability(&ext, &crate::plugin::Capability::FileViewer) {
+                        FileKind::PluginTable
+                    } else {
+                        FileKind::Plugin
+                    },
+                );
+            }
             None
         }
     }

--- a/src/components/toolbar.rs
+++ b/src/components/toolbar.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use eframe::egui;
 
 use crate::{
-    app::pick_file,
     components::{
         icon_button::{IconButton, IconButtonProps},
         traits::{ContextComponent, StatelessComponent},
@@ -11,6 +10,10 @@ use crate::{
     file::lazy_loader::FileKind,
     shortcuts::KeyboardShortcuts,
 };
+
+// pick_file is only used by the Linux in-window menu bar.
+#[cfg(target_os = "linux")]
+use crate::app::pick_file;
 
 #[derive(Default)]
 pub struct Toolbar {
@@ -83,207 +86,171 @@ impl Toolbar {
                     bottom: 0,
                 }))
                 .show_inside(ui, |ui| {
-                    ui.vertical_centered(|ui| {
-                        ui.horizontal_centered(|ui| {
-                            // Space for macOS traffic light buttons
-                            #[cfg(target_os = "macos")]
-                            let traffic_light_space = 70.0;
-                            #[cfg(not(target_os = "macos"))]
-                            let traffic_light_space = 0.0;
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing = egui::vec2(2.0, 0.0);
 
+                        #[cfg(target_os = "macos")]
+                        let traffic_light_space = 70.0_f32;
+                        #[cfg(not(target_os = "macos"))]
+                        let traffic_light_space = 0.0_f32;
+
+                        // Reserve space for macOS traffic lights
+                        if traffic_light_space > 0.0 {
                             ui.add_space(traffic_light_space);
+                        }
 
-                            // Display "Thoth - filename" or just "Thoth" centered
-                            let title = if let Some(path) = props.file_path {
-                                let filename = path
-                                    .file_name()
-                                    .and_then(|n| n.to_str())
-                                    .unwrap_or("Untitled");
-                                format!("Thoth - {}", filename)
-                            } else {
-                                "Thoth".to_string()
-                            };
+                        let button_size = egui::vec2(26.0, 26.0);
 
-                            // Calculate centering: total width - traffic light space, then center within that
-                            let available_width = ui.available_width();
-                            let text_width = ui.fonts_mut(|f| {
-                                f.layout_no_wrap(
-                                    title.clone(),
-                                    egui::FontId::proportional(13.0),
-                                    ui.visuals().text_color(),
-                                )
-                                .rect
-                                .width()
-                            });
-
-                            // Center the text, accounting for the traffic light offset
-                            let center_offset =
-                                (available_width - text_width) / 2.0 - traffic_light_space / 2.0;
-                            if center_offset > 0.0 {
-                                ui.add_space(center_offset);
-                            }
-
-                            ui.label(egui::RichText::new(title).size(13.0));
+                        // Measure title text width so we can center the whole group
+                        let title = if let Some(path) = props.file_path {
+                            let filename = path
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .unwrap_or("Untitled");
+                            format!("Thoth - {}", filename)
+                        } else {
+                            "Thoth".to_string()
+                        };
+                        let title_width = ui.fonts_mut(|f| {
+                            f.layout_no_wrap(
+                                title.clone(),
+                                egui::FontId::proportional(13.0),
+                                egui::Color32::WHITE,
+                            )
+                            .rect
+                            .width()
                         });
+
+                        // Group = back(26) + gap(2) + fwd(26) + gap(8) + title
+                        let group_width = button_size.x + 2.0 + button_size.x + 8.0 + title_width;
+                        let total_width = ui.max_rect().width();
+                        // Center the group within the full panel, offset by traffic lights
+                        let lead =
+                            ((total_width - group_width) / 2.0 - traffic_light_space).max(0.0);
+                        ui.add_space(lead);
+
+                        // Navigation buttons
+                        let back_btn = IconButton::render(
+                            ui,
+                            IconButtonProps {
+                                icon: egui_phosphor::regular::CARET_LEFT,
+                                frame: false,
+                                tooltip: Some(&format!(
+                                    "Go back ({})",
+                                    props.shortcuts.nav_back.format()
+                                )),
+                                badge_color: None,
+                                size: Some(button_size),
+                                disabled: !props.can_go_back,
+                                selected: false,
+                                icon_size: None,
+                            },
+                        );
+                        if back_btn.clicked {
+                            events.push(ToolbarEvent::NavigateBack);
+                        }
+
+                        let fwd_btn = IconButton::render(
+                            ui,
+                            IconButtonProps {
+                                icon: egui_phosphor::regular::CARET_RIGHT,
+                                frame: false,
+                                tooltip: Some(&format!(
+                                    "Go forward ({})",
+                                    props.shortcuts.nav_forward.format()
+                                )),
+                                badge_color: None,
+                                size: Some(button_size),
+                                disabled: !props.can_go_forward,
+                                selected: false,
+                                icon_size: None,
+                            },
+                        );
+                        if fwd_btn.clicked {
+                            events.push(ToolbarEvent::NavigateForward);
+                        }
+
+                        ui.add_space(8.0);
+                        ui.label(egui::RichText::new(title).size(13.0));
                     });
                 });
         }
 
-        // Row 2: Button toolbar (32px height)
-        egui::Panel::top("button_toolbar")
-            .exact_size(32.0)
+        // Row 2: In-window egui menu bar — only on Linux.
+        // macOS and Windows use the native menu bar set up via muda in ThothApp::new().
+        #[cfg(target_os = "linux")]
+        egui::Panel::top("menu_bar_row")
+            .exact_size(28.0)
             .frame(egui::Frame::NONE.fill(bg_color).inner_margin(egui::Margin {
-                left: 8,
-                right: 8,
+                left: 4,
+                right: 4,
                 top: 0,
                 bottom: 0,
             }))
             .show_inside(ui, |ui| {
                 ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing = egui::vec2(4.0, 0.0);
+                    ui.spacing_mut().item_spacing = egui::vec2(2.0, 0.0);
 
-                    // Button size to match ComboBox height
-                    let button_size = egui::vec2(28.0, 28.0);
+                    let mut pending: Option<ToolbarEvent> = None;
 
-                    // Navigation buttons (back/forward)
-                    let back_button = IconButton::render(
-                        ui,
-                        IconButtonProps {
-                            icon: egui_phosphor::regular::CARET_LEFT,
-                            frame: false,
-                            tooltip: Some(&format!(
-                                "Go back ({})",
-                                props.shortcuts.nav_back.format()
-                            )),
-                            badge_color: None,
-                            size: Some(button_size),
-                            disabled: !props.can_go_back,
-                            selected: false,
-                            icon_size: None,
-                        },
-                    );
-
-                    if back_button.clicked {
-                        events.push(ToolbarEvent::NavigateBack);
-                    }
-
-                    let forward_button = IconButton::render(
-                        ui,
-                        IconButtonProps {
-                            icon: egui_phosphor::regular::CARET_RIGHT,
-                            frame: false,
-                            tooltip: Some(&format!(
-                                "Go forward ({})",
-                                props.shortcuts.nav_forward.format()
-                            )),
-                            badge_color: None,
-                            size: Some(button_size),
-                            disabled: !props.can_go_forward,
-                            selected: false,
-                            icon_size: None,
-                        },
-                    );
-
-                    if forward_button.clicked {
-                        events.push(ToolbarEvent::NavigateForward);
-                    }
-
-                    ui.add_space(4.0);
-                    ui.separator();
-                    ui.add_space(4.0);
-
-                    // File actions (icon-only buttons)
-                    if IconButton::render(
-                        ui,
-                        IconButtonProps {
-                            icon: egui_phosphor::regular::FOLDER_OPEN,
-                            frame: false,
-                            tooltip: Some(&format!(
-                                "Open file ({})",
-                                props.shortcuts.open_file.format()
-                            )),
-                            badge_color: None,
-                            size: Some(button_size),
-                            disabled: false,
-                            icon_size: None,
-                            selected: false,
-                        },
-                    )
-                    .clicked
-                        && let Some(path) = pick_file(props.plugins_enabled)
-                            && let Some(file_type) = infer_file_type(&path) {
-                                self.previous_file_type = file_type;
-                                events.push(ToolbarEvent::FileOpen { path, file_type });
-                            }
-
-                    if IconButton::render(
-                        ui,
-                        IconButtonProps {
-                            icon: egui_phosphor::regular::X,
-                            frame: false,
-                            tooltip: Some(&format!(
-                                "Close tab ({})",
-                                props.shortcuts.close_tab.format()
-                            )),
-                            badge_color: None,
-                            size: Some(button_size),
-                            disabled: false,
-                            icon_size: None,
-                            selected: false,
-                        },
-                    )
-                    .clicked
-                    {
-                        events.push(ToolbarEvent::FileClear);
-                    }
-
-                    if IconButton::render(
-                        ui,
-                        IconButtonProps {
-                            icon: egui_phosphor::regular::SQUARES_FOUR,
-                            frame: false,
-                            tooltip: Some(&format!(
-                                "New window ({})",
-                                props.shortcuts.new_window.format()
-                            )),
-                            badge_color: None,
-                            size: Some(button_size),
-                            disabled: false,
-                            icon_size: None,
-                            selected: false,
-                        },
-                    )
-                    .clicked
-                    {
-                        events.push(ToolbarEvent::NewWindow);
-                    }
-
-                    // Spacer to push right-side items to the right
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        ui.spacing_mut().item_spacing = egui::vec2(4.0, 0.0);
-
-                        // Settings button (icon-only)
-                        if IconButton::render(
-                            ui,
-                            IconButtonProps {
-                                icon: egui_phosphor::regular::GEAR,
-                                frame: false,
-                                tooltip: Some("Settings (Cmd/Ctrl+,)"),
-                                badge_color: None,
-                                size: Some(button_size),
-                                disabled: false,
-                                icon_size: None,
-                                selected: false,
-                            },
-                        )
-                        .clicked
+                    // ── Thoth menu ─────────────────────────────────────────────
+                    ui.menu_button("Thoth", |ui| {
+                        if ui
+                            .button(format!("Settings  {}", props.shortcuts.settings.format()))
+                            .clicked()
                         {
-                            events.push(ToolbarEvent::OpenSettings);
+                            pending = Some(ToolbarEvent::OpenSettings);
+                            ui.close();
                         }
                     });
+                    if let Some(e) = pending.take() {
+                        events.push(e);
+                    }
+
+                    // ── File menu ──────────────────────────────────────────────
+                    let plugins_enabled = props.plugins_enabled;
+                    let open_shortcut = props.shortcuts.open_file.format();
+                    let close_shortcut = props.shortcuts.close_tab.format();
+                    let new_win_shortcut = props.shortcuts.new_window.format();
+
+                    ui.menu_button("File", |ui| {
+                        if ui
+                            .button(format!("Open File…  {open_shortcut}"))
+                            .clicked()
+                        {
+                            ui.close();
+                            if let Some(path) = pick_file(plugins_enabled)
+                                && let Some(file_type) = infer_file_type(&path)
+                            {
+                                pending = Some(ToolbarEvent::FileOpen { path, file_type });
+                            }
+                        }
+                        if ui
+                            .button(format!("New Window  {new_win_shortcut}"))
+                            .clicked()
+                        {
+                            pending = Some(ToolbarEvent::NewWindow);
+                            ui.close();
+                        }
+                        ui.separator();
+                        if ui
+                            .button(format!("Close Tab  {close_shortcut}"))
+                            .clicked()
+                        {
+                            pending = Some(ToolbarEvent::FileClear);
+                            ui.close();
+                        }
+                    });
+                    if let Some(e) = pending.take() {
+                        events.push(e);
+                    }
                 });
             });
     }
+}
+
+pub fn infer_file_type_pub(path: &Path) -> Option<FileKind> {
+    infer_file_type(path)
 }
 
 fn infer_file_type(path: &Path) -> Option<FileKind> {

--- a/src/components/toolbar.rs
+++ b/src/components/toolbar.rs
@@ -35,7 +35,7 @@ pub struct ToolbarProps<'a> {
 /// Events emitted by the toolbar (bottom-to-top communication)
 pub enum ToolbarEvent {
     FileOpen { path: PathBuf, file_type: FileKind },
-    FileClear,
+    CloseTab,
     NewWindow,
     ToggleTheme,
     OpenSettings,
@@ -231,7 +231,7 @@ impl Toolbar {
                         }
                         ui.separator();
                         if ui.button(format!("Close Tab  {close_shortcut}")).clicked() {
-                            pending = Some(ToolbarEvent::FileClear);
+                            pending = Some(ToolbarEvent::CloseTab);
                             ui.close();
                         }
                     });

--- a/src/components/toolbar.rs
+++ b/src/components/toolbar.rs
@@ -210,14 +210,11 @@ impl Toolbar {
                         },
                     )
                     .clicked
-                    {
-                        if let Some(path) = pick_file(props.plugins_enabled) {
-                            if let Some(file_type) = infer_file_type(&path) {
+                        && let Some(path) = pick_file(props.plugins_enabled)
+                            && let Some(file_type) = infer_file_type(&path) {
                                 self.previous_file_type = file_type;
                                 events.push(ToolbarEvent::FileOpen { path, file_type });
                             }
-                        }
-                    }
 
                     if IconButton::render(
                         ui,
@@ -297,8 +294,8 @@ fn infer_file_type(path: &Path) -> Option<FileKind> {
         _ => {
             // Ask the plugin registry whether any plugin handles this extension
             // so we don't fall back to a stale file-type from the previous file.
-            if let Some(Some(pm)) = crate::PLUGIN_MANAGER.get() {
-                if pm.find_loader_for_extension(&ext).is_some() {
+            if let Some(Some(pm)) = crate::PLUGIN_MANAGER.get()
+                && pm.find_loader_for_extension(&ext).is_some() {
                     return Some(
                         if pm.plugin_has_capability(&ext, &crate::plugin::Capability::FileViewer) {
                             FileKind::PluginTable
@@ -307,7 +304,6 @@ fn infer_file_type(path: &Path) -> Option<FileKind> {
                         },
                     );
                 }
-            }
             None
         }
     }

--- a/src/components/toolbar.rs
+++ b/src/components/toolbar.rs
@@ -222,8 +222,8 @@ impl Toolbar {
                             icon: egui_phosphor::regular::X,
                             frame: false,
                             tooltip: Some(&format!(
-                                "Clear file ({})",
-                                props.shortcuts.clear_file.format()
+                                "Close tab ({})",
+                                props.shortcuts.close_tab.format()
                             )),
                             badge_color: None,
                             size: Some(button_size),

--- a/src/components/update_consent_modal.rs
+++ b/src/components/update_consent_modal.rs
@@ -1,0 +1,150 @@
+use eframe::egui::{self, Frame, Layout, Margin, RichText};
+
+use crate::{
+    components::{
+        button::{Button, ButtonColor, ButtonProps, ButtonSize, ButtonType},
+        traits::StatelessComponent,
+        typography::{Typography, TypographyProps, TypographyVariant},
+    },
+    theme::{ThemeColors, phosphor_font_id},
+};
+
+pub struct UpdateConsentModal;
+
+pub struct UpdateConsentModalProps<'a> {
+    pub current_version: &'a str,
+    pub latest_version: &'a str,
+}
+
+pub struct UpdateConsentModalOutput {
+    pub update_now: bool,
+    pub remind_later: bool,
+}
+
+impl StatelessComponent for UpdateConsentModal {
+    type Props<'a> = UpdateConsentModalProps<'a>;
+    type Output = UpdateConsentModalOutput;
+
+    fn render(ui: &mut egui::Ui, props: Self::Props<'_>) -> Self::Output {
+        let colors = ui.ctx().memory(|mem| {
+            mem.data
+                .get_temp::<ThemeColors>(egui::Id::new("theme_colors"))
+                .unwrap_or_else(|| crate::theme::Theme::default().colors())
+        });
+
+        let mut output = UpdateConsentModalOutput {
+            update_now: false,
+            remind_later: false,
+        };
+
+        let modal = egui::Modal::new(egui::Id::new("update_consent_modal"));
+        modal.show(ui.ctx(), |ui| {
+            ui.set_width(400.0);
+
+            // Backdrop color is handled by egui::Modal internally.
+
+            // ── Header ────────────────────────────────────────────────────────
+            Frame::new()
+                .inner_margin(Margin {
+                    left: 24,
+                    right: 24,
+                    top: 24,
+                    bottom: 16,
+                })
+                .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label(
+                            RichText::new(egui_phosphor::regular::ARROW_CIRCLE_UP)
+                                .font(phosphor_font_id(28.0))
+                                .color(colors.info),
+                        );
+                        ui.add_space(10.0);
+                        ui.vertical(|ui| {
+                            Typography::render(
+                                ui,
+                                TypographyProps {
+                                    text: "Update Available",
+                                    variant: TypographyVariant::BodyLarge,
+                                    bold: true,
+                                    ..Default::default()
+                                },
+                            );
+                            Typography::body_muted(
+                                ui,
+                                &format!(
+                                    "v{} → v{}",
+                                    props.current_version, props.latest_version
+                                ),
+                            );
+                        });
+                    });
+                });
+
+            ui.add(egui::Separator::default().spacing(0.0));
+
+            // ── Body ──────────────────────────────────────────────────────────
+            Frame::new()
+                .inner_margin(Margin {
+                    left: 24,
+                    right: 24,
+                    top: 16,
+                    bottom: 16,
+                })
+                .show(ui, |ui| {
+                    Typography::body(
+                        ui,
+                        "A new version of Thoth is ready to install. Update now for the latest features and improvements.",
+                    );
+                });
+
+            ui.add(egui::Separator::default().spacing(0.0));
+
+            // ── Footer ────────────────────────────────────────────────────────
+            Frame::new()
+                .fill(colors.bg_sunken)
+                .inner_margin(Margin {
+                    left: 24,
+                    right: 24,
+                    top: 12,
+                    bottom: 12,
+                })
+                .show(ui, |ui| {
+                    ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
+                        if Button::render(
+                            ui,
+                            ButtonProps {
+                                label: "Update Now".to_string(),
+                                button_type: ButtonType::Elevated,
+                                color: ButtonColor::Primary,
+                                button_size: ButtonSize::Medium,
+                                ..Default::default()
+                            },
+                        )
+                        .clicked
+                        {
+                            output.update_now = true;
+                        }
+
+                        ui.add_space(8.0);
+
+                        if Button::render(
+                            ui,
+                            ButtonProps {
+                                label: "Remind Later".to_string(),
+                                button_type: ButtonType::Text,
+                                color: ButtonColor::Default,
+                                button_size: ButtonSize::Medium,
+                                ..Default::default()
+                            },
+                        )
+                        .clicked
+                        {
+                            output.remind_later = true;
+                        }
+                    });
+                });
+        });
+
+        output
+    }
+}

--- a/src/components/welcome.rs
+++ b/src/components/welcome.rs
@@ -1,0 +1,278 @@
+use eframe::egui;
+use egui_phosphor::regular as ph;
+
+use crate::components::common::traits::StatelessComponent;
+use crate::components::common::typography::{Typography, TypographyProps, TypographyVariant};
+use crate::theme::ThemeColors;
+
+pub enum WelcomeEvent {
+    OpenFilePicker,
+    OpenRecentFile(std::path::PathBuf),
+}
+
+pub struct WelcomePanel;
+
+impl WelcomePanel {
+    pub fn render(
+        ui: &mut egui::Ui,
+        recent_files: &[String],
+        colors: Option<ThemeColors>,
+    ) -> Vec<WelcomeEvent> {
+        let mut events = Vec::new();
+
+        let c = colors.unwrap_or_else(|| {
+            ui.ctx()
+                .memory(|m| m.data.get_temp::<ThemeColors>(egui::Id::new("theme_colors")))
+                .unwrap_or_else(|| crate::theme::Theme::default().colors())
+        });
+
+        // ── PluginShell header (title row + divider) ──────────────────────────
+        // padding: 20px 24px 16px  — top 20, sides 24, bottom 16
+        let header_padding = egui::Margin { left: 24, right: 24, top: 20, bottom: 16 };
+        egui::Frame::NONE
+            .inner_margin(header_padding)
+            .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 12.0;
+                    // Title — --primary (mauve), --fs-2xl (20px), weight 700
+                    Typography::render(
+                        ui,
+                        TypographyProps {
+                            text: "Welcome to Thoth",
+                            variant: TypographyVariant::Heading,
+                            color: Some(c.accent_secondary),
+                            size_override: Some(22.0),
+                            bold: true,
+                            ..Default::default()
+                        },
+                    );
+                    // Subtitle — --overlay1, --fs-md (13px), baseline-aligned
+                    Typography::render(
+                        ui,
+                        TypographyProps {
+                            text: "Wisdom for your JSON.",
+                            variant: TypographyVariant::Subtitle,
+                            ..Default::default()
+                        },
+                    );
+                });
+            });
+
+        // Border-bottom: 1px solid --surface0
+        let sep_rect = egui::Rect::from_min_size(
+            ui.cursor().min,
+            egui::vec2(ui.available_width(), 1.0),
+        );
+        ui.painter().rect_filled(sep_rect, 0.0, c.surface);
+        ui.advance_cursor_after_rect(sep_rect);
+
+        // ── Body — padding: 24px, scrollable ─────────────────────────────────
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                let body_padding = egui::Margin::same(24);
+                egui::Frame::NONE
+                    .inner_margin(body_padding)
+                    .show(ui, |ui| {
+                        // Grid: 1fr 1fr, gap: 32, maxWidth: 880
+                        ui.set_max_width(880.0);
+                        ui.spacing_mut().item_spacing.y = 0.0;
+
+                        ui.columns(2, |cols| {
+                            let col_gap = 16.0; // half of gap: 32
+                            cols[0].add_space(0.0);
+
+                            // ── Left: Start + Recent ──────────────────────────
+                            {
+                                let ui = &mut cols[0];
+                                ui.set_max_width(ui.available_width() - col_gap);
+
+                                t_section(ui, "Start", c);
+                                ui.add_space(8.0);
+
+                                if action_row(ui, ph::FOLDER_OPEN, "Open file…", Some("⌘O"), c) {
+                                    events.push(WelcomeEvent::OpenFilePicker);
+                                }
+                                if action_row(ui, ph::APP_WINDOW, "New window", Some("⌘N"), c) {
+                                    // handled by shortcut; no event needed
+                                }
+                                if action_row(ui, ph::PUZZLE_PIECE, "Browse plugins…", None, c) {
+                                    // future: open settings → plugins
+                                }
+
+                                ui.add_space(24.0);
+                                t_section(ui, "Recent", c);
+                                ui.add_space(8.0);
+
+                                if recent_files.is_empty() {
+                                    Typography::render(
+                                        ui,
+                                        TypographyProps {
+                                            text: "No recent files",
+                                            variant: TypographyVariant::BodyMuted,
+                                            ..Default::default()
+                                        },
+                                    );
+                                } else {
+                                    for path_str in recent_files.iter().take(8) {
+                                        let path = std::path::PathBuf::from(path_str);
+                                        let name = path
+                                            .file_name()
+                                            .and_then(|n| n.to_str())
+                                            .unwrap_or(path_str.as_str())
+                                            .to_string();
+                                        let ext = path
+                                            .extension()
+                                            .and_then(|e| e.to_str())
+                                            .map(|e| e.to_uppercase());
+                                        if action_row(
+                                            ui,
+                                            ph::FILE_TEXT,
+                                            &name,
+                                            ext.as_deref(),
+                                            c,
+                                        ) {
+                                            events.push(WelcomeEvent::OpenRecentFile(path));
+                                        }
+                                    }
+                                }
+                            }
+
+                            // ── Right: Tips ───────────────────────────────────
+                            {
+                                let ui = &mut cols[1];
+                                ui.add_space(col_gap);
+
+                                t_section(ui, "Tips", c);
+                                ui.add_space(8.0);
+
+                                tip_row(ui, "Drag tab → edge", "Drop on the left, right, top, or bottom of any pane to split it.", c);
+                                tip_row(ui, "Drag tab → strip", "Move a tab between groups, or reorder within the same strip.", c);
+                                tip_row(ui, "Right-click tab", "Pin, close others, split right, split down — full VSCode-style menu.", c);
+                                tip_row(ui, "⌘W", "Close active tab. Last welcome tab closes the window.", c);
+                                tip_row(ui, "⌘⌥→ / ⌘⌥←", "Cycle to next or previous tab.", c);
+                                tip_row(ui, "⌘1 – ⌘9", "Jump to tab by position.", c);
+                            }
+                        });
+                    });
+            });
+
+        events
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// `.t-section` — bold 12px content-area section label
+fn t_section(ui: &mut egui::Ui, text: &str, _c: ThemeColors) {
+    Typography::render(
+        ui,
+        TypographyProps {
+            text,
+            variant: TypographyVariant::SectionHeader,
+            ..Default::default()
+        },
+    );
+}
+
+/// ActionRow — flex row, icon (16px --accent), label (13px --text, flex:1), optional hint (12px mono --overlay1)
+/// Hover: --surface0 bg, borderRadius 4
+fn action_row(
+    ui: &mut egui::Ui,
+    icon: &str,
+    label: &str,
+    hint: Option<&str>,
+    c: ThemeColors,
+) -> bool {
+    // padding: 8px 10px on each side — total height ~ 13 (font) + 16 (pad) = ~32
+    let row_h = 32.0;
+    let pad_x = 10.0;
+    let available_w = ui.available_width();
+    let (rect, response) =
+        ui.allocate_exact_size(egui::vec2(available_w, row_h), egui::Sense::click());
+
+    if ui.is_rect_visible(rect) {
+        // Hover bg
+        if response.hovered() {
+            ui.painter().rect_filled(rect, 4.0, c.surface);
+        }
+
+        // Icon: left-padded, 16px, --accent
+        let icon_x = rect.min.x + pad_x + 8.0; // 10px pad + ~8px to center
+        ui.painter().text(
+            egui::pos2(icon_x, rect.center().y),
+            egui::Align2::CENTER_CENTER,
+            icon,
+            egui::FontId::new(16.0, egui::FontFamily::Name("phosphor".into())),
+            c.accent,
+        );
+
+        // Hint (right-aligned, monospace 12px --overlay1) — layout first to reserve space
+        let hint_w = if let Some(h) = hint {
+            let g = ui.painter().layout_no_wrap(
+                h.to_string(),
+                egui::FontId::monospace(12.0),
+                c.fg_muted,
+            );
+            let gsize = g.size();
+            let hint_x = rect.max.x - pad_x - gsize.x;
+            ui.painter()
+                .galley(egui::pos2(hint_x, rect.center().y - gsize.y / 2.0), g, c.fg_muted);
+            gsize.x + pad_x + 4.0
+        } else {
+            0.0
+        };
+
+        // Label (flex:1, 13px --text, single line)
+        let label_x = rect.min.x + pad_x + 8.0 + 10.0 + 6.0; // after icon + gap:10
+        let label_max_w = (rect.max.x - hint_w - label_x).max(0.0);
+        let lg = ui.painter().layout(
+            label.to_string(),
+            egui::FontId::proportional(13.0),
+            c.fg,
+            label_max_w,
+        );
+        ui.painter()
+            .galley(egui::pos2(label_x, rect.center().y - lg.size().y / 2.0), lg, c.fg);
+    }
+
+    if response.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+    response.clicked()
+}
+
+/// Tip row — badge (mono 12px, --surface0 bg, 2px/8px padding, --text) + body (13px --overlay1)
+fn tip_row(ui: &mut egui::Ui, kbd: &str, body: &str, c: ThemeColors) {
+    // padding: 8px 0 on the row
+    ui.add_space(4.0);
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing = egui::vec2(12.0, 4.0);
+
+        // Badge: padding 2px 8px, borderRadius 4, bg --surface0, color --text
+        let badge_font = egui::FontId::monospace(12.0);
+        let badge_galley =
+            ui.painter()
+                .layout_no_wrap(kbd.to_string(), badge_font, c.fg);
+        let pad = egui::vec2(8.0, 2.0);
+        let badge_size = badge_galley.size() + pad * 2.0;
+        let (badge_rect, _) = ui.allocate_exact_size(badge_size, egui::Sense::hover());
+        if ui.is_rect_visible(badge_rect) {
+            ui.painter().rect_filled(badge_rect, 4.0, c.surface);
+            ui.painter().galley(badge_rect.min + pad, badge_galley, c.fg);
+        }
+
+        // Body: 13px --overlay1
+        Typography::render(
+            ui,
+            TypographyProps {
+                text: body,
+                variant: TypographyVariant::BodyMuted,
+                color: Some(c.fg_muted),
+                size_override: Some(13.0),
+                ..Default::default()
+            },
+        );
+    });
+    ui.add_space(4.0);
+}

--- a/src/components/welcome.rs
+++ b/src/components/welcome.rs
@@ -22,13 +22,21 @@ impl WelcomePanel {
 
         let c = colors.unwrap_or_else(|| {
             ui.ctx()
-                .memory(|m| m.data.get_temp::<ThemeColors>(egui::Id::new("theme_colors")))
+                .memory(|m| {
+                    m.data
+                        .get_temp::<ThemeColors>(egui::Id::new("theme_colors"))
+                })
                 .unwrap_or_else(|| crate::theme::Theme::default().colors())
         });
 
         // ── PluginShell header (title row + divider) ──────────────────────────
         // padding: 20px 24px 16px  — top 20, sides 24, bottom 16
-        let header_padding = egui::Margin { left: 24, right: 24, top: 20, bottom: 16 };
+        let header_padding = egui::Margin {
+            left: 24,
+            right: 24,
+            top: 20,
+            bottom: 16,
+        };
         egui::Frame::NONE
             .inner_margin(header_padding)
             .show(ui, |ui| {
@@ -59,10 +67,8 @@ impl WelcomePanel {
             });
 
         // Border-bottom: 1px solid --surface0
-        let sep_rect = egui::Rect::from_min_size(
-            ui.cursor().min,
-            egui::vec2(ui.available_width(), 1.0),
-        );
+        let sep_rect =
+            egui::Rect::from_min_size(ui.cursor().min, egui::vec2(ui.available_width(), 1.0));
         ui.painter().rect_filled(sep_rect, 0.0, c.surface);
         ui.advance_cursor_after_rect(sep_rect);
 
@@ -216,8 +222,11 @@ fn action_row(
             );
             let gsize = g.size();
             let hint_x = rect.max.x - pad_x - gsize.x;
-            ui.painter()
-                .galley(egui::pos2(hint_x, rect.center().y - gsize.y / 2.0), g, c.fg_muted);
+            ui.painter().galley(
+                egui::pos2(hint_x, rect.center().y - gsize.y / 2.0),
+                g,
+                c.fg_muted,
+            );
             gsize.x + pad_x + 4.0
         } else {
             0.0
@@ -232,8 +241,11 @@ fn action_row(
             c.fg,
             label_max_w,
         );
-        ui.painter()
-            .galley(egui::pos2(label_x, rect.center().y - lg.size().y / 2.0), lg, c.fg);
+        ui.painter().galley(
+            egui::pos2(label_x, rect.center().y - lg.size().y / 2.0),
+            lg,
+            c.fg,
+        );
     }
 
     if response.hovered() {
@@ -251,15 +263,16 @@ fn tip_row(ui: &mut egui::Ui, kbd: &str, body: &str, c: ThemeColors) {
 
         // Badge: padding 2px 8px, borderRadius 4, bg --surface0, color --text
         let badge_font = egui::FontId::monospace(12.0);
-        let badge_galley =
-            ui.painter()
-                .layout_no_wrap(kbd.to_string(), badge_font, c.fg);
+        let badge_galley = ui
+            .painter()
+            .layout_no_wrap(kbd.to_string(), badge_font, c.fg);
         let pad = egui::vec2(8.0, 2.0);
         let badge_size = badge_galley.size() + pad * 2.0;
         let (badge_rect, _) = ui.allocate_exact_size(badge_size, egui::Sense::hover());
         if ui.is_rect_visible(badge_rect) {
             ui.painter().rect_filled(badge_rect, 4.0, c.surface);
-            ui.painter().galley(badge_rect.min + pad, badge_galley, c.fg);
+            ui.painter()
+                .galley(badge_rect.min + pad, badge_galley, c.fg);
         }
 
         // Body: 13px --overlay1

--- a/src/consent/manager.rs
+++ b/src/consent/manager.rs
@@ -88,17 +88,19 @@ impl ConsentManager {
     /// Enqueue any consent request.
     pub fn push(consent: PendingConsent) {
         if let Some(mutex) = crate::CONSENT_MANAGER.get()
-            && let Ok(mut cm) = mutex.lock() {
-                cm.queue.push_back(consent);
-            }
+            && let Ok(mut cm) = mutex.lock()
+        {
+            cm.queue.push_back(consent);
+        }
     }
 
     /// Remove the consent with the given id (call after the user decides).
     pub fn resolve(id: &str) {
         if let Some(mutex) = crate::CONSENT_MANAGER.get()
-            && let Ok(mut cm) = mutex.lock() {
-                cm.queue.retain(|c| c.request.id != id);
-            }
+            && let Ok(mut cm) = mutex.lock()
+        {
+            cm.queue.retain(|c| c.request.id != id);
+        }
     }
 
     /// Clone the first pending consent's data so the caller can render without

--- a/src/consent/manager.rs
+++ b/src/consent/manager.rs
@@ -87,20 +87,18 @@ impl ConsentManager {
 
     /// Enqueue any consent request.
     pub fn push(consent: PendingConsent) {
-        if let Some(mutex) = crate::CONSENT_MANAGER.get() {
-            if let Ok(mut cm) = mutex.lock() {
+        if let Some(mutex) = crate::CONSENT_MANAGER.get()
+            && let Ok(mut cm) = mutex.lock() {
                 cm.queue.push_back(consent);
             }
-        }
     }
 
     /// Remove the consent with the given id (call after the user decides).
     pub fn resolve(id: &str) {
-        if let Some(mutex) = crate::CONSENT_MANAGER.get() {
-            if let Ok(mut cm) = mutex.lock() {
+        if let Some(mutex) = crate::CONSENT_MANAGER.get()
+            && let Ok(mut cm) = mutex.lock() {
                 cm.queue.retain(|c| c.request.id != id);
             }
-        }
     }
 
     /// Clone the first pending consent's data so the caller can render without

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! This library exposes the core components and utilities of Thoth
 //! for testing and potential reuse.
 
-use std::sync::OnceLock;
+use std::sync::{OnceLock, atomic::AtomicBool};
 
 use crate::plugin::manager::PluginManager;
 
@@ -29,3 +29,7 @@ pub static NOTIFICATION_MANAGER: OnceLock<std::sync::Mutex<notification::Notific
     OnceLock::new();
 pub static CONSENT_MANAGER: OnceLock<std::sync::Mutex<consent::manager::ConsentManager>> =
     OnceLock::new();
+
+/// Set to `true` by the "Update Now" notification action callback.
+/// Polled each frame by ThothApp and cleared after opening the updates settings tab.
+pub static OPEN_UPDATES_REQUESTED: AtomicBool = AtomicBool::new(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
     thoth::platform::macos::install_all_handlers();
 
     let result = eframe::run_native(
-        "Thoth — JSON & NDJSON Viewer",
+        "Thoth",
         options,
         Box::new(move |cc| {
             // Initialize Phosphor icon fonts and register the named family so
@@ -145,7 +145,7 @@ fn main() -> Result<()> {
             );
             cc.egui_ctx.set_fonts(fonts);
 
-            Ok(Box::new(app::ThothApp::new(settings, file_to_open)))
+            Ok(Box::new(app::ThothApp::new(settings, file_to_open, cc)))
         }),
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,9 @@ fn main() -> Result<()> {
             );
             cc.egui_ctx.set_fonts(fonts);
 
-            Ok(Box::new(app::ThothApp::new(settings, file_to_open, cc)))
+            let mut app = app::ThothApp::new(settings, file_to_open);
+            app.setup_native_menu(cc);
+            Ok(Box::new(app))
         }),
     );
 

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -68,9 +68,10 @@ impl NotificationManager {
         let id = notification.id.clone();
 
         if let Some(mutex) = NOTIFICATION_MANAGER.get()
-            && let Ok(mut nm) = mutex.lock() {
-                nm.add_notification(notification);
-            }
+            && let Ok(mut nm) = mutex.lock()
+        {
+            nm.add_notification(notification);
+        }
 
         id
     }
@@ -86,16 +87,18 @@ impl NotificationManager {
 
     pub fn mark_notification_as_complete(id: &str) {
         if let Some(mutex) = NOTIFICATION_MANAGER.get()
-            && let Ok(mut nm) = mutex.lock() {
-                nm.move_to_notifications(id);
-            }
+            && let Ok(mut nm) = mutex.lock()
+        {
+            nm.move_to_notifications(id);
+        }
     }
 
     pub fn remove_notification(id: &str) {
         if let Some(mutex) = NOTIFICATION_MANAGER.get()
-            && let Ok(mut nm) = mutex.lock() {
-                nm.notifications.remove(id);
-            }
+            && let Ok(mut nm) = mutex.lock()
+        {
+            nm.notifications.remove(id);
+        }
     }
 
     pub fn all_running_notifications_tasks() -> Vec<Notification> {

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -46,6 +46,7 @@ pub struct Notification {
     pub status: NotificationStatus,
     pub kind: NotificationKind,
     pub unread: bool,
+    pub pinned: bool,
 }
 
 pub struct NotificationManager {
@@ -135,7 +136,7 @@ impl NotificationManager {
     }
 
     pub fn clear_notifications(&mut self) {
-        self.notifications.clear();
+        self.notifications.retain(|_, n| n.pinned);
         self.toasts.dismiss_all_toasts();
     }
 
@@ -184,6 +185,7 @@ impl Notification {
             status: NotificationStatus::Created,
             kind: NotificationKind::default(),
             unread: true,
+            pinned: false,
         }
     }
 
@@ -223,6 +225,11 @@ impl Notification {
 
     pub fn with_status(mut self, status: NotificationStatus) -> Self {
         self.status = status;
+        self
+    }
+
+    pub fn pinned(mut self) -> Self {
+        self.pinned = true;
         self
     }
 }

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -66,11 +66,10 @@ impl NotificationManager {
     pub fn notify(notification: Notification) -> String {
         let id = notification.id.clone();
 
-        if let Some(mutex) = NOTIFICATION_MANAGER.get() {
-            if let Ok(mut nm) = mutex.lock() {
+        if let Some(mutex) = NOTIFICATION_MANAGER.get()
+            && let Ok(mut nm) = mutex.lock() {
                 nm.add_notification(notification);
             }
-        }
 
         id
     }
@@ -85,19 +84,17 @@ impl NotificationManager {
     }
 
     pub fn mark_notification_as_complete(id: &str) {
-        if let Some(mutex) = NOTIFICATION_MANAGER.get() {
-            if let Ok(mut nm) = mutex.lock() {
+        if let Some(mutex) = NOTIFICATION_MANAGER.get()
+            && let Ok(mut nm) = mutex.lock() {
                 nm.move_to_notifications(id);
             }
-        }
     }
 
     pub fn remove_notification(id: &str) {
-        if let Some(mutex) = NOTIFICATION_MANAGER.get() {
-            if let Ok(mut nm) = mutex.lock() {
+        if let Some(mutex) = NOTIFICATION_MANAGER.get()
+            && let Ok(mut nm) = mutex.lock() {
                 nm.notifications.remove(id);
             }
-        }
     }
 
     pub fn all_running_notifications_tasks() -> Vec<Notification> {

--- a/src/notification/notification_dropdown.rs
+++ b/src/notification/notification_dropdown.rs
@@ -197,13 +197,10 @@ impl NotificationDropdown {
                                     },
                                 )
                                 .clicked
-                                {
-                                    if let Some(m) = crate::NOTIFICATION_MANAGER.get() {
-                                        if let Ok(mut nm) = m.lock() {
+                                    && let Some(m) = crate::NOTIFICATION_MANAGER.get()
+                                        && let Ok(mut nm) = m.lock() {
                                             nm.mark_all_read();
                                         }
-                                    }
-                                }
                             });
                         });
                     });
@@ -379,20 +376,17 @@ impl NotificationDropdown {
                                     },
                                 );
 
-                                if let Some(idx) = list_out.postfix_clicked {
-                                    if let Some(row) = bucket.get(idx) {
+                                if let Some(idx) = list_out.postfix_clicked
+                                    && let Some(row) = bucket.get(idx) {
                                         to_dismiss = Some(row.0.clone());
                                     }
-                                }
 
                                 // Clicking a row fires the primary (first) action only.
-                                if let Some(idx) = list_out.row_clicked {
-                                    if let Some(row) = bucket.get(idx) {
-                                        if let Some((_, cb)) = row.6.first() {
+                                if let Some(idx) = list_out.row_clicked
+                                    && let Some(row) = bucket.get(idx)
+                                        && let Some((_, cb)) = row.6.first() {
                                             cb();
                                         }
-                                    }
-                                }
                             }
                         }
                     });
@@ -420,13 +414,10 @@ impl NotificationDropdown {
                                 },
                             )
                             .clicked
-                            {
-                                if let Some(m) = crate::NOTIFICATION_MANAGER.get() {
-                                    if let Ok(mut nm) = m.lock() {
+                                && let Some(m) = crate::NOTIFICATION_MANAGER.get()
+                                    && let Ok(mut nm) = m.lock() {
                                         nm.clear_notifications();
                                     }
-                                }
-                            }
                         });
                     });
             });

--- a/src/notification/notification_dropdown.rs
+++ b/src/notification/notification_dropdown.rs
@@ -199,9 +199,10 @@ impl NotificationDropdown {
                                 )
                                 .clicked
                                     && let Some(m) = crate::NOTIFICATION_MANAGER.get()
-                                        && let Ok(mut nm) = m.lock() {
-                                            nm.mark_all_read();
-                                        }
+                                    && let Ok(mut nm) = m.lock()
+                                {
+                                    nm.mark_all_read();
+                                }
                             });
                         });
                     });
@@ -275,16 +276,18 @@ impl NotificationDropdown {
 
                 let visible: Vec<&NotifRow> = notifications
                     .iter()
-                    .filter(|(_, _, _, status, kind, unread, _, _, _)| match new_filter {
-                        Filter::All => true,
-                        Filter::Unread => *unread,
-                        Filter::Plugins => *kind == NotificationKind::Plugin,
-                        Filter::Errors => {
-                            *status == NotificationStatus::Error
-                                || *kind == NotificationKind::Error
-                                || *kind == NotificationKind::Warn
-                        }
-                    })
+                    .filter(
+                        |(_, _, _, status, kind, unread, _, _, _)| match new_filter {
+                            Filter::All => true,
+                            Filter::Unread => *unread,
+                            Filter::Plugins => *kind == NotificationKind::Plugin,
+                            Filter::Errors => {
+                                *status == NotificationStatus::Error
+                                    || *kind == NotificationKind::Error
+                                    || *kind == NotificationKind::Warn
+                            }
+                        },
+                    )
                     .collect();
 
                 egui::ScrollArea::vertical()
@@ -347,44 +350,53 @@ impl NotificationDropdown {
                                     .iter()
                                     .zip(descs.iter())
                                     .zip(action_labels.iter())
-                                    .map(|(((_, title, _, _, kind, unread, _, _, pinned), desc), action_label)| {
-                                        let (icon, icon_color) = kind_icon(*kind, colors);
-                                        let postfix = if *pinned {
-                                            action_label.as_deref().map(|label| {
-                                                ListItemPostfix::ActionButton(ButtonProps {
-                                                    label: label.to_string(),
-                                                    button_type: ButtonType::Elevated,
-                                                    color: ButtonColor::Primary,
-                                                    button_size: ButtonSize::Small,
-                                                    ..Default::default()
+                                    .map(
+                                        |(
+                                            ((_, title, _, _, kind, unread, _, _, pinned), desc),
+                                            action_label,
+                                        )| {
+                                            let (icon, icon_color) = kind_icon(*kind, colors);
+                                            let postfix = if *pinned {
+                                                action_label.as_deref().map(|label| {
+                                                    ListItemPostfix::ActionButton(ButtonProps {
+                                                        label: label.to_string(),
+                                                        button_type: ButtonType::Elevated,
+                                                        color: ButtonColor::Primary,
+                                                        button_size: ButtonSize::Small,
+                                                        ..Default::default()
+                                                    })
                                                 })
-                                            })
-                                        } else {
-                                            Some(ListItemPostfix::IconButton(IconButtonProps {
-                                                icon: egui_phosphor::regular::X,
-                                                tooltip: Some("Dismiss"),
-                                                frame: false,
-                                                badge_color: None,
-                                                size: Some(egui::vec2(18.0, 18.0)),
-                                                icon_size: Some(11.0),
-                                                disabled: false,
+                                            } else {
+                                                Some(ListItemPostfix::IconButton(IconButtonProps {
+                                                    icon: egui_phosphor::regular::X,
+                                                    tooltip: Some("Dismiss"),
+                                                    frame: false,
+                                                    badge_color: None,
+                                                    size: Some(egui::vec2(18.0, 18.0)),
+                                                    icon_size: Some(11.0),
+                                                    disabled: false,
+                                                    selected: false,
+                                                }))
+                                            };
+                                            ListItem {
+                                                title: title.as_str(),
+                                                description: Some(desc.as_str()),
+                                                prefix: Some(ListItemPrefix::Icon {
+                                                    glyph: icon,
+                                                    color: Some(icon_color),
+                                                }),
+                                                badge: None,
+                                                postfix,
                                                 selected: false,
-                                            }))
-                                        };
-                                        ListItem {
-                                            title: title.as_str(),
-                                            description: Some(desc.as_str()),
-                                            prefix: Some(ListItemPrefix::Icon {
-                                                glyph: icon,
-                                                color: Some(icon_color),
-                                            }),
-                                            badge: None,
-                                            postfix,
-                                            selected: false,
-                                            accent: if *unread { Some(icon_color) } else { None },
-                                            tags: &[],
-                                        }
-                                    })
+                                                accent: if *unread {
+                                                    Some(icon_color)
+                                                } else {
+                                                    None
+                                                },
+                                                tags: &[],
+                                            }
+                                        },
+                                    )
                                     .collect();
 
                                 let list_out = List::render(
@@ -400,23 +412,25 @@ impl NotificationDropdown {
                                 );
 
                                 if let Some(idx) = list_out.postfix_clicked
-                                    && let Some(row) = bucket.get(idx) {
-                                        if row.8 {
-                                            // Pinned row: postfix is an action button — fire it.
-                                            if let Some((_, cb)) = row.6.first() {
-                                                cb();
-                                            }
-                                        } else {
-                                            to_dismiss = Some(row.0.clone());
+                                    && let Some(row) = bucket.get(idx)
+                                {
+                                    if row.8 {
+                                        // Pinned row: postfix is an action button — fire it.
+                                        if let Some((_, cb)) = row.6.first() {
+                                            cb();
                                         }
+                                    } else {
+                                        to_dismiss = Some(row.0.clone());
                                     }
+                                }
 
                                 // Clicking a row fires the primary (first) action only.
                                 if let Some(idx) = list_out.row_clicked
                                     && let Some(row) = bucket.get(idx)
-                                        && let Some((_, cb)) = row.6.first() {
-                                            cb();
-                                        }
+                                    && let Some((_, cb)) = row.6.first()
+                                {
+                                    cb();
+                                }
                             }
                         }
                     });
@@ -445,9 +459,10 @@ impl NotificationDropdown {
                             )
                             .clicked
                                 && let Some(m) = crate::NOTIFICATION_MANAGER.get()
-                                    && let Ok(mut nm) = m.lock() {
-                                        nm.clear_notifications();
-                                    }
+                                && let Ok(mut nm) = m.lock()
+                            {
+                                nm.clear_notifications();
+                            }
                         });
                     });
             });

--- a/src/notification/notification_dropdown.rs
+++ b/src/notification/notification_dropdown.rs
@@ -17,7 +17,7 @@ use crate::{
 
 type NotifAction = Arc<dyn Fn() + Send + Sync + 'static>;
 
-// id, title, message, status, kind, unread, actions, created_at
+// id, title, message, status, kind, unread, actions, created_at, pinned
 type NotifRow = (
     String,
     String,
@@ -27,6 +27,7 @@ type NotifRow = (
     bool,
     Vec<(String, NotifAction)>,
     i64,
+    bool,
 );
 
 // ── Filter ────────────────────────────────────────────────────────────────────
@@ -263,6 +264,7 @@ impl NotificationDropdown {
                                     n.unread,
                                     n.actions.clone(),
                                     n.created_at,
+                                    n.pinned,
                                 )
                             })
                             .collect();
@@ -273,7 +275,7 @@ impl NotificationDropdown {
 
                 let visible: Vec<&NotifRow> = notifications
                     .iter()
-                    .filter(|(_, _, _, status, kind, unread, _, _)| match new_filter {
+                    .filter(|(_, _, _, status, kind, unread, _, _, _)| match new_filter {
                         Filter::All => true,
                         Filter::Unread => *unread,
                         Filter::Plugins => *kind == NotificationKind::Plugin,
@@ -309,7 +311,7 @@ impl NotificationDropdown {
                                         left: 16,
                                         right: 16,
                                         top: 8,
-                                        bottom: 4,
+                                        bottom: 8,
                                     })
                                     .show(ui, |ui| {
                                         Typography::group_label(ui, &bucket_label.to_uppercase());
@@ -329,11 +331,46 @@ impl NotificationDropdown {
                                     })
                                     .collect();
 
+                                // Pre-build action labels for pinned rows (must own the Strings).
+                                let action_labels: Vec<Option<String>> = bucket
+                                    .iter()
+                                    .map(|row| {
+                                        if row.8 {
+                                            row.6.first().map(|(label, _)| label.clone())
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .collect();
+
                                 let list_items: Vec<ListItem<'_>> = bucket
                                     .iter()
                                     .zip(descs.iter())
-                                    .map(|((_, title, _, _, kind, unread, _, _), desc)| {
+                                    .zip(action_labels.iter())
+                                    .map(|(((_, title, _, _, kind, unread, _, _, pinned), desc), action_label)| {
                                         let (icon, icon_color) = kind_icon(*kind, colors);
+                                        let postfix = if *pinned {
+                                            action_label.as_deref().map(|label| {
+                                                ListItemPostfix::ActionButton(ButtonProps {
+                                                    label: label.to_string(),
+                                                    button_type: ButtonType::Elevated,
+                                                    color: ButtonColor::Primary,
+                                                    button_size: ButtonSize::Small,
+                                                    ..Default::default()
+                                                })
+                                            })
+                                        } else {
+                                            Some(ListItemPostfix::IconButton(IconButtonProps {
+                                                icon: egui_phosphor::regular::X,
+                                                tooltip: Some("Dismiss"),
+                                                frame: false,
+                                                badge_color: None,
+                                                size: Some(egui::vec2(18.0, 18.0)),
+                                                icon_size: Some(11.0),
+                                                disabled: false,
+                                                selected: false,
+                                            }))
+                                        };
                                         ListItem {
                                             title: title.as_str(),
                                             description: Some(desc.as_str()),
@@ -342,21 +379,9 @@ impl NotificationDropdown {
                                                 color: Some(icon_color),
                                             }),
                                             badge: None,
-                                            postfix: Some(ListItemPostfix::IconButton(
-                                                IconButtonProps {
-                                                    icon: egui_phosphor::regular::X,
-                                                    tooltip: Some("Dismiss"),
-                                                    frame: false,
-                                                    badge_color: None,
-                                                    size: Some(egui::vec2(18.0, 18.0)),
-                                                    icon_size: Some(11.0),
-                                                    disabled: false,
-                                                    selected: false,
-                                                },
-                                            )),
-                                            // selected drives the left accent border
-                                            // and the hover highlight — maps to unread.
-                                            selected: *unread,
+                                            postfix,
+                                            selected: false,
+                                            accent: if *unread { Some(icon_color) } else { None },
                                             tags: &[],
                                         }
                                     })
@@ -367,18 +392,23 @@ impl NotificationDropdown {
                                     ListProps {
                                         items: &list_items,
                                         empty_label: None,
-                                        // Must be true so the List's inner ScrollArea
-                                        // shrinks to content and doesn't conflict with
-                                        // our outer ScrollArea.
                                         shrink_to_fit: true,
                                         show_separators: true,
                                         compact: false,
+                                        max_height: None,
                                     },
                                 );
 
                                 if let Some(idx) = list_out.postfix_clicked
                                     && let Some(row) = bucket.get(idx) {
-                                        to_dismiss = Some(row.0.clone());
+                                        if row.8 {
+                                            // Pinned row: postfix is an action button — fire it.
+                                            if let Some((_, cb)) = row.6.first() {
+                                                cb();
+                                            }
+                                        } else {
+                                            to_dismiss = Some(row.0.clone());
+                                        }
                                     }
 
                                 // Clicking a row fires the primary (first) action only.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -74,8 +74,24 @@ unsafe extern "C" fn handle_open_urls(
 /// Must be called **before** `eframe::run_native` so the handlers are in place
 /// when macOS delivers the initial `odoc` Apple Event during cold launch.
 pub fn install_all_handlers() {
+    disable_automatic_window_tabbing();
     install_delegate_method();
     install_apple_event_handler();
+}
+
+/// Disable macOS automatic window tabbing globally.
+///
+/// macOS Sierra+ claims ⌘⇧[ and ⌘⇧] for its own NSWindowTabbing system unless
+/// the app opts out. Calling `[NSWindow setAllowsAutomaticWindowTabbing:NO]`
+/// releases those shortcuts so the app can use them for its own tab cycling.
+fn disable_automatic_window_tabbing() {
+    use objc2::runtime::Bool;
+    let Some(cls) = objc2::runtime::AnyClass::get("NSWindow") else {
+        return;
+    };
+    unsafe {
+        let _: () = msg_send![cls, setAllowsAutomaticWindowTabbing: Bool::NO];
+    }
 }
 
 /// Add `application:openURLs:` to `NSObject`.

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -20,6 +20,7 @@ pub mod fonts;
 pub mod fs;
 #[cfg(target_os = "macos")]
 pub mod macos;
+pub mod native_menu;
 pub mod path_registry;
 
 pub use archive::get_extractor_for_file;

--- a/src/platform/native_menu.rs
+++ b/src/platform/native_menu.rs
@@ -5,7 +5,7 @@
 /// - Linux: no-op — egui in-window menu bar in toolbar.rs is used instead,
 ///   so muda (which requires GTK dev headers) is not compiled on Linux.
 
-/// Actions that can be triggered from the native menu bar.
+// Actions that can be triggered from the native menu bar.
 #[derive(Debug, Clone)]
 pub enum MenuAction {
     OpenFile,
@@ -30,7 +30,7 @@ pub fn setup(
     {
         use muda::{
             Menu, MenuItem, PredefinedMenuItem, Submenu,
-            accelerator::{Accelerator, Code, CMD_OR_CTRL},
+            accelerator::{Accelerator, CMD_OR_CTRL, Code},
         };
 
         let menu = Menu::new();

--- a/src/platform/native_menu.rs
+++ b/src/platform/native_menu.rs
@@ -1,12 +1,9 @@
-/// Cross-platform native menu bar using muda.
+/// Cross-platform native menu bar.
 ///
-/// - macOS: sets NSApplication.mainMenu (system menu bar at top of screen)
-/// - Windows: attaches a Win32 menu bar to the window
-/// - Linux: no-op (handled by egui in-window menu bar in toolbar.rs)
-use muda::{
-    Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu,
-    accelerator::{Accelerator, Code, CMD_OR_CTRL},
-};
+/// - macOS: NSApplication system menu bar (via muda)
+/// - Windows: Win32 in-window menu bar (via muda)
+/// - Linux: no-op — egui in-window menu bar in toolbar.rs is used instead,
+///   so muda (which requires GTK dev headers) is not compiled on Linux.
 
 /// Actions that can be triggered from the native menu bar.
 #[derive(Debug, Clone)]
@@ -17,110 +14,121 @@ pub enum MenuAction {
     OpenSettings,
 }
 
-/// Holds the live `Menu` to prevent it from being dropped, which would
-/// remove the menu bar from the application on some platforms.
+/// Holds the live muda `Menu` on macOS/Windows so it is not dropped.
+/// On Linux this is an empty unit struct (zero cost).
 pub struct NativeMenu {
-    _menu: Menu,
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    _menu: muda::Menu,
 }
 
-/// Build and register the native menu bar for the current platform.
-/// Returns `None` on Linux (egui fallback handles it instead).
+/// Build and register the native menu bar. Returns `None` on Linux.
 pub fn setup(
     #[allow(unused_variables)] window_handle: raw_window_handle::RawWindowHandle,
-    _shortcuts: &crate::shortcuts::KeyboardShortcuts,
+    #[allow(unused_variables)] shortcuts: &crate::shortcuts::KeyboardShortcuts,
 ) -> Option<NativeMenu> {
-    let menu = Menu::new();
-
-    // ── Thoth menu ─────────────────────────────────────────────────────────
-    let thoth_menu = Submenu::new("Thoth", true);
-
-    let settings_item = MenuItem::with_id(
-        "settings",
-        "Settings",
-        true,
-        Some(Accelerator::new(Some(CMD_OR_CTRL), Code::Comma)),
-    );
-
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     {
-        let quit_item = PredefinedMenuItem::quit(Some("Quit Thoth"));
-        let _ = thoth_menu.append_items(&[
-            &settings_item,
+        use muda::{
+            Menu, MenuItem, PredefinedMenuItem, Submenu,
+            accelerator::{Accelerator, Code, CMD_OR_CTRL},
+        };
+
+        let menu = Menu::new();
+
+        // ── Thoth menu ─────────────────────────────────────────────────────
+        let thoth_menu = Submenu::new("Thoth", true);
+        let settings_item = MenuItem::with_id(
+            "settings",
+            "Settings",
+            true,
+            Some(Accelerator::new(Some(CMD_OR_CTRL), Code::Comma)),
+        );
+
+        #[cfg(target_os = "macos")]
+        {
+            let quit_item = PredefinedMenuItem::quit(Some("Quit Thoth"));
+            let _ = thoth_menu.append_items(&[
+                &settings_item,
+                &PredefinedMenuItem::separator(),
+                &quit_item,
+            ]);
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let _ = thoth_menu.append_items(&[&settings_item]);
+        }
+
+        // ── File menu ──────────────────────────────────────────────────────
+        let file_menu = Submenu::new("File", true);
+        let open_item = MenuItem::with_id(
+            "open_file",
+            "Open File…",
+            true,
+            Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyO)),
+        );
+        let new_window_item = MenuItem::with_id(
+            "new_window",
+            "New Window",
+            true,
+            Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyN)),
+        );
+        let close_tab_item = MenuItem::with_id(
+            "close_tab",
+            "Close Tab",
+            true,
+            Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyW)),
+        );
+        let _ = file_menu.append_items(&[
+            &open_item,
+            &new_window_item,
             &PredefinedMenuItem::separator(),
-            &quit_item,
+            &close_tab_item,
         ]);
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = thoth_menu.append_items(&[&settings_item]);
-    }
 
-    // ── File menu ──────────────────────────────────────────────────────────
-    let file_menu = Submenu::new("File", true);
+        let _ = menu.append_items(&[&thoth_menu, &file_menu]);
 
-    let open_item = MenuItem::with_id(
-        "open_file",
-        "Open File…",
-        true,
-        Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyO)),
-    );
-    let new_window_item = MenuItem::with_id(
-        "new_window",
-        "New Window",
-        true,
-        Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyN)),
-    );
-    let close_tab_item = MenuItem::with_id(
-        "close_tab",
-        "Close Tab",
-        true,
-        Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyW)),
-    );
-    let _ = file_menu.append_items(&[
-        &open_item,
-        &new_window_item,
-        &PredefinedMenuItem::separator(),
-        &close_tab_item,
-    ]);
+        // ── Platform init ──────────────────────────────────────────────────
+        #[cfg(target_os = "macos")]
+        {
+            menu.init_for_nsapp();
+        }
+        #[cfg(target_os = "windows")]
+        {
+            if let raw_window_handle::RawWindowHandle::Win32(w) = window_handle {
+                let hwnd = w.hwnd.get() as isize;
+                let _ = unsafe { menu.init_for_hwnd(hwnd) };
+            }
+        }
 
-    let _ = menu.append_items(&[&thoth_menu, &file_menu]);
-
-    // ── Platform init ──────────────────────────────────────────────────────
-    #[cfg(target_os = "macos")]
-    {
-        menu.init_for_nsapp();
         return Some(NativeMenu { _menu: menu });
     }
 
-    #[cfg(target_os = "windows")]
-    {
-        if let raw_window_handle::RawWindowHandle::Win32(w) = window_handle {
-            let hwnd = w.hwnd.get() as isize;
-            let _ = unsafe { menu.init_for_hwnd(hwnd) };
-            return Some(NativeMenu { _menu: menu });
-        }
-    }
-
-    // Linux: no native init — egui menu bar used instead
+    // Linux: no native menu — egui fallback in toolbar.rs handles it.
     #[allow(unreachable_code)]
     None
 }
 
-/// Drain the muda event channel and return all pending menu actions.
-/// Should be called every frame from `ThothApp::update()`.
+/// Drain pending native menu events. Returns an empty Vec on Linux.
 pub fn poll_events() -> Vec<MenuAction> {
-    let mut actions = Vec::new();
-    while let Ok(event) = MenuEvent::receiver().try_recv() {
-        let action = match event.id().0.as_str() {
-            "open_file" => Some(MenuAction::OpenFile),
-            "new_window" => Some(MenuAction::NewWindow),
-            "close_tab" => Some(MenuAction::CloseTab),
-            "settings" => Some(MenuAction::OpenSettings),
-            _ => None,
-        };
-        if let Some(a) = action {
-            actions.push(a);
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        use muda::MenuEvent;
+        let mut actions = Vec::new();
+        while let Ok(event) = MenuEvent::receiver().try_recv() {
+            let action = match event.id().0.as_str() {
+                "open_file" => Some(MenuAction::OpenFile),
+                "new_window" => Some(MenuAction::NewWindow),
+                "close_tab" => Some(MenuAction::CloseTab),
+                "settings" => Some(MenuAction::OpenSettings),
+                _ => None,
+            };
+            if let Some(a) = action {
+                actions.push(a);
+            }
         }
+        return actions;
     }
-    actions
+
+    #[allow(unreachable_code)]
+    Vec::new()
 }

--- a/src/platform/native_menu.rs
+++ b/src/platform/native_menu.rs
@@ -1,0 +1,126 @@
+/// Cross-platform native menu bar using muda.
+///
+/// - macOS: sets NSApplication.mainMenu (system menu bar at top of screen)
+/// - Windows: attaches a Win32 menu bar to the window
+/// - Linux: no-op (handled by egui in-window menu bar in toolbar.rs)
+use muda::{
+    Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu,
+    accelerator::{Accelerator, Code, CMD_OR_CTRL},
+};
+
+/// Actions that can be triggered from the native menu bar.
+#[derive(Debug, Clone)]
+pub enum MenuAction {
+    OpenFile,
+    NewWindow,
+    CloseTab,
+    OpenSettings,
+}
+
+/// Holds the live `Menu` to prevent it from being dropped, which would
+/// remove the menu bar from the application on some platforms.
+pub struct NativeMenu {
+    _menu: Menu,
+}
+
+/// Build and register the native menu bar for the current platform.
+/// Returns `None` on Linux (egui fallback handles it instead).
+pub fn setup(
+    #[allow(unused_variables)] window_handle: raw_window_handle::RawWindowHandle,
+    _shortcuts: &crate::shortcuts::KeyboardShortcuts,
+) -> Option<NativeMenu> {
+    let menu = Menu::new();
+
+    // ── Thoth menu ─────────────────────────────────────────────────────────
+    let thoth_menu = Submenu::new("Thoth", true);
+
+    let settings_item = MenuItem::with_id(
+        "settings",
+        "Settings",
+        true,
+        Some(Accelerator::new(Some(CMD_OR_CTRL), Code::Comma)),
+    );
+
+    #[cfg(target_os = "macos")]
+    {
+        let quit_item = PredefinedMenuItem::quit(Some("Quit Thoth"));
+        let _ = thoth_menu.append_items(&[
+            &settings_item,
+            &PredefinedMenuItem::separator(),
+            &quit_item,
+        ]);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = thoth_menu.append_items(&[&settings_item]);
+    }
+
+    // ── File menu ──────────────────────────────────────────────────────────
+    let file_menu = Submenu::new("File", true);
+
+    let open_item = MenuItem::with_id(
+        "open_file",
+        "Open File…",
+        true,
+        Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyO)),
+    );
+    let new_window_item = MenuItem::with_id(
+        "new_window",
+        "New Window",
+        true,
+        Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyN)),
+    );
+    let close_tab_item = MenuItem::with_id(
+        "close_tab",
+        "Close Tab",
+        true,
+        Some(Accelerator::new(Some(CMD_OR_CTRL), Code::KeyW)),
+    );
+    let _ = file_menu.append_items(&[
+        &open_item,
+        &new_window_item,
+        &PredefinedMenuItem::separator(),
+        &close_tab_item,
+    ]);
+
+    let _ = menu.append_items(&[&thoth_menu, &file_menu]);
+
+    // ── Platform init ──────────────────────────────────────────────────────
+    #[cfg(target_os = "macos")]
+    {
+        menu.init_for_nsapp();
+        return Some(NativeMenu { _menu: menu });
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let raw_window_handle::RawWindowHandle::Win32(w) = window_handle {
+            let hwnd = w.hwnd.get() as isize;
+            let _ = unsafe { menu.init_for_hwnd(hwnd) };
+            return Some(NativeMenu { _menu: menu });
+        }
+    }
+
+    // Linux: no native init — egui menu bar used instead
+    #[allow(unreachable_code)]
+    None
+}
+
+/// Drain the muda event channel and return all pending menu actions.
+/// Should be called every frame from `ThothApp::update()`.
+pub fn poll_events() -> Vec<MenuAction> {
+    let mut actions = Vec::new();
+    while let Ok(event) = MenuEvent::receiver().try_recv() {
+        let action = match event.id().0.as_str() {
+            "open_file" => Some(MenuAction::OpenFile),
+            "new_window" => Some(MenuAction::NewWindow),
+            "close_tab" => Some(MenuAction::CloseTab),
+            "settings" => Some(MenuAction::OpenSettings),
+            _ => None,
+        };
+        if let Some(a) = action {
+            actions.push(a);
+        }
+    }
+    actions
+}

--- a/src/platform/path_registry.rs
+++ b/src/platform/path_registry.rs
@@ -155,12 +155,12 @@ pub fn register_in_path() -> Result<()> {
     let exe_path = get_executable_path()?;
     let link_path = local_bin_link()?;
 
-    if let Some(parent) = link_path.parent() {
-        if !parent.exists() {
-            std::fs::create_dir_all(parent).map_err(|e| ThothError::PathRegistryError {
-                reason: format!("Failed to create ~/.local/bin: {}", e),
-            })?;
-        }
+    if let Some(parent) = link_path.parent()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent).map_err(|e| ThothError::PathRegistryError {
+            reason: format!("Failed to create ~/.local/bin: {}", e),
+        })?;
     }
 
     if link_path.symlink_metadata().is_ok() {

--- a/src/platform/path_registry.rs
+++ b/src/platform/path_registry.rs
@@ -55,10 +55,10 @@ fn shell_escape_single_quoted(s: &str) -> String {
 #[cfg(target_os = "macos")]
 fn try_symlink_direct(exe: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {
     use std::os::unix::fs::symlink;
-    if let Some(parent) = link.parent() {
-        if !parent.exists() {
-            std::fs::create_dir_all(parent)?;
-        }
+    if let Some(parent) = link.parent()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent)?;
     }
     if link.symlink_metadata().is_ok() {
         std::fs::remove_file(link)?;

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -115,13 +115,12 @@ impl PluginManager {
         // location holds the full path to plugin.wasm — delete the parent dir
         if let Some(location) = &plugin.location {
             let wasm_path = std::path::Path::new(location);
-            if let Some(plugin_dir) = wasm_path.parent() {
-                if plugin_dir.exists() {
+            if let Some(plugin_dir) = wasm_path.parent()
+                && plugin_dir.exists() {
                     std::fs::remove_dir_all(plugin_dir).map_err(|e| ThothError::Unknown {
                         message: format!("Failed to delete plugin directory: {e}"),
                     })?;
                 }
-            }
         }
 
         self.registry.remove_plugin(id);
@@ -271,14 +270,13 @@ impl PluginManager {
         // Marketplace-installed plugins live in marketplace/installs/{id}/.
         // scan_directory can't be reused here because it appends "plugins" —
         // call scan_instances_dir directly instead.
-        if let Ok(installs_dir) = PersistentState::plugin_install_dir() {
-            if installs_dir.exists() {
+        if let Ok(installs_dir) = PersistentState::plugin_install_dir()
+            && installs_dir.exists() {
                 eprintln!("Checking marketplace installs {}", installs_dir.display());
                 if let Err(e) = self.scan_instances_dir(&installs_dir, false) {
                     eprintln!("Failed to scan marketplace installs: {e:?}");
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -116,11 +116,12 @@ impl PluginManager {
         if let Some(location) = &plugin.location {
             let wasm_path = std::path::Path::new(location);
             if let Some(plugin_dir) = wasm_path.parent()
-                && plugin_dir.exists() {
-                    std::fs::remove_dir_all(plugin_dir).map_err(|e| ThothError::Unknown {
-                        message: format!("Failed to delete plugin directory: {e}"),
-                    })?;
-                }
+                && plugin_dir.exists()
+            {
+                std::fs::remove_dir_all(plugin_dir).map_err(|e| ThothError::Unknown {
+                    message: format!("Failed to delete plugin directory: {e}"),
+                })?;
+            }
         }
 
         self.registry.remove_plugin(id);
@@ -271,12 +272,13 @@ impl PluginManager {
         // scan_directory can't be reused here because it appends "plugins" —
         // call scan_instances_dir directly instead.
         if let Ok(installs_dir) = PersistentState::plugin_install_dir()
-            && installs_dir.exists() {
-                eprintln!("Checking marketplace installs {}", installs_dir.display());
-                if let Err(e) = self.scan_instances_dir(&installs_dir, false) {
-                    eprintln!("Failed to scan marketplace installs: {e:?}");
-                }
+            && installs_dir.exists()
+        {
+            eprintln!("Checking marketplace installs {}", installs_dir.display());
+            if let Err(e) = self.scan_instances_dir(&installs_dir, false) {
+                eprintln!("Failed to scan marketplace installs: {e:?}");
             }
+        }
 
         Ok(())
     }

--- a/src/plugin/marketplace/mod.rs
+++ b/src/plugin/marketplace/mod.rs
@@ -91,8 +91,8 @@ impl MarketPlacePlugin {
             Self::update_local_file(path.clone())?;
         }
 
-        if let Ok(metadata) = fs::metadata(path.clone()) {
-            if let Ok(modified) = metadata.modified()
+        if let Ok(metadata) = fs::metadata(path.clone())
+            && let Ok(modified) = metadata.modified()
                 && let Ok(elapsed) = modified.elapsed()
                 && elapsed > one_day
             {
@@ -102,7 +102,6 @@ impl MarketPlacePlugin {
                         .map_err(|err| eprintln!("Unable to update local file - {}", err));
                 });
             }
-        }
 
         Self::read_data_from_file(path)
     }

--- a/src/plugin/marketplace/mod.rs
+++ b/src/plugin/marketplace/mod.rs
@@ -93,15 +93,15 @@ impl MarketPlacePlugin {
 
         if let Ok(metadata) = fs::metadata(path.clone())
             && let Ok(modified) = metadata.modified()
-                && let Ok(elapsed) = modified.elapsed()
-                && elapsed > one_day
-            {
-                let path_clone = path.clone();
-                thread::spawn(|| {
-                    let _ = Self::update_local_file(path_clone)
-                        .map_err(|err| eprintln!("Unable to update local file - {}", err));
-                });
-            }
+            && let Ok(elapsed) = modified.elapsed()
+            && elapsed > one_day
+        {
+            let path_clone = path.clone();
+            thread::spawn(|| {
+                let _ = Self::update_local_file(path_clone)
+                    .map_err(|err| eprintln!("Unable to update local file - {}", err));
+            });
+        }
 
         Self::read_data_from_file(path)
     }

--- a/src/plugin/render_node.rs
+++ b/src/plugin/render_node.rs
@@ -924,13 +924,14 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                 },
             );
             if output.close_requested
-                && let Some(cid) = close_id {
-                    events.push(UiEvent {
-                        widget_id: cid.clone(),
-                        kind: "click".to_string(),
-                        value: String::new(),
-                    });
-                }
+                && let Some(cid) = close_id
+            {
+                events.push(UiEvent {
+                    widget_id: cid.clone(),
+                    kind: "click".to_string(),
+                    value: String::new(),
+                });
+            }
         }
 
         // ── Inputs ────────────────────────────────────────────────────────
@@ -1552,14 +1553,15 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
             );
 
             if let Some(val) = output.selected
-                && let Ok(new_idx) = val.parse::<usize>() {
-                    active_idx = new_idx;
-                    ui.ctx().data_mut(|d| d.insert_temp(mem_id, active_idx));
-                    // Notify the plugin which header label was selected.
-                    if let Some(h) = header.get(active_idx) {
-                        events.push(ui_event(id, "change", json_str(h)));
-                    }
+                && let Ok(new_idx) = val.parse::<usize>()
+            {
+                active_idx = new_idx;
+                ui.ctx().data_mut(|d| d.insert_temp(mem_id, active_idx));
+                // Notify the plugin which header label was selected.
+                if let Some(h) = header.get(active_idx) {
+                    events.push(ui_event(id, "change", json_str(h)));
                 }
+            }
 
             if let Some(child) = children.get(active_idx) {
                 egui::Frame::new()

--- a/src/plugin/render_node.rs
+++ b/src/plugin/render_node.rs
@@ -839,6 +839,7 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                         }
                     }),
                     selected: false,
+                    accent: None,
                     tags: &[],
                 })
                 .collect();
@@ -854,6 +855,7 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                         shrink_to_fit: false,
                         show_separators: true,
                         compact: false,
+                        max_height: None,
                     },
                 );
 

--- a/src/plugin/render_node.rs
+++ b/src/plugin/render_node.rs
@@ -921,15 +921,14 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                     }),
                 },
             );
-            if output.close_requested {
-                if let Some(cid) = close_id {
+            if output.close_requested
+                && let Some(cid) = close_id {
                     events.push(UiEvent {
                         widget_id: cid.clone(),
                         kind: "click".to_string(),
                         value: String::new(),
                     });
                 }
-            }
         }
 
         // ── Inputs ────────────────────────────────────────────────────────
@@ -1550,8 +1549,8 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                 },
             );
 
-            if let Some(val) = output.selected {
-                if let Ok(new_idx) = val.parse::<usize>() {
+            if let Some(val) = output.selected
+                && let Ok(new_idx) = val.parse::<usize>() {
                     active_idx = new_idx;
                     ui.ctx().data_mut(|d| d.insert_temp(mem_id, active_idx));
                     // Notify the plugin which header label was selected.
@@ -1559,7 +1558,6 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                         events.push(ui_event(id, "change", json_str(h)));
                     }
                 }
-            }
 
             if let Some(child) = children.get(active_idx) {
                 egui::Frame::new()

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -129,11 +129,10 @@ impl DataSourcePluginState {
                 if let Ok(tx) = retry_tx.lock() {
                     let _ = tx.send((retry_id.clone(), req.clone()));
                 }
-                if remember {
-                    if let Ok(mut list) = runtime_allowed.lock() {
+                if remember
+                    && let Ok(mut list) = runtime_allowed.lock() {
                         list.push(dom.clone());
                     }
-                }
             }),
             on_deny,
         );
@@ -175,11 +174,10 @@ impl thoth::plugin::http_client::Host for DataSourcePluginState {
                     &domain,
                     &self.plugin_id,
                     Arc::new(move |remember: bool| {
-                        if remember {
-                            if let Ok(mut list) = runtime_allowed.lock() {
+                        if remember
+                            && let Ok(mut list) = runtime_allowed.lock() {
                                 list.push(dom.clone());
                             }
-                        }
                     }),
                     Arc::new(|_| {}),
                 );

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -129,10 +129,9 @@ impl DataSourcePluginState {
                 if let Ok(tx) = retry_tx.lock() {
                     let _ = tx.send((retry_id.clone(), req.clone()));
                 }
-                if remember
-                    && let Ok(mut list) = runtime_allowed.lock() {
-                        list.push(dom.clone());
-                    }
+                if remember && let Ok(mut list) = runtime_allowed.lock() {
+                    list.push(dom.clone());
+                }
             }),
             on_deny,
         );
@@ -174,10 +173,9 @@ impl thoth::plugin::http_client::Host for DataSourcePluginState {
                     &domain,
                     &self.plugin_id,
                     Arc::new(move |remember: bool| {
-                        if remember
-                            && let Ok(mut list) = runtime_allowed.lock() {
-                                list.push(dom.clone());
-                            }
+                        if remember && let Ok(mut list) = runtime_allowed.lock() {
+                            list.push(dom.clone());
+                        }
                     }),
                     Arc::new(|_| {}),
                 );

--- a/src/search/jsonpath.rs
+++ b/src/search/jsonpath.rs
@@ -116,9 +116,10 @@ impl JsonPathQuery {
         let mut matches = Vec::new();
         for (path, value) in current {
             if self.matches_filter(value, match_case)
-                && let Some(entry) = JsonPathMatch::from_value(path, value) {
-                    matches.push(entry);
-                }
+                && let Some(entry) = JsonPathMatch::from_value(path, value)
+            {
+                matches.push(entry);
+            }
         }
         matches
     }
@@ -386,9 +387,10 @@ impl PathSegment {
         match self {
             PathSegment::Field(name) => {
                 if let Value::Object(map) = value
-                    && let Some(child) = map.get(name) {
-                        out.push((format!("{}.{}", current_path, name), child));
-                    }
+                    && let Some(child) = map.get(name)
+                {
+                    out.push((format!("{}.{}", current_path, name), child));
+                }
             }
             PathSegment::FieldWildcard => {
                 if let Value::Object(map) = value {
@@ -399,9 +401,10 @@ impl PathSegment {
             }
             PathSegment::ArrayIndex(idx) => {
                 if let Value::Array(items) = value
-                    && let Some(child) = items.get(*idx) {
-                        out.push((format!("{}[{}]", current_path, idx), child));
-                    }
+                    && let Some(child) = items.get(*idx)
+                {
+                    out.push((format!("{}[{}]", current_path, idx), child));
+                }
             }
             PathSegment::ArrayWildcard => {
                 if let Value::Array(items) = value {

--- a/src/search/jsonpath.rs
+++ b/src/search/jsonpath.rs
@@ -115,11 +115,10 @@ impl JsonPathQuery {
 
         let mut matches = Vec::new();
         for (path, value) in current {
-            if self.matches_filter(value, match_case) {
-                if let Some(entry) = JsonPathMatch::from_value(path, value) {
+            if self.matches_filter(value, match_case)
+                && let Some(entry) = JsonPathMatch::from_value(path, value) {
                     matches.push(entry);
                 }
-            }
         }
         matches
     }
@@ -386,11 +385,10 @@ impl PathSegment {
     fn apply<'a>(&self, current_path: &str, value: &'a Value, out: &mut Vec<(String, &'a Value)>) {
         match self {
             PathSegment::Field(name) => {
-                if let Value::Object(map) = value {
-                    if let Some(child) = map.get(name) {
+                if let Value::Object(map) = value
+                    && let Some(child) = map.get(name) {
                         out.push((format!("{}.{}", current_path, name), child));
                     }
-                }
             }
             PathSegment::FieldWildcard => {
                 if let Value::Object(map) = value {
@@ -400,11 +398,10 @@ impl PathSegment {
                 }
             }
             PathSegment::ArrayIndex(idx) => {
-                if let Value::Array(items) = value {
-                    if let Some(child) = items.get(*idx) {
+                if let Value::Array(items) = value
+                    && let Some(child) = items.get(*idx) {
                         out.push((format!("{}[{}]", current_path, idx), child));
                     }
-                }
             }
             PathSegment::ArrayWildcard => {
                 if let Value::Array(items) = value {

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -115,8 +115,18 @@ impl Shortcut {
 pub struct KeyboardShortcuts {
     // File operations
     pub open_file: Shortcut,
-    pub clear_file: Shortcut,
     pub new_window: Shortcut,
+
+    // Tab operations — bump serde key names when defaults change to avoid stale persisted values.
+    #[serde(rename = "tab_close")]
+    pub close_tab: Shortcut,
+    #[serde(rename = "tab_new")]
+    pub new_tab: Shortcut,
+    // v3: ⌘⌥→ / ⌘⌥← (arrow keys, no composition issues, not OS-intercepted)
+    #[serde(rename = "tab_cycle_next")]
+    pub next_tab: Shortcut,
+    #[serde(rename = "tab_cycle_prev")]
+    pub prev_tab: Shortcut,
 
     // Navigation
     pub focus_search: Shortcut,
@@ -159,8 +169,14 @@ impl Default for KeyboardShortcuts {
         Self {
             // File operations - use COMMAND for cross-platform (Cmd on Mac, Ctrl elsewhere)
             open_file: Shortcut::new("O").command(),
-            clear_file: Shortcut::new("W").command(),
             new_window: Shortcut::new("N").command(),
+
+            // Tab operations
+            close_tab: Shortcut::new("W").command(),
+            new_tab: Shortcut::new("T").command(),
+            // ⌘⌥→ / ⌘⌥← — Firefox-style, arrow keys have no char-composition issues.
+            next_tab: Shortcut::new("ArrowRight").command().alt(),
+            prev_tab: Shortcut::new("ArrowLeft").command().alt(),
 
             // Navigation
             focus_search: Shortcut::new("F").command(),
@@ -363,5 +379,10 @@ mod tests {
         let shortcuts = KeyboardShortcuts::default();
         assert!(shortcuts.open_file.command);
         assert_eq!(shortcuts.open_file.key, "O");
+        assert_eq!(shortcuts.close_tab.key, "W");
+        assert!(shortcuts.close_tab.command);
+        assert_eq!(shortcuts.next_tab.key, "ArrowRight");
+        assert!(shortcuts.next_tab.command && shortcuts.next_tab.alt);
+        assert_eq!(shortcuts.prev_tab.key, "ArrowLeft");
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -113,11 +113,10 @@ impl NavigationHistory {
     /// If we're not at the end of history, this truncates forward history
     pub fn push(&mut self, path: String) {
         // Don't add if it's the same as the current path
-        if let Some(idx) = self.current_index {
-            if idx < self.history.len() && self.history[idx] == path {
+        if let Some(idx) = self.current_index
+            && idx < self.history.len() && self.history[idx] == path {
                 return;
             }
-        }
 
         // If we're in the middle of history, truncate everything after current
         if let Some(idx) = self.current_index {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
 use crate::{
+    app::tab_manager::TabManager,
     components,
-    error::ThothError,
-    file,
     plugin::{render_node::UiOutput, wasm_data_source::WasmDataSourceLoader},
-    search, update,
+    search,
+    update,
 };
 
 /// Holds the active plugin pane shown in the main area.
@@ -23,27 +23,15 @@ pub struct ActivePluginPane {
 mod tests;
 
 // ============================================================================
-// Window State - Per-window state (file, search, UI)
+// Window State - Per-window state (UI chrome + tab manager)
 // ============================================================================
 
-/// Per-window state - each window has its own file, search, and UI components
-/// Note: This is independent of PersistentState which is shared application-wide
+/// Per-window state. File/search/navigation state lives inside each tab via TabManager.
 pub struct WindowState {
-    // File state
-    pub file_path: Option<PathBuf>,
-    pub file_type: file::lazy_loader::FileKind,
-    pub error: Option<ThothError>,
-    pub total_items: usize,
+    // Tab manager owns all per-tab state and the dock layout.
+    pub tab_manager: TabManager,
 
-    // Search state
-    pub search_engine_state: SearchEngineState,
-
-    // Navigation state
-    pub navigation_history: NavigationHistory,
-    /// Pending navigation to apply after file loads
-    pub pending_navigation: Option<String>,
-
-    // UI state
+    // Sidebar state (global — one sidebar for all tabs)
     pub sidebar_expanded: bool,
     pub sidebar_selected_section: Option<components::sidebar::SidebarSection>,
     /// Track previous section to determine when to focus search
@@ -51,18 +39,9 @@ pub struct WindowState {
     /// Track previous expanded state to detect sidebar reopening
     pub previous_sidebar_expanded: bool,
 
-    /// Plugin-driven main-pane content. When `Some`, `CentralPanel` renders this
-    /// instead of the file viewer. Cleared when a new file is opened.
-    pub active_plugin_pane: Option<ActivePluginPane>,
-
-    /// Cached sidebar output from the active ui-component plugin's `render-sidebar`.
-    /// `None` means the plugin has no sidebar content.
-    pub plugin_sidebar_output: Option<crate::plugin::render_node::UiOutput>,
-
-    // UI components
+    // UI components (global)
     pub sidebar: components::sidebar::Sidebar,
     pub toolbar: components::toolbar::Toolbar,
-    pub central_panel: components::central_panel::CentralPanel,
     pub status_bar: components::status_bar::StatusBar,
     pub error_modal: components::error_modal::ErrorModal,
 }
@@ -70,25 +49,23 @@ pub struct WindowState {
 impl Default for WindowState {
     fn default() -> Self {
         Self {
-            file_path: None,
-            file_type: file::lazy_loader::FileKind::default(),
-            error: None,
-            total_items: 0,
-            search_engine_state: SearchEngineState::default(),
-            navigation_history: NavigationHistory::default(),
-            pending_navigation: None,
-            active_plugin_pane: None,
+            tab_manager: TabManager::new(NavigationHistory::DEFAULT_CAPACITY),
             sidebar_expanded: true,
             sidebar_selected_section: Some(components::sidebar::SidebarSection::RecentFiles),
             previous_sidebar_section: None,
             previous_sidebar_expanded: false,
-            plugin_sidebar_output: None,
             sidebar: components::sidebar::Sidebar::default(),
             toolbar: components::toolbar::Toolbar::default(),
-            central_panel: components::central_panel::CentralPanel::default(),
             status_bar: components::status_bar::StatusBar::default(),
             error_modal: components::error_modal::ErrorModal,
         }
+    }
+}
+
+impl WindowState {
+    /// Convenience accessor — delegates to the tab manager.
+    pub fn active_tab_mut(&mut self) -> Option<&mut crate::app::tab_manager::TabState> {
+        self.tab_manager.active_tab_mut()
     }
 }
 
@@ -114,9 +91,13 @@ pub struct NavigationHistory {
 }
 
 impl NavigationHistory {
+    pub const DEFAULT_CAPACITY: usize = 100;
+}
+
+impl NavigationHistory {
     /// Create a new navigation history with default max size
     pub fn new() -> Self {
-        Self::with_capacity(100)
+        Self::with_capacity(Self::DEFAULT_CAPACITY)
     }
 
     /// Create a new navigation history with specified max size

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,8 +4,7 @@ use crate::{
     app::tab_manager::TabManager,
     components,
     plugin::{render_node::UiOutput, wasm_data_source::WasmDataSourceLoader},
-    search,
-    update,
+    search, update,
 };
 
 /// Holds the active plugin pane shown in the main area.
@@ -114,9 +113,11 @@ impl NavigationHistory {
     pub fn push(&mut self, path: String) {
         // Don't add if it's the same as the current path
         if let Some(idx) = self.current_index
-            && idx < self.history.len() && self.history[idx] == path {
-                return;
-            }
+            && idx < self.history.len()
+            && self.history[idx] == path
+        {
+            return;
+        }
 
         // If we're in the middle of history, truncate everything after current
         if let Some(idx) = self.current_index {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -304,6 +304,53 @@ impl ThemeColors {
             special: hex(self.error),
         }
     }
+
+    /// Build a Catppuccin-themed [`egui_dock::Style`] from these colors.
+    pub fn dock_style(&self, egui_style: &egui::Style) -> egui_dock::Style {
+        let mut style = egui_dock::Style::from_egui(egui_style);
+        let zero_rounding = egui::CornerRadius::ZERO;
+
+        style.tab_bar.bg_fill = self.bg_sunken;
+        style.tab_bar.height = 35.0;
+        style.tab_bar.hline_color = self.surface;
+
+        style.tab.tab_body.bg_fill = self.bg;
+        style.tab.tab_body.inner_margin = egui::Margin::ZERO;
+        style.tab.tab_body.stroke = egui::Stroke::NONE;
+
+        style.tab.active.bg_fill = self.bg;
+        style.tab.active.text_color = self.fg;
+        style.tab.active.outline_color = self.accent;
+        style.tab.active.corner_radius = zero_rounding;
+
+        style.tab.focused.bg_fill = self.bg;
+        style.tab.focused.text_color = self.fg;
+        style.tab.focused.outline_color = self.accent;
+        style.tab.focused.corner_radius = zero_rounding;
+
+        style.tab.inactive.bg_fill = self.bg_sunken;
+        style.tab.inactive.text_color = self.fg_muted;
+        style.tab.inactive.outline_color = Color32::TRANSPARENT;
+        style.tab.inactive.corner_radius = zero_rounding;
+
+        style.tab.hovered.bg_fill = self.surface;
+        style.tab.hovered.text_color = self.fg;
+        style.tab.hovered.outline_color = Color32::TRANSPARENT;
+        style.tab.hovered.corner_radius = zero_rounding;
+
+        style.tab.inactive_with_kb_focus = style.tab.inactive.clone();
+        style.tab.active_with_kb_focus = style.tab.active.clone();
+        style.tab.focused_with_kb_focus = style.tab.focused.clone();
+
+        style.tab.hline_below_active_tab_name = false;
+
+        style.separator.width = 4.0;
+        style.separator.color_idle = self.surface;
+        style.separator.color_hovered = self.accent;
+        style.separator.color_dragged = self.accent;
+
+        style
+    }
 }
 
 // ── apply_fonts ───────────────────────────────────────────────────────────────

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -314,7 +314,12 @@ impl ThemeColors {
         style.tab_bar.bg_fill = self.bg_sunken;
         style.tab_bar.height = 28.0;
         // Side padding on the tab bar strip itself.
-        style.tab_bar.inner_margin = egui::Margin { left: 12, right: 12, top: 0, bottom: 0 };
+        style.tab_bar.inner_margin = egui::Margin {
+            left: 12,
+            right: 12,
+            top: 0,
+            bottom: 0,
+        };
         style.tab_bar.hline_color = self.surface;
 
         // ── Tab body ──────────────────────────────────────────────────────────
@@ -395,24 +400,25 @@ pub fn apply_fonts(ctx: &egui::Context, settings: &Settings) {
     );
 
     if let Some(family) = &settings.font_family
-        && let Some(bytes) = crate::platform::find_font_bytes(family) {
-            fonts.font_data.insert(
-                family.clone(),
-                std::sync::Arc::new(egui::FontData::from_owned(bytes)),
-            );
+        && let Some(bytes) = crate::platform::find_font_bytes(family)
+    {
+        fonts.font_data.insert(
+            family.clone(),
+            std::sync::Arc::new(egui::FontData::from_owned(bytes)),
+        );
 
-            // Monospace-style fonts: prepend to both Proportional and Monospace stacks.
-            // Purely proportional fonts (e.g. Inter) only go into Proportional.
-            let is_mono = !matches!(family.as_str(), "Inter");
-            for target in [egui::FontFamily::Proportional]
-                .iter()
-                .chain(is_mono.then_some(&egui::FontFamily::Monospace))
-            {
-                if let Some(list) = fonts.families.get_mut(target) {
-                    list.insert(0, family.clone());
-                }
+        // Monospace-style fonts: prepend to both Proportional and Monospace stacks.
+        // Purely proportional fonts (e.g. Inter) only go into Proportional.
+        let is_mono = !matches!(family.as_str(), "Inter");
+        for target in [egui::FontFamily::Proportional]
+            .iter()
+            .chain(is_mono.then_some(&egui::FontFamily::Monospace))
+        {
+            if let Some(list) = fonts.families.get_mut(target) {
+                list.insert(0, family.clone());
             }
         }
+    }
 
     ctx.set_fonts(fonts);
     ctx.memory_mut(|m| m.data.insert_temp(cache_key, settings.font_family.clone()));

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -331,8 +331,8 @@ pub fn apply_fonts(ctx: &egui::Context, settings: &Settings) {
         vec!["phosphor".into()],
     );
 
-    if let Some(family) = &settings.font_family {
-        if let Some(bytes) = crate::platform::find_font_bytes(family) {
+    if let Some(family) = &settings.font_family
+        && let Some(bytes) = crate::platform::find_font_bytes(family) {
             fonts.font_data.insert(
                 family.clone(),
                 std::sync::Arc::new(egui::FontData::from_owned(bytes)),
@@ -350,7 +350,6 @@ pub fn apply_fonts(ctx: &egui::Context, settings: &Settings) {
                 }
             }
         }
-    }
 
     ctx.set_fonts(fonts);
     ctx.memory_mut(|m| m.data.insert_temp(cache_key, settings.font_family.clone()));

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -310,14 +310,19 @@ impl ThemeColors {
         let mut style = egui_dock::Style::from_egui(egui_style);
         let zero_rounding = egui::CornerRadius::ZERO;
 
+        // ── Tab bar ───────────────────────────────────────────────────────────
         style.tab_bar.bg_fill = self.bg_sunken;
-        style.tab_bar.height = 35.0;
+        style.tab_bar.height = 28.0;
+        // Side padding on the tab bar strip itself.
+        style.tab_bar.inner_margin = egui::Margin { left: 12, right: 12, top: 0, bottom: 0 };
         style.tab_bar.hline_color = self.surface;
 
+        // ── Tab body ──────────────────────────────────────────────────────────
         style.tab.tab_body.bg_fill = self.bg;
         style.tab.tab_body.inner_margin = egui::Margin::ZERO;
         style.tab.tab_body.stroke = egui::Stroke::NONE;
 
+        // ── Active / focused tab: top+side accent (bottom covered by egui_dock) ─
         style.tab.active.bg_fill = self.bg;
         style.tab.active.text_color = self.fg;
         style.tab.active.outline_color = self.accent;
@@ -328,11 +333,13 @@ impl ThemeColors {
         style.tab.focused.outline_color = self.accent;
         style.tab.focused.corner_radius = zero_rounding;
 
+        // ── Inactive tab: no visible border ───────────────────────────────────
         style.tab.inactive.bg_fill = self.bg_sunken;
         style.tab.inactive.text_color = self.fg_muted;
         style.tab.inactive.outline_color = Color32::TRANSPARENT;
         style.tab.inactive.corner_radius = zero_rounding;
 
+        // ── Hovered tab ───────────────────────────────────────────────────────
         style.tab.hovered.bg_fill = self.surface;
         style.tab.hovered.text_color = self.fg;
         style.tab.hovered.outline_color = Color32::TRANSPARENT;
@@ -344,6 +351,15 @@ impl ThemeColors {
 
         style.tab.hline_below_active_tab_name = false;
 
+        // ── Close (×) button: invisible until cursor enters the × hit-area ───
+        // egui_dock doesn't support "show × on tab hover" — the best available
+        // approximation is keeping the × transparent until the pointer is over
+        // the × itself. The hit-target is always present for middle-click close.
+        style.buttons.close_tab_color = Color32::TRANSPARENT;
+        style.buttons.close_tab_active_color = self.fg_muted;
+        style.buttons.close_tab_bg_fill = self.surface_raised;
+
+        // ── Separator between split panes ─────────────────────────────────────
         style.separator.width = 4.0;
         style.separator.color_idle = self.surface;
         style.separator.color_hovered = self.accent;

--- a/src/update/manager.rs
+++ b/src/update/manager.rs
@@ -295,11 +295,10 @@ impl UpdateManager {
                 return Ok(path);
             }
 
-            if path.is_dir() {
-                if let Ok(found) = Self::find_executable(&path) {
+            if path.is_dir()
+                && let Ok(found) = Self::find_executable(&path) {
                     return Ok(found);
                 }
-            }
         }
 
         Err(ThothError::UpdateInstallError {

--- a/src/update/manager.rs
+++ b/src/update/manager.rs
@@ -296,9 +296,10 @@ impl UpdateManager {
             }
 
             if path.is_dir()
-                && let Ok(found) = Self::find_executable(&path) {
-                    return Ok(found);
-                }
+                && let Ok(found) = Self::find_executable(&path)
+            {
+                return Ok(found);
+            }
         }
 
         Err(ThothError::UpdateInstallError {

--- a/tests/file_association_tests.rs
+++ b/tests/file_association_tests.rs
@@ -165,7 +165,11 @@ fn thoth_app_picks_up_os_dispatched_file() {
     app.poll_os_open_requests();
 
     assert!(
-        app.window_state.tab_manager.tabs.values().any(|t| t.file_path.as_deref() == Some(path.as_path())),
+        app.window_state
+            .tab_manager
+            .tabs
+            .values()
+            .any(|t| t.file_path.as_deref() == Some(path.as_path())),
         "poll_os_open_requests must open the OS-dispatched file in some tab"
     );
 }
@@ -177,7 +181,10 @@ fn argv_path_still_loads_on_construction() {
     let path = make_temp_json_file("argv_test.json");
     let mut app = ThothApp::new(Settings::default(), Some(path.clone()));
     assert_eq!(
-        app.window_state.tab_manager.active_tab_mut().and_then(|t| t.file_path.as_deref()),
+        app.window_state
+            .tab_manager
+            .active_tab_mut()
+            .and_then(|t| t.file_path.as_deref()),
         Some(path.as_path()),
         "file_to_open passed via argv must set the active tab's file_path in constructor"
     );
@@ -193,14 +200,24 @@ fn second_os_dispatch_replaces_current_file() {
 
     // App launched with first file via argv
     let mut app = ThothApp::new(Settings::default(), Some(p1.clone()));
-    assert!(app.window_state.tab_manager.tabs.values().any(|t| t.file_path.as_deref() == Some(p1.as_path())));
+    assert!(
+        app.window_state
+            .tab_manager
+            .tabs
+            .values()
+            .any(|t| t.file_path.as_deref() == Some(p1.as_path()))
+    );
 
     // OS dispatches a second file — with multi-tab support it opens in a new tab.
     file_open_channel::enqueue_open_request(p2.clone());
     app.poll_os_open_requests();
 
     assert!(
-        app.window_state.tab_manager.tabs.values().any(|t| t.file_path.as_deref() == Some(p2.as_path())),
+        app.window_state
+            .tab_manager
+            .tabs
+            .values()
+            .any(|t| t.file_path.as_deref() == Some(p2.as_path())),
         "OS-dispatched file must appear in some tab"
     );
 }
@@ -223,11 +240,17 @@ fn os_dispatch_clears_previous_error() {
     app.poll_os_open_requests();
 
     assert!(
-        app.window_state.tab_manager.active_tab_mut().is_none_or(|t| t.error.is_none()),
+        app.window_state
+            .tab_manager
+            .active_tab_mut()
+            .is_none_or(|t| t.error.is_none()),
         "OS-dispatched file must clear any previous error on the active tab"
     );
     assert_eq!(
-        app.window_state.tab_manager.active_tab_mut().and_then(|t| t.file_path.as_deref()),
+        app.window_state
+            .tab_manager
+            .active_tab_mut()
+            .and_then(|t| t.file_path.as_deref()),
         Some(path.as_path())
     );
 }

--- a/tests/file_association_tests.rs
+++ b/tests/file_association_tests.rs
@@ -41,7 +41,9 @@ fn reset() {
 /// Serialize all tests in this file to avoid races on the shared global queue.
 fn test_guard() -> std::sync::MutexGuard<'static, ()> {
     static TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
-    TEST_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap()
+    let mutex = TEST_MUTEX.get_or_init(|| Mutex::new(()));
+    // Recover from a poisoned mutex so one test failure doesn't cascade.
+    mutex.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 // ---------------------------------------------------------------------------
@@ -152,7 +154,7 @@ fn thoth_app_picks_up_os_dispatched_file() {
 
     // Launch app with no file (simulates Finder-launched empty window)
     let mut app = ThothApp::new(Settings::default(), None);
-    assert!(app.window_state.file_path.is_none());
+    assert!(app.window_state.tab_manager.active_tab_mut().and_then(|t| t.file_path.as_deref()).is_none());
 
     // Simulate macOS dispatching a file via Apple Event
     let path = make_temp_json_file("os_dispatch.json");
@@ -162,9 +164,9 @@ fn thoth_app_picks_up_os_dispatched_file() {
     app.poll_os_open_requests();
 
     assert_eq!(
-        app.window_state.file_path.as_deref(),
+        app.window_state.tab_manager.active_tab_mut().and_then(|t| t.file_path.as_deref()),
         Some(path.as_path()),
-        "poll_os_open_requests must set window_state.file_path"
+        "poll_os_open_requests must set the active tab's file_path"
     );
 }
 
@@ -173,11 +175,11 @@ fn argv_path_still_loads_on_construction() {
     let _guard = test_guard();
     // This guards against regressions: the existing CLI flow must keep working.
     let path = make_temp_json_file("argv_test.json");
-    let app = ThothApp::new(Settings::default(), Some(path.clone()));
+    let mut app = ThothApp::new(Settings::default(), Some(path.clone()));
     assert_eq!(
-        app.window_state.file_path.as_deref(),
+        app.window_state.tab_manager.active_tab_mut().and_then(|t| t.file_path.as_deref()),
         Some(path.as_path()),
-        "file_to_open passed via argv must set window_state.file_path in constructor"
+        "file_to_open passed via argv must set the active tab's file_path in constructor"
     );
 }
 
@@ -191,16 +193,15 @@ fn second_os_dispatch_replaces_current_file() {
 
     // App launched with first file via argv
     let mut app = ThothApp::new(Settings::default(), Some(p1.clone()));
-    assert_eq!(app.window_state.file_path.as_deref(), Some(p1.as_path()));
+    assert!(app.window_state.tab_manager.tabs.values().any(|t| t.file_path.as_deref() == Some(p1.as_path())));
 
-    // OS dispatches a second file (e.g. user double-clicks another .json in Finder)
+    // OS dispatches a second file — with multi-tab support it opens in a new tab.
     file_open_channel::enqueue_open_request(p2.clone());
     app.poll_os_open_requests();
 
-    assert_eq!(
-        app.window_state.file_path.as_deref(),
-        Some(p2.as_path()),
-        "OS-dispatched file must replace the currently loaded file"
+    assert!(
+        app.window_state.tab_manager.tabs.values().any(|t| t.file_path.as_deref() == Some(p2.as_path())),
+        "OS-dispatched file must appear in some tab"
     );
 }
 
@@ -210,18 +211,23 @@ fn os_dispatch_clears_previous_error() {
     reset();
 
     let mut app = ThothApp::new(Settings::default(), None);
-    // Simulate an error state
-    app.window_state.error = Some(thoth::error::ThothError::Unknown {
-        message: "test error".to_string(),
-    });
+    // Simulate an error state on the active tab
+    if let Some(tab) = app.window_state.tab_manager.active_tab_mut() {
+        tab.error = Some(thoth::error::ThothError::Unknown {
+            message: "test error".to_string(),
+        });
+    }
 
     let path = make_temp_json_file("clear_error.json");
     file_open_channel::enqueue_open_request(path.clone());
     app.poll_os_open_requests();
 
     assert!(
-        app.window_state.error.is_none(),
-        "OS-dispatched file must clear any previous error"
+        app.window_state.tab_manager.active_tab_mut().is_none_or(|t| t.error.is_none()),
+        "OS-dispatched file must clear any previous error on the active tab"
     );
-    assert_eq!(app.window_state.file_path.as_deref(), Some(path.as_path()));
+    assert_eq!(
+        app.window_state.tab_manager.active_tab_mut().and_then(|t| t.file_path.as_deref()),
+        Some(path.as_path())
+    );
 }

--- a/tests/file_association_tests.rs
+++ b/tests/file_association_tests.rs
@@ -152,9 +152,10 @@ fn thoth_app_picks_up_os_dispatched_file() {
     let _guard = test_guard();
     reset();
 
-    // Launch app with no file (simulates Finder-launched empty window)
+    // Launch app with no file (simulates Finder-launched empty window).
+    // Session restore may reopen previously-open tabs, so we don't assert a blank
+    // initial state — that is legitimate behaviour.
     let mut app = ThothApp::new(Settings::default(), None);
-    assert!(app.window_state.tab_manager.active_tab_mut().and_then(|t| t.file_path.as_deref()).is_none());
 
     // Simulate macOS dispatching a file via Apple Event
     let path = make_temp_json_file("os_dispatch.json");
@@ -163,10 +164,9 @@ fn thoth_app_picks_up_os_dispatched_file() {
     // Drive the OS-dispatch drain (this method must exist for the fix to work)
     app.poll_os_open_requests();
 
-    assert_eq!(
-        app.window_state.tab_manager.active_tab_mut().and_then(|t| t.file_path.as_deref()),
-        Some(path.as_path()),
-        "poll_os_open_requests must set the active tab's file_path"
+    assert!(
+        app.window_state.tab_manager.tabs.values().any(|t| t.file_path.as_deref() == Some(path.as_path())),
+        "poll_os_open_requests must open the OS-dispatched file in some tab"
     );
 }
 


### PR DESCRIPTION
closes #78 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-tab interface with session persistence, tab-aware UI, tab open/close/switch/cycle and numeric tab switching
  * Native menu bar on macOS/Windows and a Welcome screen with recent files
  * Update consent modal with “Update Now” action and pinned notifications
  * Sidebar “Settings” button and tab-aware drag‑and‑drop that opens files into tabs

* **Documentation**
  * Keyboard shortcuts guide expanded with tab operations

* **Other**
  * Rust toolchain requirement bumped to 1.92; docking support added

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anitnilay20/thoth/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->