### PR TITLE
Release target arch and db docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         env:
           RUSTC_WRAPPER: sccache
           SCCACHE_GHA_ENABLED: "true"
-        run: cargo build --release
+        run: cargo build --release --target ${{ matrix.target }}
 
       # Install cargo-component after the main build so it doesn't affect the
       # main build's sccache keys or add noise to the build.rs subprocess chain.
@@ -163,12 +163,12 @@ jobs:
           RUST_LOG: cargo_packager=debug
         run: |
           # Create MSI installer using cargo-packager (format is 'wix' for MSI)
-          cargo packager --release --formats wix -v
+          cargo packager --release --target ${{ matrix.target }} --formats wix -v
           New-Item -ItemType Directory -Force -Path artifacts
 
           # cargo-packager outputs MSI to target/release/ on Windows
-          if (Test-Path "target\release\*.msi") {
-            Copy-Item "target\release\*.msi" artifacts\
+          if (Test-Path "target\${{ matrix.target }}\release\*.msi") {
+            Copy-Item "target\${{ matrix.target }}\release\*.msi" artifacts\
             Write-Host "MSI installer copied to artifacts/"
           } else {
             Write-Host "MSI not found, checking dist/ directory"
@@ -176,71 +176,71 @@ jobs:
               Copy-Item "dist\*.msi" artifacts\
             } else {
               Write-Host "MSI not found in either location"
-              Get-ChildItem -Path target\release\ -Filter *.msi -Recurse | ForEach-Object { Write-Host $_.FullName }
+              Get-ChildItem -Path target\${{ matrix.target }}\release\ -Filter *.msi -Recurse | ForEach-Object { Write-Host $_.FullName }
             }
           }
 
           # Also copy the exe as fallback
-          Copy-Item target\release\thoth.exe artifacts\
+          Copy-Item target\${{ matrix.target }}\release\thoth.exe artifacts\
 
       - name: Create macOS DMG installer
         if: runner.os == 'macOS' && matrix.target == 'x86_64-apple-darwin'
         run: |
           # Build both app bundle and DMG using cargo-packager
-          cargo packager --release --formats app,dmg
+          cargo packager --release --target ${{ matrix.target }} --formats app,dmg
           mkdir -p artifacts
 
           # cargo-packager outputs to target/release/ directory
           echo "Listing target/release/ contents:"
-          ls -la target/release/
+          ls -la target/${{ matrix.target }}/release/
 
           # Copy the DMG if it exists
-          cp target/release/*.dmg artifacts/ 2>/dev/null || echo "DMG not found"
+          cp target/${{ matrix.target }}/release/*.dmg artifacts/ 2>/dev/null || echo "DMG not found"
 
           # Copy the .app bundle to artifacts/ for tar.gz creation
-          if [ -d "target/release/Thoth.app" ]; then
-            cp -r target/release/Thoth.app artifacts/
+          if [ -d "target/${{ matrix.target }}/release/Thoth.app" ]; then
+            cp -r target/${{ matrix.target }}/release/Thoth.app artifacts/
             echo "Copied Thoth.app from target/release/"
           else
             echo "App bundle not found, checking for .app files:"
-            find target/release -name "*.app" -type d
+            find target/${{ matrix.target }}/release -name "*.app" -type d
           fi
 
       - name: Create macOS ARM64 DMG installer
         if: runner.os == 'macOS' && matrix.target == 'aarch64-apple-darwin'
         run: |
           # Build both app bundle and DMG using cargo-packager
-          cargo packager --release --formats app,dmg
+          cargo packager --release --target ${{ matrix.target }} --formats app,dmg
           mkdir -p artifacts
 
           # cargo-packager outputs to target/release/ directory
           echo "Listing target/release/ contents:"
-          ls -la target/release/
+          ls -la target/${{ matrix.target }}/release/
 
           # Copy the DMG if it exists
-          cp target/release/*.dmg artifacts/ 2>/dev/null || echo "DMG not found"
+          cp target/${{ matrix.target }}/release/*.dmg artifacts/ 2>/dev/null || echo "DMG not found"
 
           # Copy the .app bundle to artifacts/ for tar.gz creation
-          if [ -d "target/release/Thoth.app" ]; then
-            cp -r target/release/Thoth.app artifacts/
+          if [ -d "target/${{ matrix.target }}/release/Thoth.app" ]; then
+            cp -r target/${{ matrix.target }}/release/Thoth.app artifacts/
             echo "Copied Thoth.app from target/release/"
           else
             echo "App bundle not found, checking for .app files:"
-            find target/release -name "*.app" -type d
+            find target/${{ matrix.target }}/release -name "*.app" -type d
           fi
 
       - name: Create Linux packages (deb)
         if: runner.os == 'Linux'
         run: |
           # Create deb package using cargo-packager
-          cargo packager --release --formats deb
+          cargo packager --release --target ${{ matrix.target }} --formats deb
           mkdir -p artifacts
 
           # cargo-packager outputs to target/release/ directory
-          cp target/release/*.deb artifacts/ 2>/dev/null || echo "DEB not found"
+          cp target/${{ matrix.target }}/release/*.deb artifacts/ 2>/dev/null || echo "DEB not found"
 
           # Also copy raw binary as fallback
-          cp target/release/thoth artifacts/
+          cp target/${{ matrix.target }}/release/thoth artifacts/
           chmod +x artifacts/thoth
 
       # Create compressed archives

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,14 +184,14 @@ jobs:
           Copy-Item target\${{ matrix.target }}\release\thoth.exe artifacts\
 
       - name: Create macOS DMG installer
-        if: runner.os == 'macOS' && matrix.target == 'x86_64-apple-darwin'
+        if: runner.os == 'macOS'
         run: |
           # Build both app bundle and DMG using cargo-packager
           cargo packager --release --target ${{ matrix.target }} --formats app,dmg
           mkdir -p artifacts
 
-          # cargo-packager outputs to target/release/ directory
-          echo "Listing target/release/ contents:"
+          # cargo-packager outputs to target/${{ matrix.target }}/release/ directory
+          echo "Listing target/${{ matrix.target }}/release/ contents:"
           ls -la target/${{ matrix.target }}/release/
 
           # Copy the DMG if it exists
@@ -200,30 +200,7 @@ jobs:
           # Copy the .app bundle to artifacts/ for tar.gz creation
           if [ -d "target/${{ matrix.target }}/release/Thoth.app" ]; then
             cp -r target/${{ matrix.target }}/release/Thoth.app artifacts/
-            echo "Copied Thoth.app from target/release/"
-          else
-            echo "App bundle not found, checking for .app files:"
-            find target/${{ matrix.target }}/release -name "*.app" -type d
-          fi
-
-      - name: Create macOS ARM64 DMG installer
-        if: runner.os == 'macOS' && matrix.target == 'aarch64-apple-darwin'
-        run: |
-          # Build both app bundle and DMG using cargo-packager
-          cargo packager --release --target ${{ matrix.target }} --formats app,dmg
-          mkdir -p artifacts
-
-          # cargo-packager outputs to target/release/ directory
-          echo "Listing target/release/ contents:"
-          ls -la target/${{ matrix.target }}/release/
-
-          # Copy the DMG if it exists
-          cp target/${{ matrix.target }}/release/*.dmg artifacts/ 2>/dev/null || echo "DMG not found"
-
-          # Copy the .app bundle to artifacts/ for tar.gz creation
-          if [ -d "target/${{ matrix.target }}/release/Thoth.app" ]; then
-            cp -r target/${{ matrix.target }}/release/Thoth.app artifacts/
-            echo "Copied Thoth.app from target/release/"
+            echo "Copied Thoth.app from target/${{ matrix.target }}/release/"
           else
             echo "App bundle not found, checking for .app files:"
             find target/${{ matrix.target }}/release -name "*.app" -type d

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -47,8 +47,13 @@ impl PluginManager {
 
         let mut config = Config::new();
         config.consume_fuel(true);
-        if let Ok(cache) = Cache::new(CacheConfig::new()) {
-            config.cache(Some(cache));
+        match Cache::new(CacheConfig::new()) {
+            Ok(cache) => {
+                config.cache(Some(cache));
+            }
+            Err(e) => {
+                eprintln!("Plugin cache init failed, proceeding without compilation cache: {e}");
+            }
         }
         let engine = Engine::new(&config).map_err(|e| ThothError::PluginLoadError {
             path: PathBuf::new(),


### PR DESCRIPTION
cargo build/packager ran without --target, so x86_64-apple-darwin (built on the arm64 macos-latest runner) produced an arm64 binary mislabeled as the Intel artifact. Make build and all cargo-packager invocations target-explicit and point downstream artifact paths at target/<triple>/release.

Also log (instead of silently swallowing) wasmtime Cache init failures in PluginManager::init.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded cross-platform build and packaging to use per-target builds for Windows, macOS (consolidated handling for architectures) and Linux, with more reliable artifact discovery and copying.
  * Improved plugin initialization to report cache compilation errors with detailed diagnostics while continuing to operate without a cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->