### PR TITLE
ci+fix: release pipeline fixes, OTA plugin sync, Windows per-user installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,12 @@ jobs:
       # bumps: unchanged crates like wasmtime still hit the cache even after
       # adding/removing other dependencies.
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       # Cache cargo registry and installed binaries (cargo-packager, cargo-component).
       # cache-targets is false because sccache handles compilation caching.
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "release-${{ runner.os }}"
           cache-targets: false
@@ -89,7 +89,7 @@ jobs:
 
       # cargo-binstall downloads pre-compiled binaries — no source compilation.
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.19.1
+        uses: cargo-bins/cargo-binstall@aaa84a43aec4955a42c5ffc65d258961e39f276e # v1.19.1
 
       # Install tools from pre-built binaries (~5s each vs 1–5 min from source)
       - name: Install cargo-packager

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,15 +51,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      # Use Swatinem's rust-cache action for optimized Rust caching
-      - name: Cache Rust dependencies and build artifacts
+      # sccache caches individual crate compilation units keyed on source hash —
+      # unlike Swatinem (which keys on Cargo.lock), sccache survives Cargo.lock
+      # bumps: unchanged crates like wasmtime still hit the cache even after
+      # adding/removing other dependencies.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      # Cache cargo registry and installed binaries (cargo-packager, cargo-component).
+      # cache-targets is false because sccache handles compilation caching.
+      - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          # Cache key includes OS and Cargo.lock hash
           shared-key: "release-${{ runner.os }}"
-          # Cache the target directory
-          cache-targets: true
-          # Also cache cargo registry
+          cache-targets: false
           cache-all-crates: true
 
       # Ensure we have the right target for cross-compilation
@@ -82,17 +87,13 @@ jobs:
           echo "Matrix Target: ${{ matrix.target }}"
           echo "Matrix OS: ${{ matrix.os }}"
 
-      # Install cargo-packager (stable cross-platform bundler)
+      # cargo-binstall downloads pre-compiled binaries — no source compilation.
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.19.1
+
+      # Install tools from pre-built binaries (~5s each vs 1–5 min from source)
       - name: Install cargo-packager
-        run: cargo install cargo-packager --locked
-
-      # Install cargo-component for building WASM plugins
-      - name: Install cargo-component
-        run: cargo install cargo-component --locked
-
-      # Add WASM target required by cargo-component plugin builds
-      - name: Add wasm32-wasip1 target
-        run: rustup target add wasm32-wasip1
+        run: cargo binstall cargo-packager --no-confirm --locked
 
       # macOS-specific dependencies
       # Note: cargo-packager handles DMG creation natively, no extra tools needed
@@ -117,15 +118,52 @@ jobs:
             Write-Host "WiX Toolset found at: $wixPath"
           }
 
+      # Build main app first — cargo-component is absent so build.rs skips
+      # plugin compilation. This keeps the heavy cranelift compile as the only
+      # work in this step, letting sccache cache it cleanly.
       - name: Build release binary
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
         run: cargo build --release
+
+      # Install cargo-component after the main build so it doesn't affect the
+      # main build's sccache keys or add noise to the build.rs subprocess chain.
+      - name: Install cargo-component
+        run: cargo binstall cargo-component --no-confirm
+
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
+
+      # Build WASM plugins explicitly with sccache so plugin crates are cached
+      # independently of the main app build.
+      - name: Build WASM plugins
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+        shell: bash
+        run: |
+          for plugin_dir in plugins/*/; do
+            [ -f "$plugin_dir/Cargo.toml" ] || continue  # skip theme plugins
+            plugin_name=$(basename "$plugin_dir")
+            cargo component build --release --target wasm32-wasip1 \
+              --manifest-path "$plugin_dir/Cargo.toml"
+            wasm_name="${plugin_name//-/_}"
+            dst="assets/plugins/$plugin_name"
+            mkdir -p "$dst"
+            cp "target/wasm32-wasip1/release/${wasm_name}.wasm" "$dst/plugin.wasm"
+            cp "$plugin_dir/plugin.toml" "$dst/plugin.toml"
+            [ -f "$plugin_dir/icon.png" ] && cp "$plugin_dir/icon.png" "$dst/icon.png" || true
+          done
 
       # Create bundles for each platform
       - name: Create Windows MSI installer
         if: runner.os == 'Windows'
+        env:
+          RUST_LOG: cargo_packager=debug
         run: |
           # Create MSI installer using cargo-packager (format is 'wix' for MSI)
-          cargo packager --release --formats wix
+          cargo packager --release --formats wix -v
           New-Item -ItemType Directory -Force -Path artifacts
 
           # cargo-packager outputs MSI to target/release/ on Windows

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ target
 # Plugin runtime directory (built/copied by build.rs at compile time)
 assets/plugins/
 .idea/
+
+# Design handoff documents (local only)
+design_handoff_*/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5840,7 +5840,7 @@ dependencies = [
 
 [[package]]
 name = "thoth"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5840,7 +5840,7 @@ dependencies = [
 
 [[package]]
 name = "thoth"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5840,7 +5840,7 @@ dependencies = [
 
 [[package]]
 name = "thoth"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,9 +3371,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
 
 [[package]]
 name = "leb128fmt"
@@ -5402,9 +5402,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -5840,7 +5840,7 @@ dependencies = [
 
 [[package]]
 name = "thoth"
-version = "0.3.8"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6060,7 +6060,7 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -6132,9 +6132,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -6505,8 +6505,8 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wat",
 ]
 
@@ -6517,7 +6517,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -6528,8 +6538,8 @@ checksum = "da55e60097e8b37b475a0fa35c3420dd71d9eb7bd66109978ab55faf56a57efb"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -6546,6 +6556,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+dependencies = [
+ "bitflags 2.10.0",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6553,7 +6574,7 @@ checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -6591,8 +6612,8 @@ dependencies = [
  "target-lexicon 0.13.5",
  "tempfile",
  "wasm-compose",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -6633,8 +6654,8 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon 0.13.5",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -6713,7 +6734,7 @@ dependencies = [
  "smallvec",
  "target-lexicon 0.13.5",
  "thiserror 2.0.18",
- "wasmparser",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -6794,7 +6815,7 @@ dependencies = [
  "log",
  "object 0.38.1",
  "target-lexicon 0.13.5",
- "wasmparser",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -6890,24 +6911,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "245.0.1"
+version = "246.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.245.1"
+version = "1.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
 dependencies = [
- "wast 245.0.1",
+ "wast 246.0.2",
 ]
 
 [[package]]
@@ -7087,14 +7108,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7378,7 +7399,7 @@ dependencies = [
  "smallvec",
  "target-lexicon 0.13.5",
  "thiserror 2.0.18",
- "wasmparser",
+ "wasmparser 0.245.1",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -7971,9 +7992,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.245.1",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.245.1",
  "wit-parser",
 ]
 
@@ -7993,7 +8014,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ info_plist_path = "assets/Info.plist"
 # WiX fragment that writes DefaultIcon registry entries for each file type.
 # cargo-packager generates ProgIds as "<identifier>.<extension>" (e.g. com.thoth.app.json).
 [package.metadata.packager.wix]
-template = "assets/wix/main.wxs"
 fragment_paths = ["assets/wix/file-type-icons.wxs"]
 component_group_refs = ["FileTypeIconsGroup"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-members = ["."]
 
 [package]
 name = "thoth"
-version = "0.3.19"
+version = "0.3.20"
 edition = "2024"
 repository = "https://github.com/anitnilay20/thoth"
 authors = ["Anit Nilay <anit.nilay20@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-members = ["."]
 
 [package]
 name = "thoth"
-version = "0.3.20"
+version = "0.3.21"
 edition = "2024"
 repository = "https://github.com/anitnilay20/thoth"
 authors = ["Anit Nilay <anit.nilay20@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-members = ["."]
 
 [package]
 name = "thoth"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2024"
 repository = "https://github.com/anitnilay20/thoth"
 authors = ["Anit Nilay <anit.nilay20@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-members = ["."]
 
 [package]
 name = "thoth"
-version = "0.3.8"
+version = "0.3.19"
 edition = "2024"
 repository = "https://github.com/anitnilay20/thoth"
 authors = ["Anit Nilay <anit.nilay20@gmail.com>"]
@@ -42,20 +42,8 @@ path = "src/lib.rs"
 name = "thoth"
 path = "src/main.rs"
 
-[profile.release]
-codegen-units = 1
-lto = true
-
-# Faster local release builds: thin LTO links in parallel, ~3–5 min vs 20+ min.
-# Use with: cargo build --profile release-local
-[profile.release-local]
-inherits = "release"
-lto = "thin"
-codegen-units = 8
-
 # cargo-packager configuration (stable cross-platform bundler)
 [package.metadata.packager]
-before_packaging_command = "cargo build --release"
 product_name = "Thoth"
 identifier = "com.thoth.app"
 category = "DeveloperTool"
@@ -93,6 +81,7 @@ info_plist_path = "assets/Info.plist"
 # WiX fragment that writes DefaultIcon registry entries for each file type.
 # cargo-packager generates ProgIds as "<identifier>.<extension>" (e.g. com.thoth.app.json).
 [package.metadata.packager.wix]
+template = "assets/wix/main.wxs"
 fragment_paths = ["assets/wix/file-type-icons.wxs"]
 component_group_refs = ["FileTypeIconsGroup"]
 
@@ -140,7 +129,7 @@ zip = "0.6"
 sha2 = "0.10"
 open = "5.0"
 which = "7.0"
-wasmtime = { version = "43.0.0", features = ["component-model"] }
+wasmtime = { version = "43.0.0", features = ["component-model", "cache"] }
 wasmtime-wasi = "43.0.0"
 wasmtime-wasi-http = "43"
 wit-bindgen = "0.54.0"

--- a/assets/wix/file-type-icons.wxs
+++ b/assets/wix/file-type-icons.wxs
@@ -11,7 +11,7 @@
 
         <!-- JSON (.json) -->
         <RegistryValue
-          Root="HKLM"
+          Root="HKCU"
           Key="Software\Classes\com.thoth.app.json\DefaultIcon"
           Value="[INSTALLDIR]thoth.exe,0"
           Type="string"
@@ -19,7 +19,7 @@
 
         <!-- NDJSON (.ndjson) -->
         <RegistryValue
-          Root="HKLM"
+          Root="HKCU"
           Key="Software\Classes\com.thoth.app.ndjson\DefaultIcon"
           Value="[INSTALLDIR]thoth.exe,0"
           Type="string"
@@ -27,7 +27,7 @@
 
         <!-- JSONL (.jsonl) -->
         <RegistryValue
-          Root="HKLM"
+          Root="HKCU"
           Key="Software\Classes\com.thoth.app.jsonl\DefaultIcon"
           Value="[INSTALLDIR]thoth.exe,0"
           Type="string"
@@ -35,7 +35,7 @@
 
         <!-- GeoJSON (.geojson) -->
         <RegistryValue
-          Root="HKLM"
+          Root="HKCU"
           Key="Software\Classes\com.thoth.app.geojson\DefaultIcon"
           Value="[INSTALLDIR]thoth.exe,0"
           Type="string"

--- a/assets/wix/main.wxs
+++ b/assets/wix/main.wxs
@@ -1,0 +1,299 @@
+<?if $(sys.BUILDARCH)="x86"?>
+    <?define Win64 = "no" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?elseif $(sys.BUILDARCH)="x64"?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?else?>
+    <?error Unsupported value of sys.BUILDARCH=$(sys.BUILDARCH)?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product
+            Id="*"
+            Name="{{product_name}}"
+            UpgradeCode="{{upgrade_code}}"
+            Language="!(loc.CargoPackagerLanguage)"
+            Manufacturer="{{manufacturer}}"
+            Version="{{version}}">
+
+        <Package Id="*"
+                 Keywords="Installer"
+                 InstallerVersion="450"
+                 Languages="0"
+                 Compressed="yes"
+                 InstallScope="perUser"
+                 SummaryCodepage="!(loc.CargoPackagerCodepage)"/>
+
+        <!-- https://docs.microsoft.com/en-us/windows/win32/msi/reinstallmode -->
+        <!-- reinstall all files; rewrite all registry entries; reinstall all shortcuts -->
+        <Property Id="REINSTALLMODE" Value="amus" />
+
+        {{#if allow_downgrades}}
+            <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
+        {{else}}
+            <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" AllowSameVersionUpgrades="yes" />
+        {{/if}}
+
+        <InstallExecuteSequence>
+            <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
+        </InstallExecuteSequence>
+
+        <Media Id="1" Cabinet="app.cab" EmbedCab="yes" />
+
+        {{#if banner_path}}
+        <WixVariable Id="WixUIBannerBmp" Value="{{banner_path}}" />
+        {{/if}}
+        {{#if dialog_image_path}}
+        <WixVariable Id="WixUIDialogBmp" Value="{{dialog_image_path}}" />
+        {{/if}}
+        {{#if license}}
+        <WixVariable Id="WixUILicenseRtf" Value="{{license}}" />
+        {{/if}}
+
+        {{#if icon_path}}
+        <Icon Id="ProductIcon" SourceFile="{{icon_path}}"/>
+        <Property Id="ARPPRODUCTICON" Value="ProductIcon" />
+        {{/if}}
+        <Property Id="ARPNOREPAIR" Value="yes" Secure="yes" />      <!-- Remove repair -->
+        <SetProperty Id="ARPNOMODIFY" Value="1" After="InstallValidate" Sequence="execute"/>
+
+        <!-- initialize with previous InstallDir -->
+        <Property Id="INSTALLDIR">
+            <RegistrySearch Id="PrevInstallDirReg" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw"/>
+        </Property>
+
+        <!-- launch app checkbox -->
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="!(loc.LaunchApp)" />
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"/>
+        <Property Id="WixShellExecTarget" Value="[!Path]" />
+        <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
+
+        <UI>
+            <!-- launch app checkbox -->
+            <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
+
+            <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+
+            {{#unless license}}
+            <!-- Skip license dialog -->
+            <Publish Dialog="WelcomeDlg"
+                     Control="Next"
+                     Event="NewDialog"
+                     Value="InstallDirDlg"
+                     Order="2">1</Publish>
+            <Publish Dialog="InstallDirDlg"
+                     Control="Back"
+                     Event="NewDialog"
+                     Value="WelcomeDlg"
+                     Order="2">1</Publish>
+            {{/unless}}
+        </UI>
+
+        <UIRef Id="WixUI_InstallDir" />
+
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="DesktopFolder" Name="Desktop">
+                <Component Id="ApplicationShortcutDesktop" Guid="*">
+                    <Shortcut Id="ApplicationDesktopShortcut" Name="{{product_name}}" Description="Runs {{product_name}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
+                    <RemoveFolder Id="DesktopFolder" On="uninstall" />
+                    <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Desktop Shortcut" Type="integer" Value="1" KeyPath="yes" />
+                </Component>
+            </Directory>
+            <Directory Id="LocalAppDataFolder">
+                <Directory Id="Programs" Name="Programs">
+                    <Directory Id="INSTALLDIR" Name="{{product_name}}"/>
+                </Directory>
+            </Directory>
+            <Directory Id="ProgramMenuFolder">
+                <Directory Id="ApplicationProgramsFolder" Name="{{product_name}}"/>
+            </Directory>
+        </Directory>
+
+        <DirectoryRef Id="INSTALLDIR">
+            <Component Id="RegistryEntries" Guid="*">
+                <RegistryKey Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
+                </RegistryKey>
+                <!-- Change the Root to HKCU for perUser installations -->
+                {{#each deep_link_protocols as |protocol| ~}}
+                <RegistryKey Root="HKLM" Key="Software\Classes\\{{protocol}}">
+                    <RegistryValue Type="string" Name="URL Protocol" Value=""/>
+                    <RegistryValue Type="string" Value="URL:{{bundle_id}} protocol"/>
+                    <RegistryKey Key="DefaultIcon">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot;,0" />
+                    </RegistryKey>
+                    <RegistryKey Key="shell\open\command">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot; &quot;%1&quot;" />
+                    </RegistryKey>
+                </RegistryKey>
+                {{/each~}}
+            </Component>
+            <Component Id="Path" Guid="{{path_component_guid}}" Win64="$(var.Win64)">
+                <File Id="Path" Source="{{app_exe_source}}" KeyPath="yes" Checksum="yes"/>
+                {{#each file_associations as |association| ~}}
+                {{#each association.ext as |ext| ~}}
+                <ProgId Id="{{../../product_name}}.{{ext}}" Advertise="no" Description="{{association.description}}">
+                    <Extension Id="{{ext}}" Advertise="no">
+                        <Verb Id="open" Command="Open with {{../../product_name}}" Argument="&quot;%1&quot;" />
+                    </Extension>
+                </ProgId>
+                {{/each~}}
+                {{/each~}}
+            </Component>
+            {{#each binaries as |bin| ~}}
+            <Component Id="{{ bin.id }}" Guid="{{bin.guid}}" Win64="$(var.Win64)">
+                <File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>
+            </Component>
+            {{/each~}}
+            {{resources}}
+            <Component Id="CMP_UninstallShortcut" Guid="*">
+
+                <Shortcut Id="UninstallShortcut"
+						  Name="Uninstall {{product_name}}"
+						  Description="Uninstalls {{product_name}}"
+						  Target="[System64Folder]msiexec.exe"
+						  Arguments="/x [ProductCode]" />
+
+				<RemoveFolder Id="INSTALLDIR"
+							  On="uninstall" />
+
+				<RegistryValue Root="HKCU"
+							   Key="Software\\{{manufacturer}}\\{{product_name}}"
+							   Name="Uninstaller Shortcut"
+							   Type="integer"
+							   Value="1"
+							   KeyPath="yes" />
+            </Component>
+        </DirectoryRef>
+
+        <DirectoryRef Id="ApplicationProgramsFolder">
+            <Component Id="ApplicationShortcut" Guid="*">
+                <Shortcut Id="ApplicationStartMenuShortcut"
+                    Name="{{product_name}}"
+                    Description="Runs {{product_name}}"
+                    Target="[!Path]"
+                    {{#if icon_path}}
+                    Icon="ProductIcon"
+                    {{/if}}
+                    WorkingDirectory="INSTALLDIR">
+                    <ShortcutProperty Key="System.AppUserModel.ID" Value="{{identifier}}"/>
+                </Shortcut>
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+                <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Start Menu Shortcut" Type="integer" Value="1" KeyPath="yes"/>
+           </Component>
+        </DirectoryRef>
+
+        {{#each merge_modules as |msm| ~}}
+        <DirectoryRef Id="TARGETDIR">
+            <Merge Id="{{ msm.name }}" SourceFile="{{ msm.path }}" DiskId="1" Language="!(loc.CargoPackagerLanguage)" />
+        </DirectoryRef>
+
+        <Feature Id="{{ msm.name }}" Title="{{ msm.name }}" AllowAdvertise="no" Display="hidden" Level="1">
+            <MergeRef Id="{{ msm.name }}"/>
+        </Feature>
+        {{/each~}}
+
+        <Feature
+                Id="MainProgram"
+                Title="Application"
+                Description="!(loc.InstallAppFeature)"
+                Level="1"
+                ConfigurableDirectory="INSTALLDIR"
+                AllowAdvertise="no"
+                Display="expand"
+                Absent="disallow">
+
+            <ComponentRef Id="RegistryEntries"/>
+
+            {{#each resource_file_ids as |resource_file_id| ~}}
+                <ComponentRef Id="{{ resource_file_id }}"/>
+            {{/each~}}
+
+            <Feature Id="ShortcutsFeature"
+                Title="Shortcuts"
+                Level="1">
+                <ComponentRef Id="Path"/>
+                <ComponentRef Id="CMP_UninstallShortcut" />
+                <ComponentRef Id="ApplicationShortcut" />
+                <ComponentRef Id="ApplicationShortcutDesktop" />
+            </Feature>
+
+            <Feature
+                Id="Environment"
+                Title="PATH Environment Variable"
+                Description="!(loc.PathEnvVarFeature)"
+                Level="1"
+                Absent="allow">
+            <ComponentRef Id="Path"/>
+            {{#each binaries as |bin| ~}}
+            <ComponentRef Id="{{ bin.id }}"/>
+            {{/each~}}
+            </Feature>
+        </Feature>
+
+        <Feature Id="External" AllowAdvertise="no" Absent="disallow">
+            {{#each component_group_refs as |id| ~}}
+            <ComponentGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each component_refs as |id| ~}}
+            <ComponentRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_group_refs as |id| ~}}
+            <FeatureGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_refs as |id| ~}}
+            <FeatureRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each merge_refs as |id| ~}}
+            <MergeRef Id="{{ id }}"/>
+            {{/each~}}
+        </Feature>
+
+        {{#each custom_action_refs as |id| ~}}
+            <CustomActionRef Id="{{ id }}"/>
+        {{/each~}}
+
+        {{#if install_webview}}
+        <!-- WebView2 -->
+        <Property Id="WVRTINSTALLED">
+            <RegistrySearch Id="WVRTInstalledSystem" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" Win64="no" />
+            <RegistrySearch Id="WVRTInstalledUser" Root="HKCU" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw"/>
+        </Property>
+
+        {{#if download_bootstrapper}}
+        <CustomAction Id='DownloadAndInvokeBootstrapper' Directory="INSTALLDIR" Execute="deferred" ExeCommand='powershell.exe -NoProfile -windowstyle hidden try [\{] [\[]Net.ServicePointManager[\]]::SecurityProtocol = [\[]Net.SecurityProtocolType[\]]::Tls12 [\}] catch [\{][\}]; Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" ; Start-Process -FilePath "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" -ArgumentList ({{webview_installer_args}} &apos;/install&apos;) -Wait' Return='check'/>
+        <InstallExecuteSequence>
+            <Custom Action='DownloadAndInvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR WVRTINSTALLED)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        <!-- Embedded webview bootstrapper mode -->
+        {{#if webview2_bootstrapper_path}}
+        <Binary Id="MicrosoftEdgeWebview2Setup.exe" SourceFile="{{webview2_bootstrapper_path}}"/>
+        <CustomAction Id='InvokeBootstrapper' BinaryKey='MicrosoftEdgeWebview2Setup.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR WVRTINSTALLED)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        <!-- Embedded offline installer -->
+        {{#if webview2_installer_path}}
+        <Binary Id="MicrosoftEdgeWebView2RuntimeInstaller.exe" SourceFile="{{webview2_installer_path}}"/>
+        <CustomAction Id='InvokeStandalone' BinaryKey='MicrosoftEdgeWebView2RuntimeInstaller.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeStandalone' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR WVRTINSTALLED)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{/if}}
+
+        <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>
+    </Product>
+</Wix>

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
 use wasmtime::component::ResourceTable;
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Cache, CacheConfig, Config, Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView};
 
 use crate::PLUGIN_MANAGER;
@@ -47,6 +47,9 @@ impl PluginManager {
 
         let mut config = Config::new();
         config.consume_fuel(true);
+        if let Ok(cache) = Cache::new(CacheConfig::new()) {
+            config.cache(Some(cache));
+        }
         let engine = Engine::new(&config).map_err(|e| ThothError::PluginLoadError {
             path: PathBuf::new(),
             reason: e.to_string(),

--- a/src/update/manager.rs
+++ b/src/update/manager.rs
@@ -298,18 +298,18 @@ impl UpdateManager {
 
         // Sync bundled plugins from the extracted archive so OTA updates
         // pick up new/updated plugins, not just the binary.
-        Self::sync_plugins(&temp_dir, &current_exe);
+        Self::sync_plugins(&temp_dir, &current_exe)?;
 
         Ok(())
     }
 
     /// Copy `assets/plugins/` from the extracted archive next to the installed
     /// binary (macOS: `../Resources/assets/plugins/`, others: `assets/plugins/`).
-    fn sync_plugins(extracted_dir: &std::path::Path, current_exe: &std::path::Path) {
+    fn sync_plugins(extracted_dir: &std::path::Path, current_exe: &std::path::Path) -> Result<()> {
         // Find the plugins directory inside the extracted archive.
         let src = match Self::find_in_tree(extracted_dir, "plugins") {
             Some(p) if p.is_dir() => p,
-            _ => return, // archive has no plugins dir — nothing to do
+            _ => return Ok(()), // archive has no plugins dir — nothing to do
         };
 
         // Resolve destination relative to the installed binary.
@@ -330,14 +330,13 @@ impl UpdateManager {
             }
         };
 
-        let dst = match dst {
-            Some(p) => p,
-            None => return,
-        };
+        let dst = dst.ok_or_else(|| ThothError::UpdateInstallError {
+            reason: "Could not resolve plugin destination directory".to_string(),
+        })?;
 
-        if let Err(e) = Self::copy_dir_all(&src, &dst) {
-            eprintln!("Warning: could not sync plugins during update: {e}");
-        }
+        Self::copy_dir_all(&src, &dst).map_err(|e| ThothError::UpdateInstallError {
+            reason: format!("Failed to sync plugins: {e}"),
+        })
     }
 
     /// Recursively copy `src` into `dst`, creating directories as needed.
@@ -436,7 +435,14 @@ impl UpdateManager {
                 std::fs::remove_file(&backup_path)?;
             }
             std::fs::copy(current_exe, &backup_path)?;
-            std::fs::copy(new_exe, current_exe)?;
+            if let Err(e) = std::fs::copy(new_exe, current_exe) {
+                // Restore the backup so the binary is not left in a partial state.
+                let _ = std::fs::copy(&backup_path, current_exe);
+                return Err(ThothError::UpdateInstallError {
+                    reason: format!("Could not write new executable: {e}"),
+                });
+            }
+            let _ = std::fs::remove_file(&backup_path);
         }
 
         Ok(())

--- a/src/update/manager.rs
+++ b/src/update/manager.rs
@@ -271,13 +271,107 @@ impl UpdateManager {
         // Get current executable path
         let current_exe = std::env::current_exe()?;
 
+        // On macOS replace the entire .app bundle so Resources (plugins,
+        // assets) are updated alongside the binary — not just the binary.
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(app_bundle) = Self::find_in_tree(&temp_dir, "Thoth.app") {
+                // current_exe is …/Thoth.app/Contents/MacOS/thoth
+                // installed bundle is three levels up
+                if let Some(installed_bundle) = current_exe
+                    .parent()
+                    .and_then(|p| p.parent())
+                    .and_then(|p| p.parent())
+                {
+                    Self::copy_dir_all(&app_bundle, installed_bundle)?;
+                    return Ok(());
+                }
+            }
+            // Fallthrough: no .app found in archive — replace binary + sync plugins
+        }
+
         // Find the new executable in the extracted files
         let new_exe = Self::find_executable(&temp_dir)?;
 
         // Replace the current executable
         Self::replace_executable(&new_exe, &current_exe)?;
 
+        // Sync bundled plugins from the extracted archive so OTA updates
+        // pick up new/updated plugins, not just the binary.
+        Self::sync_plugins(&temp_dir, &current_exe);
+
         Ok(())
+    }
+
+    /// Copy `assets/plugins/` from the extracted archive next to the installed
+    /// binary (macOS: `../Resources/assets/plugins/`, others: `assets/plugins/`).
+    fn sync_plugins(extracted_dir: &std::path::Path, current_exe: &std::path::Path) {
+        // Find the plugins directory inside the extracted archive.
+        let src = match Self::find_in_tree(extracted_dir, "plugins") {
+            Some(p) if p.is_dir() => p,
+            _ => return, // archive has no plugins dir — nothing to do
+        };
+
+        // Resolve destination relative to the installed binary.
+        let dst = {
+            #[cfg(target_os = "macos")]
+            {
+                // binary is at Thoth.app/Contents/MacOS/thoth
+                // plugins go to Thoth.app/Contents/Resources/assets/plugins/
+                current_exe
+                    .parent() // MacOS/
+                    .and_then(|p| p.parent()) // Contents/
+                    .map(|p| p.join("Resources/assets/plugins"))
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                // binary sits next to assets/plugins/ on Linux/Windows
+                current_exe.parent().map(|p| p.join("assets/plugins"))
+            }
+        };
+
+        let dst = match dst {
+            Some(p) => p,
+            None => return,
+        };
+
+        if let Err(e) = Self::copy_dir_all(&src, &dst) {
+            eprintln!("Warning: could not sync plugins during update: {e}");
+        }
+    }
+
+    /// Recursively copy `src` into `dst`, creating directories as needed.
+    fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(dst)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            let dst_path = dst.join(entry.file_name());
+            if entry.file_type()?.is_dir() {
+                Self::copy_dir_all(&entry.path(), &dst_path)?;
+            } else {
+                std::fs::copy(entry.path(), dst_path)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Walk `dir` looking for a file or directory named `name`.
+    fn find_in_tree(dir: &std::path::Path, name: &str) -> Option<std::path::PathBuf> {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return None;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.file_name().and_then(|n| n.to_str()) == Some(name) {
+                return Some(path);
+            }
+            if path.is_dir()
+                && let Some(found) = Self::find_in_tree(&path, name)
+            {
+                return Some(found);
+            }
+        }
+        None
     }
 
     fn find_executable(dir: &std::path::Path) -> Result<std::path::PathBuf> {
@@ -308,19 +402,42 @@ impl UpdateManager {
     }
 
     fn replace_executable(new_exe: &std::path::Path, current_exe: &std::path::Path) -> Result<()> {
-        // Set executable permissions using platform abstraction
         let fs_ops = get_fs_ops();
         fs_ops.make_executable(new_exe)?;
 
-        // Create backup of current executable
-        let backup_path = current_exe.with_extension("backup");
-        if backup_path.exists() {
-            std::fs::remove_file(&backup_path)?;
+        #[cfg(target_os = "windows")]
+        {
+            // Windows won't let you write over a running .exe, but it does
+            // allow renaming one. Rename the running binary out of the way,
+            // then copy the new one into its place. The renamed .old file is
+            // cleaned up on the next update or can be left harmlessly.
+            let old_path = current_exe.with_extension("exe.old");
+            if old_path.exists() {
+                let _ = std::fs::remove_file(&old_path);
+            }
+            std::fs::rename(current_exe, &old_path).map_err(|e| {
+                ThothError::UpdateInstallError {
+                    reason: format!("Could not rename current executable: {e}"),
+                }
+            })?;
+            std::fs::copy(new_exe, current_exe).map_err(|e| {
+                // Restore original if copy fails
+                let _ = std::fs::rename(&old_path, current_exe);
+                ThothError::UpdateInstallError {
+                    reason: format!("Could not write new executable: {e}"),
+                }
+            })?;
         }
-        std::fs::copy(current_exe, &backup_path)?;
 
-        // Replace current executable
-        std::fs::copy(new_exe, current_exe)?;
+        #[cfg(not(target_os = "windows"))]
+        {
+            let backup_path = current_exe.with_extension("backup");
+            if backup_path.exists() {
+                std::fs::remove_file(&backup_path)?;
+            }
+            std::fs::copy(current_exe, &backup_path)?;
+            std::fs::copy(new_exe, current_exe)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
CI / Build:
- Add sccache (mozilla-actions/sccache-action@v0.0.10) with explicit RUSTC_WRAPPER + SCCACHE_GHA_ENABLED so compiler output is cached across releases — fixes 6h timeout caused by cold cranelift builds
- Use cargo-bins/cargo-binstall@v1.19.1 for fast tool installs
- Build main binary before installing cargo-component so build.rs skips plugin compilation; plugins built in a separate explicit step with sccache enabled and theme-plugin directories skipped
- Remove lto = true from release profile (imperceptible perf difference for a desktop I/O app; was invalidating sccache on every flag change)
- Add wasmtime cache feature to prevent 2-3s UI freeze on plugin load
- Remove redundant before_packaging_command from cargo-packager config

OTA updates:
- macOS: replace entire .app bundle so Resources/assets including plugins are updated on every OTA install, not just the binary
- Windows: rename-then-copy trick to replace a running .exe without error
- All platforms: sync assets/plugins/ from extracted archive so newly bundled plugins appear after an in-app update

Windows installer:
- Custom WiX template: InstallScope=perUser, install to LocalAppDataFolder\Programs\Thoth — no elevation required to install or for OTA updates to write back
- File type icon registry entries use HKCU (no admin needed)
- ProgId/Extension Advertise=no for perUser scope compatibility

Misc:
- gitignore: exclude design_handoff_*/ directories
- clippy + cargo fmt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved macOS app-bundle installation and plugin asset synchronization
  * Added a comprehensive Windows installer template and updated MSI packaging behavior

* **Improvements**
  * Per-user file associations/registry entries
  * Build pipeline now uses compilation caching, faster WASM plugin builds, and installs prebuilt packager tools
  * Wasmtime plugin caching enabled when available

* **Chores**
  * Version bumped to 0.3.22
  * .gitignore updated to ignore local design handoff folders
<!-- end of auto-generated comment: release notes by coderabbit.ai -->