### PR TITLE
feat(plugins): plugin tab windows with host-managed state #80

### DIFF
--- a/plugins/url-source/src/bindings.rs
+++ b/plugins/url-source/src/bindings.rs
@@ -665,6 +665,119 @@ pub mod thoth {
                 }
             }
         }
+        /// ---------------------------------------------------------------------------
+        /// ui-tabs — host-provided import for plugins that render in tab windows
+        ///
+        /// Lets a plugin ask the host to open a NEW dock tab hosting a fresh instance
+        /// of the same plugin. Mirrors http-client.submit: the call returns an opaque
+        /// tab id immediately and the host actually opens the tab on its next frame.
+        /// The new instance is seeded with `initial-state` via tab-host.init-with-state.
+        /// ---------------------------------------------------------------------------
+        #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+        pub mod ui_tabs {
+            #[used]
+            #[doc(hidden)]
+            static __FORCE_SECTION_REF: fn() = super::super::super::__link_custom_section_describing_imports;
+            use super::super::super::_rt;
+            #[allow(unused_unsafe, clippy::all)]
+            /// Request the host to open a new tab hosting this plugin.
+            /// `icon` is an optional Phosphor glyph shown in the tab label.
+            /// `initial-state` is an optional JSON blob (same shape as get-state
+            /// returns) used to seed the new tab's plugin instance.
+            /// Returns a host-assigned tab id (currently informational).
+            pub fn open_tab(
+                title: &str,
+                icon: Option<&str>,
+                initial_state: Option<&str>,
+            ) -> _rt::String {
+                unsafe {
+                    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                    struct RetArea(
+                        [::core::mem::MaybeUninit<
+                            u8,
+                        >; 2 * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let mut ret_area = RetArea(
+                        [::core::mem::MaybeUninit::uninit(); 2
+                            * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let vec0 = title;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let (result2_0, result2_1, result2_2) = match icon {
+                        Some(e) => {
+                            let vec1 = e;
+                            let ptr1 = vec1.as_ptr().cast::<u8>();
+                            let len1 = vec1.len();
+                            (1i32, ptr1.cast_mut(), len1)
+                        }
+                        None => (0i32, ::core::ptr::null_mut(), 0usize),
+                    };
+                    let (result4_0, result4_1, result4_2) = match initial_state {
+                        Some(e) => {
+                            let vec3 = e;
+                            let ptr3 = vec3.as_ptr().cast::<u8>();
+                            let len3 = vec3.len();
+                            (1i32, ptr3.cast_mut(), len3)
+                        }
+                        None => (0i32, ::core::ptr::null_mut(), 0usize),
+                    };
+                    let ptr5 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/ui-tabs@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "open-tab"]
+                        fn wit_import6(
+                            _: *mut u8,
+                            _: usize,
+                            _: i32,
+                            _: *mut u8,
+                            _: usize,
+                            _: i32,
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                        );
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import6(
+                        _: *mut u8,
+                        _: usize,
+                        _: i32,
+                        _: *mut u8,
+                        _: usize,
+                        _: i32,
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe {
+                        wit_import6(
+                            ptr0.cast_mut(),
+                            len0,
+                            result2_0,
+                            result2_1,
+                            result2_2,
+                            result4_0,
+                            result4_1,
+                            result4_2,
+                            ptr5,
+                        )
+                    };
+                    let l7 = *ptr5.add(0).cast::<*mut u8>();
+                    let l8 = *ptr5
+                        .add(::core::mem::size_of::<*const u8>())
+                        .cast::<usize>();
+                    let len9 = l8;
+                    let bytes9 = _rt::Vec::from_raw_parts(l7.cast(), len9, len9);
+                    let result10 = _rt::string_lift(bytes9);
+                    result10
+                }
+            }
+        }
     }
 }
 #[rustfmt::skip]
@@ -1904,6 +2017,306 @@ pub mod exports {
                 );
             }
             /// ---------------------------------------------------------------------------
+            /// tab-host — implement when the plugin renders in a tab window
+            ///
+            /// Provides the host with the tab's title/icon, lets the host snapshot and
+            /// restore the plugin's per-tab state across app restarts (like a file tab
+            /// remembers its path), and delivers tab lifecycle notifications.
+            /// ---------------------------------------------------------------------------
+            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+            pub mod tab_host {
+                #[used]
+                #[doc(hidden)]
+                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
+                use super::super::super::super::_rt;
+                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_tab_title_cabi<T: Guest>() -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let result0 = T::tab_title();
+                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    let vec2 = (result0.into_bytes()).into_boxed_slice();
+                    let ptr2 = vec2.as_ptr().cast::<u8>();
+                    let len2 = vec2.len();
+                    ::core::mem::forget(vec2);
+                    *ptr1.add(::core::mem::size_of::<*const u8>()).cast::<usize>() = len2;
+                    *ptr1.add(0).cast::<*mut u8>() = ptr2.cast_mut();
+                    ptr1
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_tab_title<T: Guest>(arg0: *mut u8) {
+                    let l0 = *arg0.add(0).cast::<*mut u8>();
+                    let l1 = *arg0
+                        .add(::core::mem::size_of::<*const u8>())
+                        .cast::<usize>();
+                    _rt::cabi_dealloc(l0, l1, 1);
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_tab_icon_cabi<T: Guest>() -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let result0 = T::tab_icon();
+                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result0 {
+                        Some(e) => {
+                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
+                            let vec2 = (e.into_bytes()).into_boxed_slice();
+                            let ptr2 = vec2.as_ptr().cast::<u8>();
+                            let len2 = vec2.len();
+                            ::core::mem::forget(vec2);
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len2;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr2.cast_mut();
+                        }
+                        None => {
+                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
+                        }
+                    };
+                    ptr1
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_tab_icon<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {}
+                        _ => {
+                            let l1 = *arg0
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                    }
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_get_state_cabi<T: Guest>() -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let result0 = T::get_state();
+                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result0 {
+                        Ok(e) => {
+                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
+                            let vec2 = (e.into_bytes()).into_boxed_slice();
+                            let ptr2 = vec2.as_ptr().cast::<u8>();
+                            let len2 = vec2.len();
+                            ::core::mem::forget(vec2);
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len2;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr2.cast_mut();
+                        }
+                        Err(e) => {
+                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
+                            let super::super::super::super::thoth::plugin::types::PluginError {
+                                code: code3,
+                                message: message3,
+                            } = e;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(code3);
+                            let vec4 = (message3.into_bytes()).into_boxed_slice();
+                            let ptr4 = vec4.as_ptr().cast::<u8>();
+                            let len4 = vec4.len();
+                            ::core::mem::forget(vec4);
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len4;
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr4.cast_mut();
+                        }
+                    };
+                    ptr1
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_get_state<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {
+                            let l1 = *arg0
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                        _ => {
+                            let l3 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l4 = *arg0
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l3, l4, 1);
+                        }
+                    }
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_init_with_state_cabi<T: Guest>(
+                    arg0: *mut u8,
+                    arg1: usize,
+                ) -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let len0 = arg1;
+                    let bytes0 = _rt::Vec::from_raw_parts(arg0.cast(), len0, len0);
+                    let result1 = T::init_with_state(_rt::string_lift(bytes0));
+                    let ptr2 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result1 {
+                        Ok(_) => {
+                            *ptr2.add(0).cast::<u8>() = (0i32) as u8;
+                        }
+                        Err(e) => {
+                            *ptr2.add(0).cast::<u8>() = (1i32) as u8;
+                            let super::super::super::super::thoth::plugin::types::PluginError {
+                                code: code3,
+                                message: message3,
+                            } = e;
+                            *ptr2
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(code3);
+                            let vec4 = (message3.into_bytes()).into_boxed_slice();
+                            let ptr4 = vec4.as_ptr().cast::<u8>();
+                            let len4 = vec4.len();
+                            ::core::mem::forget(vec4);
+                            *ptr2
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len4;
+                            *ptr2
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr4.cast_mut();
+                        }
+                    };
+                    ptr2
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_init_with_state<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {}
+                        _ => {
+                            let l1 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                    }
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_on_tab_focused_cabi<T: Guest>() {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    T::on_tab_focused();
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_on_tab_blurred_cabi<T: Guest>() {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    T::on_tab_blurred();
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_on_tab_closed_cabi<T: Guest>() {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    T::on_tab_closed();
+                }
+                pub trait Guest {
+                    /// The title shown in the dock tab label. Queried after render-ui and
+                    /// after each handle-event so the title can stay live.
+                    fn tab_title() -> _rt::String;
+                    /// Optional Phosphor glyph shown before the title. `none` = no icon.
+                    fn tab_icon() -> Option<_rt::String>;
+                    /// Serialize the plugin's current per-tab state to a JSON blob. The host
+                    /// persists it in the session and passes it back via init-with-state when
+                    /// the tab is reopened on the next launch.
+                    fn get_state() -> Result<_rt::String, PluginError>;
+                    /// Restore from a previously saved blob. Called once, instead of a blank
+                    /// start, when the host reopens a persisted tab.
+                    fn init_with_state(state: _rt::String) -> Result<(), PluginError>;
+                    /// This tab became the active/focused tab.
+                    fn on_tab_focused() -> ();
+                    /// This tab lost focus (another tab became active).
+                    fn on_tab_blurred() -> ();
+                    /// This tab is being closed. Release any per-tab resources.
+                    fn on_tab_closed() -> ();
+                }
+                #[doc(hidden)]
+                macro_rules! __export_thoth_plugin_tab_host_0_1_0_cabi {
+                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
+                        const _ : () = { #[unsafe (export_name =
+                        "thoth:plugin/tab-host@0.1.0#tab-title")] unsafe extern "C" fn
+                        export_tab_title() -> * mut u8 { unsafe { $($path_to_types)*::
+                        _export_tab_title_cabi::<$ty > () } } #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/tab-host@0.1.0#tab-title")] unsafe extern
+                        "C" fn _post_return_tab_title(arg0 : * mut u8,) { unsafe {
+                        $($path_to_types)*:: __post_return_tab_title::<$ty > (arg0) } }
+                        #[unsafe (export_name = "thoth:plugin/tab-host@0.1.0#tab-icon")]
+                        unsafe extern "C" fn export_tab_icon() -> * mut u8 { unsafe {
+                        $($path_to_types)*:: _export_tab_icon_cabi::<$ty > () } }
+                        #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/tab-host@0.1.0#tab-icon")] unsafe extern
+                        "C" fn _post_return_tab_icon(arg0 : * mut u8,) { unsafe {
+                        $($path_to_types)*:: __post_return_tab_icon::<$ty > (arg0) } }
+                        #[unsafe (export_name = "thoth:plugin/tab-host@0.1.0#get-state")]
+                        unsafe extern "C" fn export_get_state() -> * mut u8 { unsafe {
+                        $($path_to_types)*:: _export_get_state_cabi::<$ty > () } }
+                        #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/tab-host@0.1.0#get-state")] unsafe extern
+                        "C" fn _post_return_get_state(arg0 : * mut u8,) { unsafe {
+                        $($path_to_types)*:: __post_return_get_state::<$ty > (arg0) } }
+                        #[unsafe (export_name =
+                        "thoth:plugin/tab-host@0.1.0#init-with-state")] unsafe extern "C"
+                        fn export_init_with_state(arg0 : * mut u8, arg1 : usize,) -> *
+                        mut u8 { unsafe { $($path_to_types)*::
+                        _export_init_with_state_cabi::<$ty > (arg0, arg1) } } #[unsafe
+                        (export_name =
+                        "cabi_post_thoth:plugin/tab-host@0.1.0#init-with-state")] unsafe
+                        extern "C" fn _post_return_init_with_state(arg0 : * mut u8,) {
+                        unsafe { $($path_to_types)*:: __post_return_init_with_state::<$ty
+                        > (arg0) } } #[unsafe (export_name =
+                        "thoth:plugin/tab-host@0.1.0#on-tab-focused")] unsafe extern "C"
+                        fn export_on_tab_focused() { unsafe { $($path_to_types)*::
+                        _export_on_tab_focused_cabi::<$ty > () } } #[unsafe (export_name
+                        = "thoth:plugin/tab-host@0.1.0#on-tab-blurred")] unsafe extern
+                        "C" fn export_on_tab_blurred() { unsafe { $($path_to_types)*::
+                        _export_on_tab_blurred_cabi::<$ty > () } } #[unsafe (export_name
+                        = "thoth:plugin/tab-host@0.1.0#on-tab-closed")] unsafe extern "C"
+                        fn export_on_tab_closed() { unsafe { $($path_to_types)*::
+                        _export_on_tab_closed_cabi::<$ty > () } } };
+                    };
+                }
+                #[doc(hidden)]
+                pub(crate) use __export_thoth_plugin_tab_host_0_1_0_cabi;
+                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                struct _RetArea(
+                    [::core::mem::MaybeUninit<
+                        u8,
+                    >; 4 * ::core::mem::size_of::<*const u8>()],
+                );
+                static mut _RET_AREA: _RetArea = _RetArea(
+                    [::core::mem::MaybeUninit::uninit(); 4
+                        * ::core::mem::size_of::<*const u8>()],
+                );
+            }
+            /// ---------------------------------------------------------------------------
             /// plugin-meta — required by every plugin
             ///
             /// Maps from src/wit/mod.rs `Plugin` struct (as the return type of get-info).
@@ -2527,6 +2940,9 @@ macro_rules! __export_data_source_plugin_impl {
         exports::thoth::plugin::ui_component::__export_thoth_plugin_ui_component_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::ui_component);
         $($path_to_types_root)*::
+        exports::thoth::plugin::tab_host::__export_thoth_plugin_tab_host_0_1_0_cabi!($ty
+        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::tab_host);
+        $($path_to_types_root)*::
         exports::thoth::plugin::plugin_meta::__export_thoth_plugin_plugin_meta_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_meta);
         $($path_to_types_root)*::
@@ -2545,9 +2961,9 @@ pub(crate) use __export_data_source_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1797] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xfc\x0c\x01A\x02\x01\
-A\x12\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 2101] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xac\x0f\x01A\x02\x01\
+A\x16\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
 \x0fsearch-provider\x10new-ui-component\x04\0\x0acapability\x03\0\0\x01p\x01\x01\
 ks\x01r\x08\x02ids\x04names\x07versions\x0bdescriptions\x0ccapabilities\x02\x06a\
 uthor\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplugin-info\x03\0\x04\x01r\x02\x04\
@@ -2560,32 +2976,39 @@ y\x05\x04\0\x0chttp-request\x03\0\x06\x01r\x03\x06status{\x07headers\x03\x04body
 \x0a\x04\0\x05fetch\x01\x0b\x01@\x01\x03req\x07\0s\x04\0\x06submit\x01\x0c\x03\0\
 \x1ethoth:plugin/http-client@0.1.0\x05\x02\x01B\x05\x01@\0\0s\x04\0\x04read\x01\0\
 \x01j\0\x01s\x01@\x01\x04datas\0\x01\x04\0\x05write\x01\x02\x03\0!thoth:plugin/p\
-lugin-storage@0.1.0\x05\x03\x01B\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\
-\0\0\x01r\x04\x04names\x0bdescriptions\x08required\x7f\x05values\x04\0\x0cconfig\
--entry\x03\0\x02\x01r\x03\x04names\x09type-hints\x08nullable\x7f\x04\0\x0cfield-\
-schema\x03\0\x04\x01p\x05\x01r\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\
-\x03\0\x07\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\
-\x01p\x03\x01@\0\0\x0b\x04\0\x0frequired-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\
-\x06config\x0b\0\x0d\x04\0\x07connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\
-\x01\x06handles\0\x10\x04\0\x06schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\
-\0\x05query\x01\x12\x01@\x01\x06handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\
-\x01\x01\x01@\x01\x06handles\0\x14\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:p\
-lugin/data-source@0.1.0\x05\x04\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-err\
-or\x03\0\0\x01r\x03\x09widget-ids\x04kinds\x05values\x04\0\x08ui-event\x03\0\x02\
-\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\
-\x01\x01\x01@\0\0\x06\x04\0\x09render-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\
-\0\x0chandle-event\x01\x08\x01k\x05\x01j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0er\
-ender-sidebar\x01\x0b\x04\0\x1fthoth:plugin/ui-component@0.1.0\x05\x05\x02\x03\0\
-\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x06\x04\0\x0bplugin-info\x03\0\0\x01@\
-\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x07\
-\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08\
-on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:plugin/plugin-life\
-cycle@0.1.0\x05\x08\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01\
-r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\
-\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugi\
-n-settings@0.1.0\x05\x09\x04\0%thoth:plugin/data-source-plugin@0.1.0\x04\0\x0b\x18\
-\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0d\
-wit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
+lugin-storage@0.1.0\x05\x03\x01B\x03\x01ks\x01@\x03\x05titles\x04icon\0\x0diniti\
+al-state\0\0s\x04\0\x08open-tab\x01\x01\x03\0\x1athoth:plugin/ui-tabs@0.1.0\x05\x04\
+\x01B\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04names\x0b\
+descriptions\x08required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\x03\x04\
+names\x09type-hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\x05\x01\
+r\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09node-j\
+sons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\0\x0f\
+required-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\0\x07\
+connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\0\x06\
+schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\x01\x06\
+handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06handles\0\x14\
+\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\x05\x05\x01\
+B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09widget-ids\x04\
+kinds\x05values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\x0bheight-hin\
+ty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\0\x09rende\
+r-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\x01k\x05\x01\
+j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\x1fthoth:pl\
+ugin/ui-component@0.1.0\x05\x06\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-err\
+or\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\0\x08tab-\
+icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\x01j\0\x01\
+\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\x01\0\x04\0\
+\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0don-tab-close\
+d\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.0\x05\x07\x02\x03\0\0\x0bplugin-inf\
+o\x01B\x04\x02\x03\x02\x01\x08\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08\
+get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x09\x01B\x05\x01@\x01\
+\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\
+\x04\0\x11on-setting-change\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x0a\
+\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jso\
+ns\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\
+\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.\
+0\x05\x0b\x04\0%thoth:plugin/data-source-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12dat\
+a-source-plugin\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\
+\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/url-source/src/helper.rs
+++ b/plugins/url-source/src/helper.rs
@@ -39,6 +39,15 @@ pub fn parse_kv_list(s: &str) -> Vec<KvPair> {
     serde_json::from_str(s).unwrap_or_default()
 }
 
+/// True when the form holds a meaningful request (so we shouldn't overwrite it
+/// in place, e.g. when importing a cURL — open a new tab instead).
+pub fn request_is_non_empty(st: &State) -> bool {
+    !st.url.is_empty()
+        || !st.body.is_empty()
+        || st.params.iter().any(|p| !p.key.is_empty())
+        || st.req_headers.iter().any(|h| !h.key.is_empty())
+}
+
 pub fn pct_encode(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for b in s.bytes() {
@@ -129,11 +138,13 @@ pub fn parse_url_into_state(st: &mut State, raw: String) {
                 KvPair {
                     key: decode(&pair[..eq]),
                     value: decode(&pair[eq + 1..]),
+                    enabled: true,
                 }
             } else {
                 KvPair {
                     key: decode(pair),
                     value: String::new(),
+                    enabled: true,
                 }
             }
         })

--- a/plugins/url-source/src/http.rs
+++ b/plugins/url-source/src/http.rs
@@ -24,7 +24,11 @@ pub fn http_fetch(st: &State) -> Result<Vec<u8>, PluginError> {
 pub fn build_request(st: &State) -> HttpRequest {
     // URL + query params
     let url = {
-        let active: Vec<&KvPair> = st.params.iter().filter(|p| !p.key.is_empty()).collect();
+        let active: Vec<&KvPair> = st
+            .params
+            .iter()
+            .filter(|p| p.enabled && !p.key.is_empty())
+            .collect();
         if active.is_empty() {
             // Also handle api-key-in-query auth
             if st.auth_type == "api-key"
@@ -66,7 +70,7 @@ pub fn build_request(st: &State) -> HttpRequest {
     let mut headers: Vec<(String, String)> = st
         .req_headers
         .iter()
-        .filter(|h| !h.key.is_empty())
+        .filter(|h| h.enabled && !h.key.is_empty())
         .map(|h| (h.key.clone(), h.value.clone()))
         .collect();
 

--- a/plugins/url-source/src/lib.rs
+++ b/plugins/url-source/src/lib.rs
@@ -16,6 +16,7 @@ use bindings::exports::thoth::plugin::{
     plugin_lifecycle::Guest as LifecycleGuest,
     plugin_meta::Guest as MetaGuest,
     plugin_settings::{Guest as SettingsGuest, SettingsOutput},
+    tab_host::Guest as TabHostGuest,
     ui_component::{Guest as UiComponentGuest, UiEvent, UiOutput},
 };
 use bindings::thoth::plugin::types::Capability;
@@ -27,10 +28,11 @@ use crate::{
 
 struct UrlSourcePlugin;
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
 struct State {
     // ── Saved requests ────────────────────────────────────────────────────
     request_name: String, // name input in the sidebar
+    #[serde(default)]
     saved_requests: Vec<SavedRequest>,
 
     // ── Request ───────────────────────────────────────────────────────────
@@ -53,19 +55,26 @@ struct State {
     resp_tab: String, // "pretty" | "raw" | "headers"
 
     // ── cURL export / import modals ──────────────────────────────────────
+    #[serde(skip)]
     show_export_modal: bool,
+    #[serde(skip)]
     show_import_modal: bool,
+    #[serde(skip)]
     curl_import_input: String,
 
-    // ── Async fetch state ─────────────────────────────────────────────────
+    // ── Async fetch state (transient — never persisted) ───────────────────
     /// True while a submit() request is in flight.
+    #[serde(skip)]
     loading: bool,
     /// True when loading is paused waiting for the user to approve a consent popup.
+    #[serde(skip)]
     consent_pending: bool,
     /// The request_id returned by submit(); matched against the http-response event.
+    #[serde(skip)]
     pending_request_id: Option<String>,
 
-    // ── Response cache ────────────────────────────────────────────────────
+    // ── Response cache (transient — never persisted) ──────────────────────
+    #[serde(skip)]
     response: Option<ResponseState>,
 }
 
@@ -670,9 +679,23 @@ impl UiComponentGuest for UrlSourcePlugin {
             } else if event.widget_id == "saved-requests" {
                 match event.kind.as_str() {
                     "click" => {
+                        // Open the saved request in a NEW TAB (seeded with that
+                        // request), rather than loading it into the sidebar form.
                         if let Ok(idx) = event.value.parse::<usize>() {
                             if let Some(req) = st.saved_requests.get(idx).cloned() {
-                                load_saved_request(&mut st, req);
+                                let mut seed = st.clone();
+                                load_saved_request(&mut seed, req);
+                                let title = if seed.url.is_empty() {
+                                    "URL Source".to_string()
+                                } else {
+                                    format!("{} {}", seed.method, seed.url)
+                                };
+                                let initial_state = serde_json::to_string(&seed).ok();
+                                bindings::thoth::plugin::ui_tabs::open_tab(
+                                    &title,
+                                    Some("\u{E28C}"),
+                                    initial_state.as_deref(),
+                                );
                             }
                         }
                     }
@@ -693,6 +716,19 @@ impl UiComponentGuest for UrlSourcePlugin {
                     }
                     _ => {}
                 }
+            } else if event.widget_id == "open-new-tab" {
+                // Open a fresh url-source tab seeded with this request's form.
+                let initial_state = serde_json::to_string(&st).ok();
+                let title = if st.url.is_empty() {
+                    "URL Source".to_string()
+                } else {
+                    format!("{} {}", st.method, st.url)
+                };
+                bindings::thoth::plugin::ui_tabs::open_tab(
+                    &title,
+                    Some("\u{E28C}"),
+                    initial_state.as_deref(),
+                );
             } else if event.widget_id == "consent-approved" {
                 // Host has dispatched the retry request — switch spinner text
                 // from "Waiting for consent approval" back to "Sending request".
@@ -721,6 +757,60 @@ impl UiComponentGuest for UrlSourcePlugin {
             *s.borrow_mut() = st.clone();
             Ok(ui_out(ui::build_ui(&st)))
         })
+    }
+}
+
+impl TabHostGuest for UrlSourcePlugin {
+    /// Show the active request in the tab label so two url-source tabs are
+    /// distinguishable.
+    fn tab_title() -> String {
+        STATE.with(|s| {
+            let st = s.borrow();
+            if st.url.is_empty() {
+                "URL Source".to_string()
+            } else {
+                let shown = if st.url.len() > 40 {
+                    format!("{}…", &st.url[..40])
+                } else {
+                    st.url.clone()
+                };
+                format!("{} {}", st.method, shown)
+            }
+        })
+    }
+
+    fn tab_icon() -> Option<String> {
+        Some("\u{E28C}".to_string()) // GLOBE_HEMISPHERE_WEST
+    }
+
+    /// Snapshot the per-tab request form so the host can persist it. Transient
+    /// fields (response, loading, modals) are `#[serde(skip)]` and not included.
+    fn get_state() -> Result<String, PluginError> {
+        STATE
+            .with(|s| serde_json::to_string(&*s.borrow()).map_err(|e| plugin_err(3, e.to_string())))
+    }
+
+    /// Restore the request form from a previously saved snapshot.
+    fn init_with_state(state: String) -> Result<(), PluginError> {
+        if state.is_empty() {
+            return Ok(());
+        }
+        if let Ok(restored) = serde_json::from_str::<State>(&state) {
+            STATE.with(|s| *s.borrow_mut() = restored);
+        }
+        Ok(())
+    }
+
+    fn on_tab_focused() {
+        eprintln!("[url-source] on_tab_focused");
+    }
+
+    fn on_tab_blurred() {
+        eprintln!("[url-source] on_tab_blurred");
+    }
+
+    fn on_tab_closed() {
+        eprintln!("[url-source] on_tab_closed");
     }
 }
 

--- a/plugins/url-source/src/lib.rs
+++ b/plugins/url-source/src/lib.rs
@@ -833,8 +833,9 @@ impl TabHostGuest for UrlSourcePlugin {
         if state.is_empty() {
             return Ok(());
         }
-        if let Ok(restored) = serde_json::from_str::<State>(&state) {
-            STATE.with(|s| *s.borrow_mut() = restored);
+        match serde_json::from_str::<State>(&state) {
+            Ok(restored) => STATE.with(|s| *s.borrow_mut() = restored),
+            Err(e) => eprintln!("[url-source] init_with_state: invalid state blob: {e}"),
         }
         Ok(())
     }

--- a/plugins/url-source/src/lib.rs
+++ b/plugins/url-source/src/lib.rs
@@ -22,7 +22,7 @@ use bindings::exports::thoth::plugin::{
 use bindings::thoth::plugin::types::Capability;
 
 use crate::{
-    helper::{ce, normalise_array, plugin_err, type_hint, ui_out},
+    helper::{ce, normalise_array, plugin_err, request_is_non_empty, type_hint, ui_out},
     http::http_fetch,
 };
 
@@ -106,10 +106,28 @@ struct ResponseState {
     size_bytes: usize,
 }
 
-#[derive(Clone, Default, serde::Serialize, serde::Deserialize, Debug)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
 struct KvPair {
     key: String,
     value: String,
+    /// Whether this row is sent. Disabled rows are kept (so the user can re-enable
+    /// them) but skipped when building the request / cURL. Defaults to true.
+    #[serde(default = "default_true")]
+    enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for KvPair {
+    fn default() -> Self {
+        Self {
+            key: String::new(),
+            value: String::new(),
+            enabled: true,
+        }
+    }
 }
 
 /// A single saved request entry.
@@ -225,6 +243,7 @@ impl DataSourceGuest for UrlSourcePlugin {
                                     .map(|(k, v)| KvPair {
                                         key: k.clone(),
                                         value: v.as_str().unwrap_or("").to_string(),
+                                        enabled: true,
                                     })
                                     .collect();
                             }
@@ -411,7 +430,11 @@ fn build_curl_command(st: &State) -> String {
 
     // Build URL with query params
     let url = {
-        let active: Vec<&KvPair> = st.params.iter().filter(|p| !p.key.is_empty()).collect();
+        let active: Vec<&KvPair> = st
+            .params
+            .iter()
+            .filter(|p| p.enabled && !p.key.is_empty())
+            .collect();
         if active.is_empty() {
             st.url.clone()
         } else {
@@ -445,7 +468,7 @@ fn build_curl_command(st: &State) -> String {
 
     // Custom headers
     for h in &st.req_headers {
-        if !h.key.is_empty() {
+        if h.enabled && !h.key.is_empty() {
             parts.push(format!("-H '{}: {}'", h.key, h.value));
         }
     }
@@ -589,7 +612,11 @@ fn apply_curl_import(st: &mut State, curl: &str) {
                                 }
                             }
                         } else if !k.eq_ignore_ascii_case("content-type") {
-                            st.req_headers.push(crate::KvPair { key: k, value: v });
+                            st.req_headers.push(crate::KvPair {
+                                key: k,
+                                value: v,
+                                enabled: true,
+                            });
                         }
                     }
                     i += 2;
@@ -601,6 +628,7 @@ fn apply_curl_import(st: &mut State, curl: &str) {
                     st.req_headers.push(crate::KvPair {
                         key: "Cookie".to_string(),
                         value: cookie.clone(),
+                        enabled: true,
                     });
                     i += 2;
                     continue;
@@ -610,12 +638,14 @@ fn apply_curl_import(st: &mut State, curl: &str) {
                 st.req_headers.push(crate::KvPair {
                     key: "Cookie".to_string(),
                     value: t["--cookie=".len()..].to_string(),
+                    enabled: true,
                 });
             }
             t if t.starts_with("-b") && t.len() > 2 => {
                 st.req_headers.push(crate::KvPair {
                     key: "Cookie".to_string(),
                     value: t[2..].to_string(),
+                    enabled: true,
                 });
             }
             "-d" | "--data" | "--data-raw" => {
@@ -638,6 +668,7 @@ fn apply_curl_import(st: &mut State, curl: &str) {
                             Some(crate::KvPair {
                                 key: percent_decode(k),
                                 value: percent_decode(v),
+                                enabled: true,
                             })
                         })
                         .collect();
@@ -685,11 +716,7 @@ impl UiComponentGuest for UrlSourcePlugin {
                             if let Some(req) = st.saved_requests.get(idx).cloned() {
                                 let mut seed = st.clone();
                                 load_saved_request(&mut seed, req);
-                                let title = if seed.url.is_empty() {
-                                    "URL Source".to_string()
-                                } else {
-                                    format!("{} {}", seed.method, seed.url)
-                                };
+                                let title = tab_title_for(&seed);
                                 let initial_state = serde_json::to_string(&seed).ok();
                                 bindings::thoth::plugin::ui_tabs::open_tab(
                                     &title,
@@ -719,11 +746,7 @@ impl UiComponentGuest for UrlSourcePlugin {
             } else if event.widget_id == "open-new-tab" {
                 // Open a fresh url-source tab seeded with this request's form.
                 let initial_state = serde_json::to_string(&st).ok();
-                let title = if st.url.is_empty() {
-                    "URL Source".to_string()
-                } else {
-                    format!("{} {}", st.method, st.url)
-                };
+                let title = tab_title_for(&st);
                 bindings::thoth::plugin::ui_tabs::open_tab(
                     &title,
                     Some("\u{E28C}"),
@@ -747,9 +770,24 @@ impl UiComponentGuest for UrlSourcePlugin {
                 st.curl_import_input = crate::helper::parse_str(&event.value);
             } else if event.widget_id == "curl-import-submit" {
                 let curl = st.curl_import_input.clone();
-                apply_curl_import(&mut st, &curl);
                 st.show_import_modal = false;
                 st.curl_import_input = String::new();
+                if request_is_non_empty(&st) {
+                    // Don't clobber the current request — open the imported one
+                    // in a fresh tab seeded with the parsed cURL.
+                    let mut seed = st.clone();
+                    seed.request_name = String::new();
+                    apply_curl_import(&mut seed, &curl);
+                    let title = tab_title_for(&seed);
+                    let initial_state = serde_json::to_string(&seed).ok();
+                    bindings::thoth::plugin::ui_tabs::open_tab(
+                        &title,
+                        Some("\u{E28C}"),
+                        initial_state.as_deref(),
+                    );
+                } else {
+                    apply_curl_import(&mut st, &curl);
+                }
             } else {
                 ui::apply_event(&mut st, &event);
             }
@@ -760,23 +798,23 @@ impl UiComponentGuest for UrlSourcePlugin {
     }
 }
 
+/// Title shown on the dock tab: the saved request name when set, else `method url`.
+fn tab_title_for(st: &State) -> String {
+    let name = st.request_name.trim();
+    if !name.is_empty() {
+        name.to_string()
+    } else if st.url.is_empty() {
+        "URL Source".to_string()
+    } else {
+        format!("{} {}", st.method, st.url)
+    }
+}
+
 impl TabHostGuest for UrlSourcePlugin {
-    /// Show the active request in the tab label so two url-source tabs are
+    /// Show the saved request name (or method+url) in the tab label so tabs are
     /// distinguishable.
     fn tab_title() -> String {
-        STATE.with(|s| {
-            let st = s.borrow();
-            if st.url.is_empty() {
-                "URL Source".to_string()
-            } else {
-                let shown = if st.url.len() > 40 {
-                    format!("{}…", &st.url[..40])
-                } else {
-                    st.url.clone()
-                };
-                format!("{} {}", st.method, shown)
-            }
-        })
+        STATE.with(|s| tab_title_for(&s.borrow()))
     }
 
     fn tab_icon() -> Option<String> {

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -46,6 +46,8 @@ fn method_badge_color(method: &str) -> &'static str {
 // egui_phosphor::regular::ARROW_SQUARE_OUT = export, ARROW_SQUARE_IN = import
 const ICON_EXPORT: &str = "\u{E5DE}";
 const ICON_IMPORT: &str = "\u{E5DC}";
+// egui_phosphor::regular::PLUS
+const ICON_PLUS: &str = "\u{E3D4}";
 
 /// Rendered by the host in its sidebar panel.
 pub fn build_sidebar(st: &State) -> Value {
@@ -71,6 +73,32 @@ pub fn build_sidebar(st: &State) -> Value {
         "type": "column",
         "gap": 0,
         "children": [
+            {
+                "type": "row",
+                "padding": 6,
+                "children": [
+                    {"type": "heading", "value": "Collections", "level": 3}
+                ]
+            },
+            {
+                "type": "column",
+                "padding": 6,
+                "children": [
+                    {
+                        "type": "button",
+                        "id": "open-new-tab",
+                        "props": {
+                            "label": "New Request",
+                            "button-type": "Elevated",
+                            "color": "Primary",
+                            "enabled": true,
+                            "icon": ICON_PLUS,
+                            "full-width": true
+                        }
+                    }
+                ]
+            },
+            {"type": "separator"},
             {
                 "type": "row",
                 "gap": 4,
@@ -225,21 +253,13 @@ fn build_response_column(st: &State) -> Value {
 }
 
 fn build_url_bar(st: &State) -> Value {
-    // Method pill buttons
-    let method_btns: Vec<Value> = ["GET", "POST", "PUT", "PATCH", "DELETE"]
+    // Method dropdown
+    let method_options: Vec<Value> = ["GET", "POST", "PUT", "PATCH", "DELETE"]
         .iter()
-        .map(|m| {
-            let id = format!("method-btn-{}", m.to_lowercase());
-            let selected = st.method == *m;
-            if selected {
-                btn_elevated(&id, m, true, "Secondary")
-            } else {
-                btn_text(&id, m, true)
-            }
-        })
+        .map(|m| json!({ "value": m, "label": m }))
         .collect();
 
-    // Visual order: [MethodButtons | URL(grow) | Send | Save]
+    // Visual order: [Method ▾ | URL(grow) | Clear | Send]
     // Fill layout: prefix items render LTR, then RTL sub-layout for suffix+grow.
     json!({
         "type":  "row",
@@ -248,9 +268,12 @@ fn build_url_bar(st: &State) -> Value {
         "padding": 4,
         "children": [
             {
-                "type": "row",
-                "gap": 2,
-                "children": method_btns
+                "type":    "select",
+                "id":      "method",
+                "label":   "",
+                "value":   st.method,
+                "options": method_options,
+                "width":   96
             },
             {
                 "type":        "text-input",
@@ -654,20 +677,6 @@ fn btn_elevated(id: &str, label: &str, enabled: bool, color: &str) -> Value {
             "label":       label,
             "button-type": "Elevated",
             "color":       color,
-            "enabled":     enabled
-        }
-    })
-}
-
-/// Text (ghost) button. Use for inactive method pill buttons.
-fn btn_text(id: &str, label: &str, enabled: bool) -> Value {
-    json!({
-        "type": "button",
-        "id":   id,
-        "props": {
-            "label":       label,
-            "button-type": "Text",
-            "color":       "Default",
             "enabled":     enabled
         }
     })

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -25,7 +25,9 @@ pub fn build_ui(st: &State) -> Value {
                     build_request_column(st),
                     build_response_column(st)
                 ]
-            }
+            },
+            // Export cURL modal (opened by the code icon on the request tabs line).
+            curl_export_modal(st)
         ]
     })
 }
@@ -43,11 +45,10 @@ fn method_badge_color(method: &str) -> &'static str {
     }
 }
 
-// egui_phosphor::regular::ARROW_SQUARE_OUT = export, ARROW_SQUARE_IN = import
-const ICON_EXPORT: &str = "\u{E5DE}";
-const ICON_IMPORT: &str = "\u{E5DC}";
-// egui_phosphor::regular::PLUS
-const ICON_PLUS: &str = "\u{E3D4}";
+// egui_phosphor::regular glyphs
+const ICON_PLUS: &str = "\u{E3D4}"; // PLUS
+const ICON_CODE: &str = "\u{E1BC}"; // CODE (export cURL)
+const ICON_DOWNLOAD: &str = "\u{E20C}"; // DOWNLOAD_SIMPLE (import cURL)
 
 /// Rendered by the host in its sidebar panel.
 pub fn build_sidebar(st: &State) -> Value {
@@ -67,8 +68,6 @@ pub fn build_sidebar(st: &State) -> Value {
         })
         .collect();
 
-    let curl_command = crate::build_curl_command(st);
-
     json!({
         "type": "column",
         "gap": 0,
@@ -77,11 +76,13 @@ pub fn build_sidebar(st: &State) -> Value {
                 "type": "row",
                 "padding": 6,
                 "children": [
-                    {"type": "heading", "value": "Collections", "level": 3}
+                    {"type": "heading", "value": "COLLECTIONS", "panel": true}
                 ]
             },
             {
-                "type": "column",
+                "type": "row",
+                "gap": 6,
+                "align": "fill",
                 "padding": 6,
                 "children": [
                     {
@@ -95,6 +96,14 @@ pub fn build_sidebar(st: &State) -> Value {
                             "icon": ICON_PLUS,
                             "full-width": true
                         }
+                    },
+                    {
+                        "type": "icon-button",
+                        "id": "import-curl",
+                        "icon": ICON_DOWNLOAD,
+                        "tooltip": "Import cURL",
+                        "frame": true,
+                        "button-size": "Medium"
                     }
                 ]
             },
@@ -123,77 +132,69 @@ pub fn build_sidebar(st: &State) -> Value {
                 "items": list_items,
                 "empty-label": "No saved requests"
             },
-            // Export modal
+            // Import cURL modal (opened by the download icon next to New Request).
+            curl_import_modal(st),
+        ]
+    })
+}
+
+/// The "Import cURL" modal — shared shape, rendered in the sidebar.
+fn curl_import_modal(st: &State) -> Value {
+    json!({
+        "type": "modal",
+        "id": "import-modal",
+        "title": "Import cURL",
+        "open": st.show_import_modal,
+        "close-id": "close-import",
+        "width-pct": 0.7,
+        "height-pct": 0.7,
+        "children": [
             {
-                "type": "modal",
-                "id": "export-modal",
-                "title": "Export cURL",
-                "open": st.show_export_modal,
-                "close-id": "close-export",
-                "width-pct": 0.7,
-                "height-pct": 0.7,
-                "children": [
-                    {
-                        "type": "text-input",
-                        "id": "curl-output",
-                        "value": curl_command,
-                        "label": "cURL command",
-                        "placeholder": "",
-                        "multiline": true,
-                        "rows": 10
-                    },
-                    {
-                        "type": "button",
-                        "id": "",
-                        "copy": curl_command,
-                        "props": {
-                            "label": "Copy to Clipboard",
-                            "button-type": "Elevated",
-                            "color": "Default",
-                            "enabled": true
-                        }
-                    }
-                ]
+                "type": "text-input",
+                "id": "curl-import-input",
+                "value": st.curl_import_input,
+                "placeholder": "Paste cURL command here…",
+                "label": "cURL command",
+                "multiline": true,
+                "rows": 10
             },
-            // Import modal
+            btn_elevated("curl-import-submit", "Import", !st.curl_import_input.is_empty(), "Default")
+        ]
+    })
+}
+
+/// The "Export cURL" modal — rendered in the request tab (build_ui), reflecting
+/// the current request.
+fn curl_export_modal(st: &State) -> Value {
+    let curl_command = crate::build_curl_command(st);
+    json!({
+        "type": "modal",
+        "id": "export-modal",
+        "title": "Export cURL",
+        "open": st.show_export_modal,
+        "close-id": "close-export",
+        "width-pct": 0.7,
+        "height-pct": 0.7,
+        "children": [
             {
-                "type": "modal",
-                "id": "import-modal",
-                "title": "Import cURL",
-                "open": st.show_import_modal,
-                "close-id": "close-import",
-                "width-pct": 0.7,
-                "height-pct": 0.7,
-                "children": [
-                    {
-                        "type": "text-input",
-                        "id": "curl-import-input",
-                        "value": st.curl_import_input,
-                        "placeholder": "Paste cURL command here…",
-                        "label": "cURL command",
-                        "multiline": true,
-                        "rows": 10
-                    },
-                    btn_elevated("curl-import-submit", "Import", !st.curl_import_input.is_empty(), "Default")
-                ]
+                "type": "text-input",
+                "id": "curl-output",
+                "value": curl_command,
+                "label": "cURL command",
+                "placeholder": "",
+                "multiline": true,
+                "rows": 10
             },
-            // Footer pinned at bottom
             {
-                "type": "footer",
-                "padding": 8,
-                "gap": 0,
-                "children": [
-                    {"type": "separator"},
-                    {
-                        "type": "row",
-                        "gap": 4,
-                        "padding": 4,
-                        "children": [
-                            btn_text_icon("export-curl", "Export cURL", ICON_EXPORT),
-                            btn_text_icon("import-curl", "Import cURL", ICON_IMPORT)
-                        ]
-                    }
-                ]
+                "type": "button",
+                "id": "",
+                "copy": curl_command,
+                "props": {
+                    "label": "Copy to Clipboard",
+                    "button-type": "Elevated",
+                    "color": "Default",
+                    "enabled": true
+                }
             }
         ]
     })
@@ -300,6 +301,9 @@ fn build_req_tabs(st: &State) -> Value {
         "type":   "tabs",
         "id":     "req-tabs",
         "header": ["Params", "Auth", "Headers", "Body"],
+        "actions": [
+            {"id": "export-curl", "icon": ICON_CODE, "tooltip": "Export cURL"}
+        ],
         "children": [
             // ── Params ──────────────────────────────────────────────────────
             {
@@ -571,6 +575,7 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
                         Some(KvPair {
                             key: a.first()?.as_str()?.to_string(),
                             value: a.get(1)?.as_str()?.to_string(),
+                            enabled: true,
                         })
                     })
                     .collect()
@@ -678,21 +683,6 @@ fn btn_elevated(id: &str, label: &str, enabled: bool, color: &str) -> Value {
             "button-type": "Elevated",
             "color":       color,
             "enabled":     enabled
-        }
-    })
-}
-
-/// Text button with a phosphor icon.
-fn btn_text_icon(id: &str, label: &str, icon: &str) -> Value {
-    json!({
-        "type": "button",
-        "id":   id,
-        "props": {
-            "label":       label,
-            "button-type": "Text",
-            "color":       "Default",
-            "enabled":     true,
-            "icon":        icon
         }
     })
 }

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -628,11 +628,6 @@ pub fn apply_event(st: &mut State, event: &UiEvent) {
     match event.widget_id.as_str() {
         "request-name" => st.request_name = parse_str(&event.value),
 
-        "method-btn-get" => st.method = "GET".to_string(),
-        "method-btn-post" => st.method = "POST".to_string(),
-        "method-btn-put" => st.method = "PUT".to_string(),
-        "method-btn-delete" => st.method = "DELETE".to_string(),
-        "method-btn-patch" => st.method = "PATCH".to_string(),
         "method" => st.method = parse_str(&event.value),
         "url" => {
             let raw = parse_str(&event.value);

--- a/src/app/persistent_state.rs
+++ b/src/app/persistent_state.rs
@@ -14,8 +14,17 @@ const MAX_BOOKMARKS: usize = 100; // Maximum number of bookmarks
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum PersistedTabKind {
-    File { path: String },
-    Plugin { plugin_id: String },
+    File {
+        path: String,
+    },
+    Plugin {
+        plugin_id: String,
+        /// Per-tab state blob from the plugin's `get-state` hook, passed back via
+        /// `init-with-state` on restore. Absent for older sessions / plugins
+        /// without a `tab-host` export.
+        #[serde(default)]
+        state: Option<String>,
+    },
 }
 
 /// A tab entry that can be restored on the next launch.

--- a/src/app/tab_manager.rs
+++ b/src/app/tab_manager.rs
@@ -51,7 +51,14 @@ impl TabState {
 
     pub fn title(&self) -> String {
         if let Some(pane) = &self.active_plugin_pane {
-            return pane.plugin_id.clone();
+            let title = pane
+                .cached_tab_title
+                .clone()
+                .unwrap_or_else(|| pane.plugin_id.clone());
+            return match &pane.cached_tab_icon {
+                Some(icon) if !icon.is_empty() => format!("{icon}  {title}"),
+                _ => title,
+            };
         }
         self.file_path
             .as_ref()
@@ -234,6 +241,12 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
     }
 
     fn on_close(&mut self, tab_id: &mut TabId) -> OnCloseResponse {
+        // Notify the plugin BEFORE the pane (and its loader) is dropped.
+        if let Some(tab) = self.tabs.get(tab_id)
+            && let Some(pane) = tab.active_plugin_pane.as_ref()
+        {
+            pane.loader.on_tab_closed();
+        }
         self.tabs.remove(tab_id);
         self.events.push(TabEvent::TabClosed(*tab_id));
         OnCloseResponse::Close

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -5,6 +5,7 @@ use crate::{
     NOTIFICATION_MANAGER, PLUGIN_MANAGER,
     app::{file_picker, pick_file, tab_manager::TabEvent},
     components::{self, traits::ContextComponent},
+    plugin::plugin_ui_host::PluginUiHost,
     settings, state,
 };
 
@@ -28,10 +29,60 @@ pub struct ThothApp {
     /// Plugin IDs from the persisted session that couldn't be restored yet because
     /// PLUGIN_MANAGER was still initializing on the background thread. Drained each
     /// frame once the manager becomes available.
-    pending_plugin_restores: Vec<String>,
+    pending_plugin_restores: Vec<(String, Option<String>)>,
     /// Active-tab index to switch to once all deferred session tabs are open.
     /// `None` once the switch has been applied (or when no session is being restored).
     session_restore_active_index: Option<usize>,
+    /// The plugin tab that was active last frame. Used to fire on-tab-focused /
+    /// on-tab-blurred lifecycle callbacks when the active tab changes.
+    last_active_plugin_tab: Option<crate::app::tab_manager::TabId>,
+    /// The plugin whose sidebar is currently mounted (independent of any tab).
+    sidebar_plugin: Option<SidebarPluginRuntime>,
+}
+
+/// Build the synthetic `http-response` UiEvent delivered to a plugin when an
+/// async `submit()` request completes (or fails / awaits consent).
+fn build_http_response_event(
+    request_id: String,
+    outcome: crate::plugin::plugin_ui_host::HttpCallResult,
+) -> crate::plugin::render_node::UiEvent {
+    let value = match outcome {
+        Ok(raw) => {
+            let body = String::from_utf8_lossy(&raw.body).to_string();
+            serde_json::json!({
+                "ok": {
+                    "status": raw.status,
+                    "headers": raw.headers,
+                    "body": body,
+                    "duration_ms": raw.duration_ms
+                }
+            })
+            .to_string()
+        }
+        Err(msg) => {
+            let code = if msg.contains("waiting for user consent") {
+                "consent_pending"
+            } else {
+                "error"
+            };
+            serde_json::json!({"err": {"code": code, "message": msg}}).to_string()
+        }
+    };
+    crate::plugin::render_node::UiEvent {
+        widget_id: request_id,
+        kind: "http-response".to_string(),
+        value,
+    }
+}
+
+/// A plugin's sidebar instance, independent of any dock tab. Created when the user
+/// opens the plugin's sidebar and kept alive while the sidebar is toggled, so its
+/// state survives collapse/expand and never affects (or requires) a tab. Tabs are
+/// spawned from it explicitly via the `ui-tabs` `open-tab` import.
+struct SidebarPluginRuntime {
+    plugin_id: String,
+    loader: Box<dyn PluginUiHost>,
+    output: Option<crate::plugin::render_node::UiOutput>,
 }
 
 impl ThothApp {
@@ -89,6 +140,8 @@ impl ThothApp {
             _native_menu: None,
             pending_plugin_restores,
             session_restore_active_index,
+            last_active_plugin_tab: None,
+            sidebar_plugin: None,
         }
     }
 
@@ -223,7 +276,7 @@ impl App for ThothApp {
 
         settings::Settings::store(&ctx, &self.settings);
 
-        self.poll_plugin_http_results(&ctx);
+        self.poll_plugin_panes(&ctx);
 
         if self.settings.ui.show_toolbar {
             self.render_toolbar(ui);
@@ -603,13 +656,41 @@ impl ThothApp {
         ctx.send_viewport_cmd(egui::ViewportCommand::Title(title));
     }
 
-    fn dispatch_plugin_event(&mut self, event: crate::plugin::render_node::UiEvent) {
-        if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
+    /// Build an `ActivePluginPane`, snapshotting the plugin's tab title/icon so the
+    /// dock label can be rendered cheaply without locking the WASM store each frame.
+    fn make_plugin_pane(
+        plugin_id: String,
+        loader: Box<dyn PluginUiHost>,
+        ui_output: crate::plugin::render_node::UiOutput,
+    ) -> crate::state::ActivePluginPane {
+        let cached_tab_title = loader.tab_title();
+        let cached_tab_icon = loader.tab_icon();
+        crate::state::ActivePluginPane {
+            plugin_id,
+            display_url: String::new(),
+            ui_output,
+            loader,
+            cached_tab_title,
+            cached_tab_icon,
+        }
+    }
+
+    /// Forward a UI event to the plugin pane on a specific tab (used so async HTTP
+    /// results land in the tab that originated them, not whichever tab is active).
+    fn dispatch_plugin_event_for(
+        &mut self,
+        tab_id: crate::app::tab_manager::TabId,
+        event: crate::plugin::render_node::UiEvent,
+    ) {
+        if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id)
             && let Some(pane) = tab.active_plugin_pane.as_mut()
         {
             match pane.loader.handle_event(event) {
                 Ok(new_output) => {
                     pane.ui_output = new_output;
+                    // Title/icon may change in response to the event.
+                    pane.cached_tab_title = pane.loader.tab_title();
+                    pane.cached_tab_icon = pane.loader.tab_icon();
                     if let Ok(sidebar) = pane.loader.render_sidebar() {
                         tab.plugin_sidebar_output = sidebar;
                     }
@@ -618,6 +699,163 @@ impl ThothApp {
                     tab.error = Some(crate::error::ThothError::Unknown {
                         message: e.to_string(),
                     });
+                }
+            }
+        }
+    }
+
+    /// Open a pure ui-component plugin in a tab (reusing an empty active tab or a
+    /// new one), optionally seeding it with a saved state blob.
+    /// Instantiate the right loader for a plugin based on its capabilities:
+    /// data-source plugins (which import http-client) use the data-source loader;
+    /// pure ui-component plugins use the ui-component loader.
+    fn build_plugin_loader(
+        manager: &crate::plugin::manager::PluginManager,
+        plugin_id: &str,
+        settings: &settings::Settings,
+    ) -> Option<Box<dyn PluginUiHost>> {
+        use crate::plugin::Capability;
+        let plugin = manager.registry.get_by_id(plugin_id)?;
+        if plugin.capabilities.contains(&Capability::DataSource) {
+            use crate::plugin::network_policy::NetworkPolicy;
+            let user_policy = settings
+                .plugins
+                .network_policies
+                .get(plugin_id)
+                .cloned()
+                .unwrap_or_default();
+            let policy = NetworkPolicy::from_plugin_and_settings(
+                &plugin.network.clone().unwrap_or_default(),
+                &user_policy,
+            );
+            manager
+                .open_data_source(plugin_id, policy)
+                .ok()
+                .map(|l| Box::new(l) as Box<dyn PluginUiHost>)
+        } else if plugin.capabilities.contains(&Capability::NewUIComponent) {
+            manager
+                .open_ui_component(plugin_id)
+                .ok()
+                .map(|l| Box::new(l) as Box<dyn PluginUiHost>)
+        } else {
+            None
+        }
+    }
+
+    fn open_ui_component_tab(&mut self, plugin_id: &str, initial_state: Option<&str>) {
+        let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) else {
+            return;
+        };
+        let Some(loader) = Self::build_plugin_loader(manager, plugin_id, &self.settings) else {
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                tab.error = Some(crate::error::ThothError::Unknown {
+                    message: format!("Failed to load plugin '{plugin_id}'"),
+                });
+            }
+            return;
+        };
+        if let Some(state) = initial_state {
+            let _ = loader.init_with_state(state);
+        }
+        let Ok(ui_output) = loader.render_ui() else {
+            return;
+        };
+        let sidebar_output = loader.render_sidebar().ok().flatten();
+        let nav_capacity = self.settings.performance.navigation_history_size;
+        let tab_id = if self
+            .window_state
+            .tab_manager
+            .active_tab_mut()
+            .is_some_and(|t| t.is_empty())
+        {
+            self.window_state.tab_manager.active_tab_id().unwrap()
+        } else {
+            self.window_state.tab_manager.open_new_tab(nav_capacity)
+        };
+        if let Some(t) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
+            t.active_plugin_pane = Some(Self::make_plugin_pane(
+                plugin_id.to_string(),
+                loader,
+                ui_output,
+            ));
+            t.plugin_sidebar_output = sidebar_output;
+        }
+        self.session_dirty = true;
+    }
+
+    /// Handle a plugin-initiated `open-tab` request: always open a fresh instance
+    /// in a new tab, seeded with the requested initial state.
+    fn open_ui_component_tab_from_request(
+        &mut self,
+        req: crate::plugin::plugin_ui_host::TabOpenRequest,
+    ) {
+        let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) else {
+            return;
+        };
+        let Some(loader) = Self::build_plugin_loader(manager, &req.plugin_id, &self.settings)
+        else {
+            return;
+        };
+        if let Some(state) = req.initial_state.as_deref() {
+            let _ = loader.init_with_state(state);
+        }
+        let Ok(ui_output) = loader.render_ui() else {
+            return;
+        };
+        let sidebar_output = loader.render_sidebar().ok().flatten();
+        let nav_capacity = self.settings.performance.navigation_history_size;
+        let tab_id = self.window_state.tab_manager.open_new_tab(nav_capacity);
+        if let Some(t) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
+            let mut pane = Self::make_plugin_pane(req.plugin_id.clone(), loader, ui_output);
+            // Prefer the title/icon the plugin passed to open-tab if it didn't
+            // override them via tab-title/tab-icon.
+            if pane.cached_tab_title.is_none() && !req.title.is_empty() {
+                pane.cached_tab_title = Some(req.title);
+            }
+            if pane.cached_tab_icon.is_none() {
+                pane.cached_tab_icon = req.icon;
+            }
+            t.active_plugin_pane = Some(pane);
+            t.plugin_sidebar_output = sidebar_output;
+        }
+        self.session_dirty = true;
+    }
+
+    /// Ensure a tab-independent sidebar runtime is mounted for `plugin_id`,
+    /// reusing the existing one if it already hosts this plugin.
+    fn ensure_sidebar_plugin(&mut self, plugin_id: &str) {
+        if self
+            .sidebar_plugin
+            .as_ref()
+            .is_some_and(|s| s.plugin_id == plugin_id)
+        {
+            return;
+        }
+        let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) else {
+            return;
+        };
+        let Some(loader) = Self::build_plugin_loader(manager, plugin_id, &self.settings) else {
+            return;
+        };
+        let output = loader.render_sidebar().ok().flatten();
+        self.sidebar_plugin = Some(SidebarPluginRuntime {
+            plugin_id: plugin_id.to_string(),
+            loader,
+            output,
+        });
+    }
+
+    /// Forward a widget event from the mounted plugin sidebar to its loader and
+    /// refresh the cached sidebar output. (Tab-open requests it raises are drained
+    /// in `poll_plugin_panes`.)
+    fn dispatch_sidebar_event(&mut self, event: crate::plugin::render_node::UiEvent) {
+        if let Some(rt) = self.sidebar_plugin.as_mut() {
+            match rt.loader.handle_event(event) {
+                Ok(_) => {
+                    rt.output = rt.loader.render_sidebar().ok().flatten();
+                }
+                Err(e) => {
+                    eprintln!("Plugin sidebar event error: {e}");
                 }
             }
         }
@@ -649,76 +887,99 @@ impl ThothApp {
         }
     }
 
-    /// Drain completed async HTTP requests from the active plugin pane and
-    /// forward each result to the plugin via `handle_event`.  Must be called
-    /// before any rendering so the updated `ui_output` is used in this frame.
-    fn poll_plugin_http_results(&mut self, ctx: &egui::Context) {
+    /// Drive every open plugin tab once per frame, before rendering:
+    ///  * deliver completed async HTTP results to the tab that originated them,
+    ///  * re-dispatch consent-approved retries,
+    ///  * open any tabs the plugins requested via `open-tab`,
+    ///  * fire on-tab-focused / on-tab-blurred when the active tab changes.
+    fn poll_plugin_panes(&mut self, ctx: &egui::Context) {
+        use crate::app::tab_manager::TabId;
+        use crate::plugin::plugin_ui_host::{PluginHttpRequest, TabOpenRequest};
         use crate::plugin::render_node::UiEvent;
 
-        let (http_events, retry_requests, needs_repaint) = {
-            let Some(tab) = self.window_state.tab_manager.active_tab_mut() else {
-                return;
+        // Collect drained items into owned vecs BEFORE mutating the tab manager
+        // (opening tabs / dispatching events borrows it mutably).
+        let ids: Vec<TabId> = self.window_state.tab_manager.tabs.keys().copied().collect();
+        let mut http_dispatch: Vec<(TabId, UiEvent)> = Vec::new();
+        let mut retry_dispatch: Vec<(TabId, String, PluginHttpRequest)> = Vec::new();
+        let mut tab_open_reqs: Vec<TabOpenRequest> = Vec::new();
+        let mut needs_repaint = false;
+
+        for id in &ids {
+            let Some(tab) = self.window_state.tab_manager.tabs.get(id) else {
+                continue;
             };
-            let Some(pane) = tab.active_plugin_pane.as_mut() else {
-                return;
+            let Some(pane) = tab.active_plugin_pane.as_ref() else {
+                continue;
             };
-
-            let http_events: Vec<UiEvent> = pane
-                .loader
-                .drain_http_results()
-                .into_iter()
-                .map(|(request_id, outcome)| {
-                    let value = match outcome {
-                        Ok(raw) => {
-                            let body = String::from_utf8_lossy(&raw.body).to_string();
-                            serde_json::json!({
-                                "ok": {
-                                    "status": raw.status,
-                                    "headers": raw.headers,
-                                    "body": body,
-                                    "duration_ms": raw.duration_ms
-                                }
-                            })
-                            .to_string()
-                        }
-                        Err(msg) => {
-                            let code = if msg.contains("waiting for user consent") {
-                                "consent_pending"
-                            } else {
-                                "error"
-                            };
-                            serde_json::json!({"err": {"code": code, "message": msg}}).to_string()
-                        }
-                    };
-                    UiEvent {
-                        widget_id: request_id,
-                        kind: "http-response".to_string(),
-                        value,
-                    }
-                })
-                .collect();
-
-            let retry_requests = pane.loader.drain_retry_requests();
-            let needs_repaint = pane.loader.has_pending_http();
-            (http_events, retry_requests, needs_repaint)
-        };
-
-        for event in http_events {
-            self.dispatch_plugin_event(event);
+            for (request_id, outcome) in pane.loader.drain_http_results() {
+                http_dispatch.push((*id, build_http_response_event(request_id, outcome)));
+            }
+            for (request_id, req) in pane.loader.drain_retry_requests() {
+                retry_dispatch.push((*id, request_id, req));
+            }
+            tab_open_reqs.extend(pane.loader.drain_tab_open_requests());
+            if pane.loader.has_pending_http() {
+                needs_repaint = true;
+            }
         }
 
-        for (request_id, req) in retry_requests {
-            if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                && let Some(pane) = tab.active_plugin_pane.as_mut()
+        // The mounted plugin sidebar runs independently of tabs — drive it too.
+        let mut sidebar_http: Vec<UiEvent> = Vec::new();
+        if let Some(rt) = self.sidebar_plugin.as_ref() {
+            for (request_id, outcome) in rt.loader.drain_http_results() {
+                sidebar_http.push(build_http_response_event(request_id, outcome));
+            }
+            tab_open_reqs.extend(rt.loader.drain_tab_open_requests());
+            if rt.loader.has_pending_http() {
+                needs_repaint = true;
+            }
+        }
+
+        for (id, event) in http_dispatch {
+            self.dispatch_plugin_event_for(id, event);
+        }
+        for event in sidebar_http {
+            self.dispatch_sidebar_event(event);
+        }
+
+        for (id, request_id, req) in retry_dispatch {
+            if let Some(tab) = self.window_state.tab_manager.tabs.get(&id)
+                && let Some(pane) = tab.active_plugin_pane.as_ref()
             {
                 pane.loader.dispatch_approved_request(request_id, req);
             }
-            self.dispatch_plugin_event(UiEvent {
-                widget_id: "consent-approved".to_string(),
-                kind: "notify".to_string(),
-                value: String::new(),
-            });
+            self.dispatch_plugin_event_for(
+                id,
+                UiEvent {
+                    widget_id: "consent-approved".to_string(),
+                    kind: "notify".to_string(),
+                    value: String::new(),
+                },
+            );
             ctx.request_repaint();
+        }
+
+        for req in tab_open_reqs {
+            self.open_ui_component_tab_from_request(req);
+        }
+
+        // Tab focus/blur lifecycle: notify plugins when the active tab changes.
+        let active = self.window_state.tab_manager.active_tab_id();
+        if active != self.last_active_plugin_tab {
+            if let Some(prev) = self.last_active_plugin_tab
+                && let Some(tab) = self.window_state.tab_manager.tabs.get(&prev)
+                && let Some(pane) = tab.active_plugin_pane.as_ref()
+            {
+                pane.loader.on_tab_blurred();
+            }
+            if let Some(cur) = active
+                && let Some(tab) = self.window_state.tab_manager.tabs.get(&cur)
+                && let Some(pane) = tab.active_plugin_pane.as_ref()
+            {
+                pane.loader.on_tab_focused();
+            }
+            self.last_active_plugin_tab = active;
         }
 
         if needs_repaint {
@@ -875,7 +1136,7 @@ impl ThothApp {
         tab_manager: &mut crate::app::TabManager,
         persistent_state: &PersistentState,
         settings: &settings::Settings,
-    ) -> (Vec<String>, usize) {
+    ) -> (Vec<(String, Option<String>)>, usize) {
         use crate::app::persistent_state::PersistedTabKind;
 
         let nav_capacity = settings.performance.navigation_history_size;
@@ -891,18 +1152,24 @@ impl ThothApp {
                         tab_manager.open_file(p, nav_capacity);
                     }
                 }
-                PersistedTabKind::Plugin { plugin_id } => {
+                PersistedTabKind::Plugin { plugin_id, state } => {
                     // PLUGIN_MANAGER is set by a background thread; it may not be ready yet.
                     match PLUGIN_MANAGER.get() {
                         Some(manager_opt) => {
                             if let Some(manager) = manager_opt.as_ref() {
-                                Self::open_plugin_tab(tab_manager, manager, plugin_id, settings);
+                                Self::open_plugin_tab(
+                                    tab_manager,
+                                    manager,
+                                    plugin_id,
+                                    state.as_deref(),
+                                    settings,
+                                );
                             }
                             // manager_opt == None means plugins are disabled — skip silently.
                         }
                         None => {
                             // Manager not initialized yet — defer to poll loop.
-                            deferred_plugins.push(plugin_id.clone());
+                            deferred_plugins.push((plugin_id.clone(), state.clone()));
                         }
                     }
                 }
@@ -913,30 +1180,24 @@ impl ThothApp {
     }
 
     /// Try to open a single plugin tab. Shared by initial restore and the deferred poll loop.
+    /// Picks the loader by capability: data-source plugins (which need http-client) use the
+    /// data-source loader; pure ui-component plugins use the ui-component loader. `state` is
+    /// the persisted per-tab blob, replayed via `init-with-state` after instantiation.
     fn open_plugin_tab(
         tab_manager: &mut crate::app::TabManager,
         manager: &crate::plugin::manager::PluginManager,
         plugin_id: &str,
+        state: Option<&str>,
         settings: &settings::Settings,
     ) {
         let nav_capacity = settings.performance.navigation_history_size;
-        let Some(plugin) = manager.registry.get_by_id(plugin_id) else {
+        let Some(loader) = Self::build_plugin_loader(manager, plugin_id, settings) else {
             return;
         };
-        use crate::plugin::network_policy::NetworkPolicy;
-        let user_policy = settings
-            .plugins
-            .network_policies
-            .get(plugin_id)
-            .cloned()
-            .unwrap_or_default();
-        let policy = NetworkPolicy::from_plugin_and_settings(
-            &plugin.network.clone().unwrap_or_default(),
-            &user_policy,
-        );
-        let Ok(loader) = manager.open_data_source(plugin_id, policy) else {
-            return;
-        };
+
+        if let Some(s) = state {
+            let _ = loader.init_with_state(s);
+        }
         let Ok(ui_output) = loader.render_ui() else {
             return;
         };
@@ -947,12 +1208,11 @@ impl ThothApp {
             tab_manager.open_new_tab(nav_capacity)
         };
         if let Some(t) = tab_manager.tabs.get_mut(&tab_id) {
-            t.active_plugin_pane = Some(crate::state::ActivePluginPane {
-                plugin_id: plugin_id.to_string(),
-                display_url: String::new(),
-                ui_output,
+            t.active_plugin_pane = Some(Self::make_plugin_pane(
+                plugin_id.to_string(),
                 loader,
-            });
+                ui_output,
+            ));
             t.plugin_sidebar_output = sidebar_output;
         }
     }
@@ -970,11 +1230,12 @@ impl ThothApp {
         };
         let plugin_ids = std::mem::take(&mut self.pending_plugin_restores);
         if let Some(manager) = manager_opt.as_ref() {
-            for plugin_id in &plugin_ids {
+            for (plugin_id, state) in &plugin_ids {
                 Self::open_plugin_tab(
                     &mut self.window_state.tab_manager,
                     manager,
                     plugin_id,
+                    state.as_deref(),
                     &self.settings,
                 );
             }
@@ -1018,6 +1279,7 @@ impl ThothApp {
                         tab.active_plugin_pane.as_ref().map(|pane| PersistedTab {
                             kind: PersistedTabKind::Plugin {
                                 plugin_id: pane.plugin_id.clone(),
+                                state: pane.loader.get_state().ok().flatten(),
                             },
                         })
                     });
@@ -1225,8 +1487,8 @@ impl ThothApp {
                     tab.error = None;
                 }
             }
-            TabEvent::PluginUiEvent { event, .. } => {
-                self.dispatch_plugin_event(event);
+            TabEvent::PluginUiEvent { tab_id, event } => {
+                self.dispatch_plugin_event_for(tab_id, event);
             }
             TabEvent::NavigationPush { tab_id, path } => {
                 if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
@@ -1274,20 +1536,30 @@ impl ThothApp {
             .map(|m| m.get_data_source_plugins())
             .unwrap_or_default();
 
+        let ui_plugins: Vec<&crate::plugin::Plugin> = PLUGIN_MANAGER
+            .get()
+            .and_then(|m| m.as_ref())
+            .map(|m| m.get_ui_component_plugins())
+            .unwrap_or_default();
+
         // Snapshot per-tab data we need for SidebarProps (avoids complex lifetime issues).
-        let (current_file_path, search_state_clone, active_datasource_plugin_id) =
+        let (current_file_path, search_state_clone) =
             if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
                 (
                     tab.file_path.clone(),
                     tab.search_engine_state.search.clone(),
-                    tab.active_plugin_pane.as_ref().map(|p| p.plugin_id.clone()),
                 )
             } else {
-                (None, crate::search::Search::default(), None)
+                (None, crate::search::Search::default())
             };
 
+        // The mounted plugin sidebar (independent of any tab) drives the sidebar
+        // panel and the icon-highlight state.
+        let sidebar_plugin_id: Option<String> =
+            self.sidebar_plugin.as_ref().map(|s| s.plugin_id.clone());
+
         let plugin_sidebar_strings: Option<(String, String, Option<String>)> =
-            active_datasource_plugin_id.as_ref().and_then(|plugin_id| {
+            sidebar_plugin_id.as_ref().and_then(|plugin_id| {
                 PLUGIN_MANAGER
                     .get()
                     .and_then(|m| m.as_ref())
@@ -1295,11 +1567,7 @@ impl ThothApp {
                     .map(|p| (p.id.clone(), p.name.clone(), p.icon.clone()))
             });
 
-        let plugin_sidebar_output = self
-            .window_state
-            .tab_manager
-            .active_tab_mut()
-            .and_then(|tab| tab.plugin_sidebar_output.clone());
+        let plugin_sidebar_output = self.sidebar_plugin.as_ref().and_then(|s| s.output.clone());
 
         let plugin_sidebar_prop: Option<components::sidebar::PluginSidebarInfo<'_>> =
             match (&plugin_sidebar_strings, &plugin_sidebar_output) {
@@ -1334,7 +1602,8 @@ impl ThothApp {
                 search_state: &search_state_clone,
                 search_history: search_history.as_ref(),
                 data_source_plugins: &ds_plugins,
-                active_datasource_plugin_id: active_datasource_plugin_id.as_deref(),
+                ui_component_plugins: &ui_plugins,
+                active_datasource_plugin_id: sidebar_plugin_id.as_deref(),
                 plugin_sidebar: plugin_sidebar_prop,
             },
         );
@@ -1375,99 +1644,32 @@ impl ThothApp {
                     if let components::sidebar::SidebarSection::DataSource { ref plugin_id } =
                         section
                     {
-                        let same_plugin_active = self
-                            .window_state
-                            .tab_manager
-                            .active_tab_mut()
-                            .is_some_and(|tab| {
-                                tab.active_plugin_pane
-                                    .as_ref()
-                                    .is_some_and(|p| &p.plugin_id == plugin_id)
-                            });
-
-                        if same_plugin_active {
-                            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                                tab.active_plugin_pane = None;
-                                tab.plugin_sidebar_output = None;
-                            }
+                        // Opening/closing a plugin's sidebar must NOT touch its tab.
+                        // Mount a tab-independent sidebar runtime and toggle only the
+                        // sidebar's visibility. Tabs are spawned from the sidebar's
+                        // own "New tab" control (the ui-tabs open-tab import).
+                        let already_showing = self.window_state.sidebar_expanded
+                            && matches!(
+                                &self.window_state.sidebar_selected_section,
+                                Some(components::sidebar::SidebarSection::PluginSidebar { plugin_id: p })
+                                    if p == plugin_id
+                            );
+                        if already_showing {
                             self.window_state.sidebar_expanded = false;
                             self.window_state.sidebar_selected_section = None;
-                            self.session_dirty = true;
                         } else {
-                            if let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref())
-                                && let Some(plugin) = manager.registry.get_by_id(plugin_id)
-                            {
-                                use crate::plugin::network_policy::NetworkPolicy;
-                                let user_policy = self
-                                    .settings
-                                    .plugins
-                                    .network_policies
-                                    .get(plugin_id)
-                                    .cloned()
-                                    .unwrap_or_default();
-                                let policy = NetworkPolicy::from_plugin_and_settings(
-                                    &plugin.network.clone().unwrap_or_default(),
-                                    &user_policy,
-                                );
-                                match manager.open_data_source(plugin_id, policy) {
-                                    Ok(loader) => match loader.render_ui() {
-                                        Ok(ui_output) => {
-                                            let sidebar_output =
-                                                loader.render_sidebar().ok().flatten();
-                                            let has_sidebar = sidebar_output.is_some();
-                                            if let Some(tab) =
-                                                self.window_state.tab_manager.active_tab_mut()
-                                            {
-                                                tab.file_path = None;
-                                                tab.plugin_sidebar_output = sidebar_output;
-                                                tab.active_plugin_pane =
-                                                    Some(crate::state::ActivePluginPane {
-                                                        plugin_id: plugin_id.clone(),
-                                                        display_url: String::new(),
-                                                        ui_output,
-                                                        loader,
-                                                    });
-                                                self.session_dirty = true;
-                                            }
-                                            if has_sidebar {
-                                                self.window_state.sidebar_expanded = true;
-                                                self.window_state.sidebar_selected_section =
-                                                        Some(components::sidebar::SidebarSection::PluginSidebar {
-                                                            plugin_id: plugin_id.clone(),
-                                                        });
-                                            } else {
-                                                self.window_state.sidebar_expanded = false;
-                                                self.window_state.sidebar_selected_section = None;
-                                            }
-                                        }
-                                        Err(e) => {
-                                            if let Some(tab) =
-                                                self.window_state.tab_manager.active_tab_mut()
-                                            {
-                                                tab.error =
-                                                    Some(crate::error::ThothError::Unknown {
-                                                        message: format!("Plugin UI error: {e}"),
-                                                    });
-                                            }
-                                        }
-                                    },
-                                    Err(e) => {
-                                        if let Some(tab) =
-                                            self.window_state.tab_manager.active_tab_mut()
-                                        {
-                                            tab.error = Some(crate::error::ThothError::Unknown {
-                                                message: format!("Failed to load plugin: {e}"),
-                                            });
-                                        }
-                                    }
-                                }
+                            self.ensure_sidebar_plugin(plugin_id);
+                            if self.sidebar_plugin.is_some() {
+                                self.window_state.sidebar_expanded = true;
+                                self.window_state.sidebar_selected_section =
+                                    Some(components::sidebar::SidebarSection::PluginSidebar {
+                                        plugin_id: plugin_id.clone(),
+                                    });
                             }
                         }
                     } else {
-                        let is_plugin_sidebar = matches!(
-                            section,
-                            components::sidebar::SidebarSection::PluginSidebar { .. }
-                        );
+                        // Non-plugin sections: pure sidebar visibility toggle —
+                        // never disturb open plugin tabs.
                         if self.window_state.sidebar_expanded
                             && self.window_state.sidebar_selected_section == Some(section.clone())
                         {
@@ -1479,12 +1681,6 @@ impl ThothApp {
                                 self.window_state.sidebar_selected_section.clone();
                             self.window_state.sidebar_expanded = true;
                             self.window_state.sidebar_selected_section = Some(section);
-                            if !is_plugin_sidebar
-                                && let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                            {
-                                tab.active_plugin_pane = None;
-                                tab.plugin_sidebar_output = None;
-                            }
                         }
                     }
 
@@ -1493,6 +1689,9 @@ impl ThothApp {
                             .set_sidebar_expanded(self.window_state.sidebar_expanded);
                         let _ = self.persistent_state.save();
                     }
+                }
+                components::sidebar::SidebarEvent::OpenUiComponentTab(plugin_id) => {
+                    self.open_ui_component_tab(&plugin_id, None);
                 }
                 components::sidebar::SidebarEvent::WidthChanged(new_width) => {
                     self.persistent_state.set_sidebar_width(new_width);
@@ -1591,7 +1790,7 @@ impl ThothApp {
                     }
                 }
                 components::sidebar::SidebarEvent::PluginSidebarEvent(evt) => {
-                    self.dispatch_plugin_event(evt);
+                    self.dispatch_sidebar_event(evt);
                 }
                 components::sidebar::SidebarEvent::OpenSettings => {
                     self.settings_dialog.open(&self.settings);

--- a/src/components/central_panel.rs
+++ b/src/components/central_panel.rs
@@ -153,63 +153,76 @@ impl CentralPanel {
             }
         }
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
-            // Show any error (either from props or open attempt)
-            if let Some(err) = props.error.as_ref().or(self.last_open_err.as_ref()) {
-                let message = ErrorHandler::get_user_message(err);
-                ui.colored_label(egui::Color32::RED, message);
-                ui.separator();
-            }
-
-            if self.searching {
-                ui.horizontal(|ui| {
-                    ui.add(egui::Spinner::new().size(16.0));
-                    ui.label("Searching…");
-                });
-                ui.add_space(6.0);
-                return;
-            }
-
-            // Plugin pane takes priority over the file viewer.
-            if let Some(output) = props.plugin_ui {
-                match serde_json::from_str::<UiNode>(&output.node_json) {
-                    Ok(node) => {
-                        let mut ui_events = Vec::new();
-                        render_ui_node(ui, &node, &mut ui_events);
-                        for evt in ui_events {
-                            events.push(CentralPanelEvent::PluginUiEvent(evt));
-                        }
-                    }
-                    Err(e) => {
-                        ui.colored_label(egui::Color32::RED, format!("Plugin UI parse error: {e}"));
-                    }
+        // Plugin panes manage their own padding, so drop the central-panel inner
+        // margin for them — but keep the panel *fill* (the dock tab viewer's
+        // clear_background is false, so this frame provides the background).
+        let panel_frame = if props.plugin_ui.is_some() {
+            egui::Frame::central_panel(ui.style()).inner_margin(0)
+        } else {
+            egui::Frame::central_panel(ui.style())
+        };
+        egui::CentralPanel::default()
+            .frame(panel_frame)
+            .show_inside(ui, |ui| {
+                // Show any error (either from props or open attempt)
+                if let Some(err) = props.error.as_ref().or(self.last_open_err.as_ref()) {
+                    let message = ErrorHandler::get_user_message(err);
+                    ui.colored_label(egui::Color32::RED, message);
+                    ui.separator();
                 }
-                return;
-            }
 
-            if self.loaded_path.is_none() {
-                use crate::components::welcome::{WelcomeEvent, WelcomePanel};
-                let welcome_events = WelcomePanel::render(ui, props.recent_files, props.colors);
-                for evt in welcome_events {
-                    match evt {
-                        WelcomeEvent::OpenFilePicker => {
-                            events.push(CentralPanelEvent::OpenFilePicker)
+                if self.searching {
+                    ui.horizontal(|ui| {
+                        ui.add(egui::Spinner::new().size(16.0));
+                        ui.label("Searching…");
+                    });
+                    ui.add_space(6.0);
+                    return;
+                }
+
+                // Plugin pane takes priority over the file viewer.
+                if let Some(output) = props.plugin_ui {
+                    match serde_json::from_str::<UiNode>(&output.node_json) {
+                        Ok(node) => {
+                            let mut ui_events = Vec::new();
+                            render_ui_node(ui, &node, &mut ui_events);
+                            for evt in ui_events {
+                                events.push(CentralPanelEvent::PluginUiEvent(evt));
+                            }
                         }
-                        WelcomeEvent::OpenRecentFile(path) => {
-                            events.push(CentralPanelEvent::OpenRecentFile(path))
+                        Err(e) => {
+                            ui.colored_label(
+                                egui::Color32::RED,
+                                format!("Plugin UI parse error: {e}"),
+                            );
                         }
                     }
+                    return;
                 }
-                return;
-            }
 
-            // Update viewer settings right before rendering (so changes apply immediately)
-            self.file_viewer
-                .set_syntax_highlighting(props.syntax_highlighting);
+                if self.loaded_path.is_none() {
+                    use crate::components::welcome::{WelcomeEvent, WelcomePanel};
+                    let welcome_events = WelcomePanel::render(ui, props.recent_files, props.colors);
+                    for evt in welcome_events {
+                        match evt {
+                            WelcomeEvent::OpenFilePicker => {
+                                events.push(CentralPanelEvent::OpenFilePicker)
+                            }
+                            WelcomeEvent::OpenRecentFile(path) => {
+                                events.push(CentralPanelEvent::OpenRecentFile(path))
+                            }
+                        }
+                    }
+                    return;
+                }
 
-            // Render the viewer (no filtering UI needed - search results shown in sidebar)
-            self.file_viewer.ui(ui);
-        });
+                // Update viewer settings right before rendering (so changes apply immediately)
+                self.file_viewer
+                    .set_syntax_highlighting(props.syntax_highlighting);
+
+                // Render the viewer (no filtering UI needed - search results shown in sidebar)
+                self.file_viewer.ui(ui);
+            });
     }
 
     // ========================================================================

--- a/src/components/common/button.rs
+++ b/src/components/common/button.rs
@@ -57,6 +57,9 @@ pub struct ButtonProps {
     pub enabled: bool,
     #[serde(default)]
     pub icon: Option<String>,
+    /// Stretch the button to the full available width of its container.
+    #[serde(rename = "full-width", default)]
+    pub full_width: bool,
 }
 
 fn default_enabled() -> bool {
@@ -76,6 +79,7 @@ impl Default for ButtonProps {
             height: None,
             enabled: true,
             icon: None,
+            full_width: false,
         }
     }
 }
@@ -105,6 +109,12 @@ impl StatelessComponent for Button {
         let size = props.size.unwrap_or(default_font);
         let height = Some(props.height.unwrap_or(default_h));
         let icon = props.icon.as_deref();
+        // Full-width buttons stretch to the container's available width.
+        let width = if props.full_width {
+            Some(ui.available_width())
+        } else {
+            props.width
+        };
 
         let bg_color = match props.color {
             ButtonColor::Default => colors.surface_active,
@@ -122,7 +132,7 @@ impl StatelessComponent for Button {
                         ui,
                         Self::make_layout_job(icon, &props.label, size, text_color),
                         bg_color,
-                        props.width,
+                        width,
                         height,
                     )
                 }
@@ -133,7 +143,7 @@ impl StatelessComponent for Button {
                     size,
                     bg_color,
                     colors.fg,
-                    props.width,
+                    width,
                     height,
                 ),
             })

--- a/src/components/common/button.rs
+++ b/src/components/common/button.rs
@@ -24,6 +24,18 @@ pub enum ButtonSize {
     Large,
 }
 
+impl ButtonSize {
+    /// `(font_size, height)` in logical pixels — the single source of truth so
+    /// other controls (e.g. IconButton) can size to match a button.
+    pub fn metrics(self) -> (f32, f32) {
+        match self {
+            ButtonSize::Small => (11.0, 24.0),
+            ButtonSize::Medium => (13.0, 28.0),
+            ButtonSize::Large => (15.0, 32.0),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 pub enum ButtonColor {
     #[default]
@@ -101,11 +113,7 @@ impl StatelessComponent for Button {
                 .unwrap_or_else(|| Theme::default().colors())
         });
 
-        let (default_font, default_h) = match props.button_size {
-            ButtonSize::Small => (11.0_f32, 24.0_f32),
-            ButtonSize::Medium => (13.0_f32, 28.0_f32),
-            ButtonSize::Large => (15.0_f32, 32.0_f32),
-        };
+        let (default_font, default_h) = props.button_size.metrics();
         let size = props.size.unwrap_or(default_font);
         let height = Some(props.height.unwrap_or(default_h));
         let icon = props.icon.as_deref();

--- a/src/components/common/select.rs
+++ b/src/components/common/select.rs
@@ -24,6 +24,8 @@ pub struct SelectProps<'a> {
     /// Optional static prefix shown before the selected label, e.g. `"Sort: "`.
     pub prefix_label: Option<&'a str>,
     pub size: SelectSize,
+    /// Fixed trigger width. When `None`, the trigger fills the available width.
+    pub width: Option<f32>,
 }
 
 pub struct SelectOutput {
@@ -64,9 +66,9 @@ impl StatelessComponent for Select {
         };
 
         // ── Trigger ───────────────────────────────────────────────────────────
-        let avail_w = ui.available_width();
+        let trigger_w = props.width.unwrap_or_else(|| ui.available_width());
         let (trigger_rect, trigger_resp) =
-            ui.allocate_exact_size(egui::vec2(avail_w, trigger_h), egui::Sense::click());
+            ui.allocate_exact_size(egui::vec2(trigger_w, trigger_h), egui::Sense::click());
 
         if ui.is_rect_visible(trigger_rect) {
             let bg = if is_open || trigger_resp.hovered() {

--- a/src/components/common/tabs.rs
+++ b/src/components/common/tabs.rs
@@ -105,9 +105,12 @@ impl StatelessComponent for Tabs {
                     }
 
                     // Right-aligned action icons (e.g. export) on the tab line.
+                    // The layout is right-to-left to pin actions to the right edge,
+                    // so iterate in reverse to keep their visual order matching
+                    // `props.actions` (first entry leftmost).
                     if !props.actions.is_empty() {
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            for action in props.actions {
+                            for action in props.actions.iter().rev() {
                                 if IconButton::render(
                                     ui,
                                     IconButtonProps {

--- a/src/components/common/tabs.rs
+++ b/src/components/common/tabs.rs
@@ -1,6 +1,7 @@
 use eframe::egui;
 
 use crate::components::button::{Button, ButtonColor, ButtonProps, ButtonSize, ButtonType};
+use crate::components::icon_button::{IconButton, IconButtonProps};
 use crate::components::traits::StatelessComponent;
 use crate::theme::ThemeColors;
 
@@ -9,15 +10,26 @@ pub struct TabItem<'a> {
     pub label: &'a str,
 }
 
+/// A right-aligned icon action shown on the tab-header line (e.g. an export button).
+pub struct TabAction<'a> {
+    pub id: &'a str,
+    pub icon: &'a str,
+    pub tooltip: Option<&'a str>,
+}
+
 pub struct TabProps<'a> {
     pub id: egui::Id,
     pub items: &'a [TabItem<'a>],
     pub active: &'a str,
+    /// Icon buttons rendered right-aligned on the same line as the tabs.
+    pub actions: &'a [TabAction<'a>],
 }
 
 pub struct TabOutput {
     /// The `value` of the tab the user clicked, if any.
     pub selected: Option<String>,
+    /// The `id` of the action icon the user clicked, if any.
+    pub clicked_action: Option<String>,
 }
 
 pub struct Tabs;
@@ -34,6 +46,7 @@ impl StatelessComponent for Tabs {
         });
 
         let mut selected: Option<String> = None;
+        let mut clicked_action: Option<String> = None;
 
         egui::Frame::new()
             .fill(colors.bg_panel)
@@ -90,9 +103,33 @@ impl StatelessComponent for Tabs {
                             selected = Some(item.value.to_string());
                         }
                     }
+
+                    // Right-aligned action icons (e.g. export) on the tab line.
+                    if !props.actions.is_empty() {
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            for action in props.actions {
+                                if IconButton::render(
+                                    ui,
+                                    IconButtonProps {
+                                        icon: action.icon,
+                                        tooltip: action.tooltip,
+                                        frame: false,
+                                        ..Default::default()
+                                    },
+                                )
+                                .clicked
+                                {
+                                    clicked_action = Some(action.id.to_string());
+                                }
+                            }
+                        });
+                    }
                 });
             });
 
-        TabOutput { selected }
+        TabOutput {
+            selected,
+            clicked_action,
+        }
     }
 }

--- a/src/components/file_viewer/json_tree_viewer.rs
+++ b/src/components/file_viewer/json_tree_viewer.rs
@@ -316,8 +316,14 @@ impl JsonTreeViewer {
                     let is_expandable = matches!(val, Value::Object(_) | Value::Array(_));
                     let is_expanded = is_expandable && self.expanded.contains(&new_path);
 
+                    // Bracket reflects the VALUE's type, not the container's.
+                    let (open, empty) = if matches!(val, Value::Array(_)) {
+                        ("[", "[]")
+                    } else {
+                        ("{", "{}")
+                    };
                     let display_text = if is_expandable {
-                        format!("\"{}\": {}", key, if is_expanded { "{" } else { "{}" })
+                        format!("\"{}\": {}", key, if is_expanded { open } else { empty })
                     } else {
                         format_simple_kv(key, val)
                     };
@@ -350,7 +356,12 @@ impl JsonTreeViewer {
                             indent,
                             is_expandable: false,
                             is_expanded: false,
-                            display_text: "}".to_string(),
+                            display_text: if matches!(val, Value::Array(_)) {
+                                "]"
+                            } else {
+                                "}"
+                            }
+                            .to_string(),
                             text_token: (TextToken::Bracket, None),
                             highlights: RowHighlights::default(),
                         });
@@ -363,8 +374,14 @@ impl JsonTreeViewer {
                     let is_expandable = matches!(val, Value::Object(_) | Value::Array(_));
                     let is_expanded = is_expandable && self.expanded.contains(&new_path);
 
+                    // Bracket reflects the VALUE's type, not the container's.
+                    let (open, empty) = if matches!(val, Value::Array(_)) {
+                        ("[", "[]")
+                    } else {
+                        ("{", "{}")
+                    };
                     let display_text = if is_expandable {
-                        format!("[{}]: {}", idx, if is_expanded { "[" } else { "[]" })
+                        format!("[{}]: {}", idx, if is_expanded { open } else { empty })
                     } else {
                         format!("[{}]: {}", idx, preview_value(val))
                     };
@@ -394,7 +411,12 @@ impl JsonTreeViewer {
                             indent,
                             is_expandable: false,
                             is_expanded: false,
-                            display_text: "]".to_string(),
+                            display_text: if matches!(val, Value::Array(_)) {
+                                "]"
+                            } else {
+                                "}"
+                            }
+                            .to_string(),
                             text_token: (TextToken::Bracket, None),
                             highlights: RowHighlights::default(),
                         });

--- a/src/components/marketplace/list.rs
+++ b/src/components/marketplace/list.rs
@@ -20,7 +20,7 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
         .inner_margin(egui::Margin::symmetric(0, 10))
         .show(ui, |ui| {
             ui.horizontal(|ui| {
-                Typography::bold(ui, "Plugin Store");
+                Typography::panel_header(ui, "PLUGIN STORE");
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     ui.label(
                         egui::RichText::new(format!("{visible_count} of {total}"))

--- a/src/components/marketplace/list.rs
+++ b/src/components/marketplace/list.rs
@@ -91,6 +91,7 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                             options: &sort_opts,
                             prefix_label: Some("Sort: "),
                             size: SelectSize::Small,
+                            width: None,
                         },
                     )
                 });

--- a/src/components/settings_dialog/general.rs
+++ b/src/components/settings_dialog/general.rs
@@ -129,6 +129,7 @@ impl StatelessComponent for GeneralTab {
                                     options: &font_opts,
                                     prefix_label: None,
                                     size: Default::default(),
+                                    width: None,
                                 },
                             );
                             if let Some(new_val) = font_out.changed {

--- a/src/components/sidebar.rs
+++ b/src/components/sidebar.rs
@@ -48,6 +48,9 @@ pub struct SidebarProps<'a> {
     pub search_history: Option<&'a Vec<String>>,
     /// All registered data-source plugins — one icon button is shown per plugin.
     pub data_source_plugins: &'a [&'a Plugin],
+    /// Pure ui-component plugins (new-ui-component, not data sources) — one icon
+    /// button each; clicking opens the plugin in a new tab.
+    pub ui_component_plugins: &'a [&'a Plugin],
     /// The plugin_id of the currently active data-source pane (for icon highlight).
     pub active_datasource_plugin_id: Option<&'a str>,
     /// If the active ui-component plugin rendered a sidebar, its (plugin, output) pair.
@@ -68,6 +71,8 @@ pub enum SidebarEvent {
     RemoveRecentFile(String),
     OpenFilePicker,
     SectionToggled(SidebarSection),
+    /// Open a pure ui-component plugin (by id) in a new tab.
+    OpenUiComponentTab(String),
     WidthChanged(f32),
     // Search events
     Search(SearchMessage),
@@ -349,6 +354,31 @@ impl Sidebar {
                     .clicked
                     {
                         events.push(SidebarEvent::SectionToggled(section));
+                    }
+                }
+
+                // Pure ui-component plugins — clicking opens the plugin in a new tab.
+                for plugin in props.ui_component_plugins {
+                    let icon = plugin
+                        .icon
+                        .as_deref()
+                        .unwrap_or(egui_phosphor::regular::PUZZLE_PIECE);
+                    if IconButton::render(
+                        ui,
+                        IconButtonProps {
+                            icon,
+                            tooltip: Some(plugin.name.as_str()),
+                            size: Some(button_size),
+                            icon_size: Some(20.0),
+                            selected: false,
+                            frame: false,
+                            badge_color: None,
+                            disabled: false,
+                        },
+                    )
+                    .clicked
+                    {
+                        events.push(SidebarEvent::OpenUiComponentTab(plugin.id.clone()));
                     }
                 }
             });

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -243,6 +243,11 @@ impl PluginManager {
             .ok_or_else(|| ThothError::Unknown {
                 message: format!("Plugin '{plugin_id}' not found"),
             })?;
+        if !plugin.capabilities.contains(&Capability::NewUIComponent) {
+            return Err(ThothError::Unknown {
+                message: format!("Plugin '{plugin_id}' does not provide a ui-component"),
+            });
+        }
         let wasm_path = plugin
             .location
             .as_deref()

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -230,6 +230,51 @@ impl PluginManager {
         )
     }
 
+    /// Instantiate a pure `ui-component` plugin (the `ui-component-plugin` world).
+    /// Unlike `open_data_source` there is no network policy — these plugins have
+    /// no http-client import.
+    pub fn open_ui_component(
+        &self,
+        plugin_id: &str,
+    ) -> Result<crate::plugin::wasm_ui_component::WasmUiComponentLoader> {
+        let plugin = self
+            .registry
+            .get_by_id(plugin_id)
+            .ok_or_else(|| ThothError::Unknown {
+                message: format!("Plugin '{plugin_id}' not found"),
+            })?;
+        let wasm_path = plugin
+            .location
+            .as_deref()
+            .map(std::path::Path::new)
+            .ok_or_else(|| ThothError::Unknown {
+                message: "Plugin has no wasm path".into(),
+            })?;
+        let settings = {
+            let guard = self
+                .plugin_settings
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
+            guard.get(plugin_id).cloned().unwrap_or_default()
+        };
+        crate::plugin::wasm_ui_component::WasmUiComponentLoader::open(
+            &self.engine,
+            wasm_path,
+            plugin_id.to_string(),
+            &settings,
+        )
+    }
+
+    /// All plugins that declare the `new-ui-component` capability but are NOT
+    /// data sources (those are listed separately in the sidebar).
+    pub fn get_ui_component_plugins(&self) -> Vec<&Plugin> {
+        self.registry
+            .get_by_capability(Capability::NewUIComponent)
+            .into_iter()
+            .filter(|p| !p.capabilities.contains(&Capability::DataSource))
+            .collect()
+    }
+
     pub fn open_plugin_settings(&self, plugin_id: &str) -> Result<WasmPluginSettings> {
         let plugin = self
             .registry

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -7,12 +7,14 @@ pub mod manager;
 pub mod marketplace;
 pub mod network_policy;
 pub mod plugin_registry;
+pub mod plugin_ui_host;
 pub mod render_node;
 pub mod theme_plugin;
 pub mod wasm_data_source;
 pub mod wasm_file_viewer_loader;
 pub mod wasm_loader;
 pub mod wasm_plugin_settings;
+pub mod wasm_ui_component;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct NetworkDeclarations {

--- a/src/plugin/plugin_ui_host.rs
+++ b/src/plugin/plugin_ui_host.rs
@@ -8,8 +8,10 @@
 //! can drive both uniformly.
 //!
 //! The tab-state / lifecycle methods (`tab_title`, `get_state`, `on_tab_*`, …) map to
-//! the optional `tab-host` WIT export. Loaders whose world does not export it (e.g. the
-//! current data-source world) inherit the no-op defaults here.
+//! the `tab-host` WIT export, which both the `ui-component-plugin` and
+//! `data-source-plugin` worlds export. The trait provides no-op defaults so any
+//! future loader whose world omits `tab-host` still compiles; the two current
+//! loaders override them to call the export.
 
 use crate::error::Result;
 use crate::plugin::render_node::{UiEvent, UiOutput};
@@ -38,6 +40,12 @@ pub struct PluginHttpRequest {
     pub body: Option<Vec<u8>>,
 }
 
+/// Upper bound on a plugin-supplied tab title (chars beyond this are dropped).
+pub const MAX_TAB_TITLE_LEN: usize = 200;
+/// Upper bound on a plugin-supplied seed-state blob; oversized blobs are dropped
+/// (not truncated, which would corrupt the JSON).
+pub const MAX_TAB_STATE_LEN: usize = 1 << 20; // 1 MiB
+
 /// A plugin's request (via the `ui-tabs` host import) to open a new dock tab
 /// hosting a fresh instance of itself.
 #[derive(Clone, Debug)]
@@ -50,6 +58,35 @@ pub struct TabOpenRequest {
     pub icon: Option<String>,
     /// JSON blob to seed the new instance with via `init-with-state`.
     pub initial_state: Option<String>,
+}
+
+impl TabOpenRequest {
+    /// Build a request with bounded title/state so a plugin can't push arbitrarily
+    /// large payloads through the `open-tab` import.
+    pub fn sanitized(
+        request_id: String,
+        plugin_id: String,
+        mut title: String,
+        icon: Option<String>,
+        initial_state: Option<String>,
+    ) -> Self {
+        if title.len() > MAX_TAB_TITLE_LEN {
+            let mut end = MAX_TAB_TITLE_LEN;
+            while end > 0 && !title.is_char_boundary(end) {
+                end -= 1;
+            }
+            title.truncate(end);
+        }
+        // Truncating a JSON blob would corrupt it, so drop it when oversized.
+        let initial_state = initial_state.filter(|s| s.len() <= MAX_TAB_STATE_LEN);
+        Self {
+            request_id,
+            plugin_id,
+            title,
+            icon,
+            initial_state,
+        }
+    }
 }
 
 /// Common interface for plugin loaders rendered inside a dock tab.

--- a/src/plugin/plugin_ui_host.rs
+++ b/src/plugin/plugin_ui_host.rs
@@ -1,0 +1,108 @@
+//! Shared abstraction over plugin loaders that render an interactive UI inside a
+//! dock tab.
+//!
+//! Both [`WasmDataSourceLoader`](crate::plugin::wasm_data_source::WasmDataSourceLoader)
+//! and [`WasmUiComponentLoader`](crate::plugin::wasm_ui_component::WasmUiComponentLoader)
+//! implement [`PluginUiHost`], so an [`ActivePluginPane`](crate::state::ActivePluginPane)
+//! can hold either behind a `Box<dyn PluginUiHost>` and the app's poll/dispatch loop
+//! can drive both uniformly.
+//!
+//! The tab-state / lifecycle methods (`tab_title`, `get_state`, `on_tab_*`, …) map to
+//! the optional `tab-host` WIT export. Loaders whose world does not export it (e.g. the
+//! current data-source world) inherit the no-op defaults here.
+
+use crate::error::Result;
+use crate::plugin::render_node::{UiEvent, UiOutput};
+use crate::settings::PluginSettingData;
+
+/// Raw HTTP response — plain Send-safe types, no WIT bindgen involvement.
+pub struct HttpResponseRaw {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+    pub duration_ms: u64,
+}
+
+/// Result type for async HTTP. Uses `std::result::Result` explicitly to avoid
+/// clashing with the crate-level `Result<T> = Result<T, ThothError>` alias.
+pub type HttpCallResult = std::result::Result<HttpResponseRaw, String>;
+
+/// A loader-agnostic HTTP request, so the trait does not depend on a concrete
+/// loader's bindgen-generated `HttpRequest` type. Loaders convert to/from their
+/// own WIT type at the boundary.
+#[derive(Clone)]
+pub struct PluginHttpRequest {
+    pub url: String,
+    pub method: String,
+    pub headers: Vec<(String, String)>,
+    pub body: Option<Vec<u8>>,
+}
+
+/// A plugin's request (via the `ui-tabs` host import) to open a new dock tab
+/// hosting a fresh instance of itself.
+#[derive(Clone, Debug)]
+pub struct TabOpenRequest {
+    /// Host-assigned id returned to the plugin from `open-tab`.
+    pub request_id: String,
+    /// The plugin that asked to open the tab — the new tab hosts the same plugin.
+    pub plugin_id: String,
+    pub title: String,
+    pub icon: Option<String>,
+    /// JSON blob to seed the new instance with via `init-with-state`.
+    pub initial_state: Option<String>,
+}
+
+/// Common interface for plugin loaders rendered inside a dock tab.
+pub trait PluginUiHost: Send {
+    fn plugin_id(&self) -> &str;
+
+    fn render_ui(&self) -> Result<UiOutput>;
+    fn handle_event(&self, event: UiEvent) -> Result<UiOutput>;
+    fn render_sidebar(&self) -> Result<Option<UiOutput>>;
+
+    /// Notify the plugin that its user-configured settings changed.
+    fn on_setting_change(&self, settings: &[PluginSettingData]) -> Result<()> {
+        let _ = settings;
+        Ok(())
+    }
+
+    // ── tab integration (tab-host export; defaults for loaders without it) ──────
+
+    /// Plugin-provided tab title. `None` → caller falls back to the plugin id.
+    fn tab_title(&self) -> Option<String> {
+        None
+    }
+    /// Plugin-provided Phosphor glyph for the tab label.
+    fn tab_icon(&self) -> Option<String> {
+        None
+    }
+    /// Serialize per-tab state for persistence. `None` when unsupported.
+    fn get_state(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
+    /// Restore per-tab state from a previously saved blob.
+    fn init_with_state(&self, _state: &str) -> Result<()> {
+        Ok(())
+    }
+    fn on_tab_focused(&self) {}
+    fn on_tab_blurred(&self) {}
+    fn on_tab_closed(&self) {}
+
+    /// Drain tab-open requests the plugin raised via the `ui-tabs` import.
+    fn drain_tab_open_requests(&self) -> Vec<TabOpenRequest> {
+        Vec::new()
+    }
+
+    // ── async HTTP (only data-source implements; defaults are no-ops) ───────────
+
+    fn drain_http_results(&self) -> Vec<(String, HttpCallResult)> {
+        Vec::new()
+    }
+    fn drain_retry_requests(&self) -> Vec<(String, PluginHttpRequest)> {
+        Vec::new()
+    }
+    fn dispatch_approved_request(&self, _request_id: String, _req: PluginHttpRequest) {}
+    fn has_pending_http(&self) -> bool {
+        false
+    }
+}

--- a/src/plugin/render_node.rs
+++ b/src/plugin/render_node.rs
@@ -325,6 +325,9 @@ pub enum UiNode {
         options: Vec<SelectOption>,
         #[serde(default)]
         disabled: bool,
+        /// Fixed trigger width in logical pixels. Omit to fill available width.
+        #[serde(default)]
+        width: Option<f32>,
     },
     MultiSelect {
         id: String,
@@ -1122,6 +1125,7 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
             value,
             options,
             disabled,
+            width,
         } => {
             let buf_id = egui::Id::new(("ui:sel", id));
             let mut buf = ui.ctx().data_mut(|d| {
@@ -1147,6 +1151,7 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                         options: &common_opts,
                         prefix_label: None,
                         size: Default::default(),
+                        width: *width,
                     },
                 );
                 if let Some(new_val) = out.changed {

--- a/src/plugin/render_node.rs
+++ b/src/plugin/render_node.rs
@@ -2,13 +2,13 @@ use eframe::egui::{self, Frame};
 use egui_code_editor::CodeEditor;
 use serde::{Deserialize, Serialize};
 
-use crate::components::button::{Button, ButtonProps, ButtonType};
+use crate::components::button::{Button, ButtonProps, ButtonSize, ButtonType};
 use crate::components::common::button_group::{ButtonGroup, ButtonGroupItem, ButtonGroupProps};
 use crate::components::common::input::{Input, InputProps};
 use crate::components::common::json_tree::{JsonTree, JsonTreeProps};
 use crate::components::common::list::{List, ListItem, ListProps};
 use crate::components::common::select::{Select, SelectOption as CommonSelectOption, SelectProps};
-use crate::components::common::tabs::{TabItem, TabProps, Tabs};
+use crate::components::common::tabs::{TabAction, TabItem, TabProps, Tabs};
 use crate::components::icon_button::{IconButton, IconButtonProps};
 use crate::components::table_view::{TableCell, TableView, TableViewProps};
 use crate::components::traits::StatelessComponent;
@@ -31,11 +31,25 @@ pub struct SelectOption {
     pub label: String,
 }
 
+/// A right-aligned icon action shown on a tabs node's header line.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabActionDef {
+    pub id: String,
+    pub icon: String,
+    #[serde(default)]
+    pub tooltip: Option<String>,
+}
+
 /// A single key/value pair used by the key-value-list node.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct KvEntry {
     pub key: String,
     pub value: String,
+    /// Whether this row is active. Disabled rows are dimmed and the plugin is
+    /// expected to skip them (e.g. omit from the request). Defaults to true so
+    /// older payloads without the field remain enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
 }
 
 /// A single option in a button-group node.
@@ -195,6 +209,10 @@ pub enum UiNode {
         value: String,
         #[serde(default = "default_heading_level")]
         level: u8,
+        /// Render as a sidebar panel header (small, uppercase-style, muted) to
+        /// match the host's built-in sidebar sections instead of a large heading.
+        #[serde(default)]
+        panel: bool,
     },
     Badge {
         label: String,
@@ -406,6 +424,9 @@ pub enum UiNode {
         enabled: bool,
         #[serde(default = "default_true")]
         frame: bool,
+        /// Size the (square) button to match a button height, e.g. "medium".
+        #[serde(rename = "button-size", default)]
+        button_size: Option<ButtonSize>,
     },
     #[serde(rename = "code-editor")]
     CodeEditor {
@@ -416,6 +437,9 @@ pub enum UiNode {
         id: String,
         header: Vec<String>,
         children: Vec<UiNode>,
+        /// Right-aligned icon actions on the tab-header line.
+        #[serde(default)]
+        actions: Vec<TabActionDef>,
     },
     Spinner {
         #[serde(default)]
@@ -522,9 +546,12 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                         // 3. The grow child renders last inside the RTL layout and
                         //    calls available_width(), filling exactly the middle gap.
                         Align::Fill => {
-                            let grow_idx = children
-                                .iter()
-                                .position(|c| matches!(c, UiNode::TextInput { grow: true, .. }));
+                            // The grow child fills the middle: a TextInput with
+                            // grow:true, or a full-width Button.
+                            let grow_idx = children.iter().position(|c| {
+                                matches!(c, UiNode::TextInput { grow: true, .. })
+                                    || matches!(c, UiNode::Button { props, .. } if props.full_width)
+                            });
                             ui.spacing_mut().item_spacing.x = *gap;
                             if let Some(gi) = grow_idx {
                                 for child in &children[..gi] {
@@ -746,13 +773,22 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                 render_ui_node(ui, child, events);
             }
         }
-        UiNode::Heading { value, level } => {
-            let size = match level {
-                1 => 24.0_f32,
-                2 => 20.0,
-                _ => 16.0,
-            };
-            ui.label(egui::RichText::new(value).strong().size(size));
+        UiNode::Heading {
+            value,
+            level,
+            panel,
+        } => {
+            if *panel {
+                // Match the host's built-in sidebar section headers.
+                crate::components::common::typography::Typography::panel_header(ui, value);
+            } else {
+                let size = match level {
+                    1 => 24.0_f32,
+                    2 => 20.0,
+                    _ => 16.0,
+                };
+                ui.label(egui::RichText::new(value).strong().size(size));
+            }
         }
         UiNode::Badge { label, color } => {
             let c = parse_hex_color(color).unwrap_or(egui::Color32::GRAY);
@@ -1326,9 +1362,10 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
 
             let mut changed = false;
             let mut to_remove: Option<usize> = None;
+            let toggle_col_w = 22.0;
             let delete_col_w = 24.0;
             let available = ui.available_width();
-            let input_w = ((available - delete_col_w - 8.0) / 2.0).max(40.0);
+            let input_w = ((available - toggle_col_w - delete_col_w - 12.0) / 2.0).max(40.0);
 
             // ── Header row ────────────────────────────────────────────────
             // TextEdit has ~4px internal left padding; match it so header
@@ -1340,6 +1377,8 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                     ui.spacing_mut().item_spacing.x = 4.0;
                     let label_color = colors.fg_muted;
                     let font = egui::FontId::proportional(11.0);
+                    // Empty header cell above the enable/disable checkbox column.
+                    ui.allocate_exact_size(egui::vec2(toggle_col_w, 24.0), egui::Sense::hover());
                     ui.painter().text(
                         ui.cursor().min + egui::vec2(text_edit_pad, 8.0),
                         egui::Align2::LEFT_TOP,
@@ -1375,12 +1414,29 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                 ui.horizontal(|ui| {
                     ui.set_width(available);
                     ui.spacing_mut().item_spacing.x = 4.0;
+                    // Enable/disable toggle.
+                    if ui
+                        .add_sized(
+                            egui::vec2(toggle_col_w, 24.0),
+                            egui::Checkbox::without_text(&mut entry.enabled),
+                        )
+                        .changed()
+                    {
+                        changed = true;
+                    }
+                    // Dim key/value text when the row is disabled.
+                    let text_color = if entry.enabled {
+                        colors.fg
+                    } else {
+                        colors.fg_muted
+                    };
                     if ui
                         .add_sized(
                             egui::vec2(input_w, 24.0),
                             egui::TextEdit::singleline(&mut entry.key)
                                 .frame(Frame::NONE)
                                 .hint_text("key")
+                                .text_color(text_color)
                                 .background_color(egui::Color32::TRANSPARENT),
                         )
                         .changed()
@@ -1393,6 +1449,7 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                             egui::TextEdit::singleline(&mut entry.value)
                                 .frame(Frame::NONE)
                                 .hint_text("value")
+                                .text_color(text_color)
                                 .background_color(egui::Color32::TRANSPARENT),
                         )
                         .changed()
@@ -1449,6 +1506,7 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                     buf.push(KvEntry {
                         key: String::new(),
                         value: String::new(),
+                        enabled: true,
                     });
                     changed = true;
                 }
@@ -1486,7 +1544,13 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
             tooltip,
             enabled,
             frame,
+            button_size,
         } => {
+            // Size the (square) button to match a button height when requested.
+            let sized = button_size.map(|bs| {
+                let h = bs.metrics().1;
+                egui::vec2(h, h)
+            });
             let btn = IconButton::render(
                 ui,
                 IconButtonProps {
@@ -1495,6 +1559,7 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                     tooltip: Some(&tooltip.clone().unwrap_or_default()),
                     disabled: !*enabled,
                     selected: false,
+                    size: sized,
                     ..Default::default()
                 },
             );
@@ -1530,6 +1595,7 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
             id,
             header,
             children,
+            actions,
         } => {
             // Active tab index is persisted in egui memory keyed by id.
             let mem_id = egui::Id::new(("ui:tabs", id.as_str()));
@@ -1547,6 +1613,15 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                 })
                 .collect();
 
+            let tab_actions: Vec<TabAction<'_>> = actions
+                .iter()
+                .map(|a| TabAction {
+                    id: a.id.as_str(),
+                    icon: a.icon.as_str(),
+                    tooltip: a.tooltip.as_deref(),
+                })
+                .collect();
+
             let active_str = active_idx.to_string();
             let output = Tabs::render(
                 ui,
@@ -1554,6 +1629,7 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                     id: mem_id,
                     items: &tab_items,
                     active: &active_str,
+                    actions: &tab_actions,
                 },
             );
 
@@ -1566,6 +1642,11 @@ pub fn render_ui_node(ui: &mut egui::Ui, node: &UiNode, events: &mut Vec<UiEvent
                 if let Some(h) = header.get(active_idx) {
                     events.push(ui_event(id, "change", json_str(h)));
                 }
+            }
+
+            // A tab-line action icon (e.g. export) was clicked.
+            if let Some(action_id) = output.clicked_action {
+                events.push(ui_event(&action_id, "click", String::new()));
             }
 
             if let Some(child) = children.get(active_idx) {

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -47,17 +47,10 @@ pub struct ConsentRequest {
 
 // ── async HTTP result sent through the mpsc channel ──────────────────────────
 
-/// Raw HTTP response — plain Send-safe types, no WIT bindgen involvement.
-pub struct HttpResponseRaw {
-    pub status: u16,
-    pub headers: Vec<(String, String)>,
-    pub body: Vec<u8>,
-    pub duration_ms: u64,
-}
-
-/// Result type for async HTTP — uses std::result::Result explicitly to avoid
-/// conflicting with the crate-level `type Result<T> = Result<T, ThothError>` alias.
-pub type HttpCallResult = std::result::Result<HttpResponseRaw, String>;
+// These plain Send-safe types live in `plugin_ui_host` so they can be shared with
+// the `PluginUiHost` trait without depending on this loader's bindgen internals.
+pub use crate::plugin::plugin_ui_host::{HttpCallResult, HttpResponseRaw};
+use crate::plugin::plugin_ui_host::{PluginHttpRequest, PluginUiHost, TabOpenRequest};
 
 // ── atomic counter so callers can know when requests are in flight ────────────
 
@@ -66,6 +59,13 @@ static REQUEST_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::Atomic
 fn next_request_id() -> String {
     format!(
         "req-{}",
+        REQUEST_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    )
+}
+
+fn next_tab_request_id() -> String {
+    format!(
+        "tab-{}",
         REQUEST_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     )
 }
@@ -87,6 +87,8 @@ struct DataSourcePluginState {
     // re-dispatch them on a background thread without needing self to be Sync.
     retry_tx:
         Arc<Mutex<std::sync::mpsc::Sender<(String, thoth::plugin::http_client::HttpRequest)>>>,
+    // Tab-open requests raised by the plugin via the `ui-tabs` import.
+    tab_tx: std::sync::mpsc::Sender<TabOpenRequest>,
 }
 
 impl WasiView for DataSourcePluginState {
@@ -274,6 +276,25 @@ impl thoth::plugin::plugin_storage::Host for DataSourcePluginState {
     }
 }
 
+impl thoth::plugin::ui_tabs::Host for DataSourcePluginState {
+    fn open_tab(
+        &mut self,
+        title: String,
+        icon: Option<String>,
+        initial_state: Option<String>,
+    ) -> String {
+        let request_id = next_tab_request_id();
+        let _ = self.tab_tx.send(TabOpenRequest {
+            request_id: request_id.clone(),
+            plugin_id: self.plugin_id.clone(),
+            title,
+            icon,
+            initial_state,
+        });
+        request_id
+    }
+}
+
 // ── reqwest bridge ────────────────────────────────────────────────────────────
 
 fn execute_http_request(
@@ -330,6 +351,8 @@ pub struct WasmDataSourceLoader {
     retry_rx: std::sync::mpsc::Receiver<(String, thoth::plugin::http_client::HttpRequest)>,
     /// Number of submitted requests that haven't been drained yet.
     pending_count: Arc<AtomicUsize>,
+    /// Receives tab-open requests raised by the plugin via the `ui-tabs` import.
+    tab_rx: std::sync::mpsc::Receiver<TabOpenRequest>,
     plugin_id: String,
 }
 
@@ -353,6 +376,7 @@ impl WasmDataSourceLoader {
         let (http_tx, http_rx) = std::sync::mpsc::channel::<(String, HttpCallResult)>();
         let (retry_tx, retry_rx) =
             std::sync::mpsc::channel::<(String, thoth::plugin::http_client::HttpRequest)>();
+        let (tab_tx, tab_rx) = std::sync::mpsc::channel::<TabOpenRequest>();
         let pending_count = Arc::new(AtomicUsize::new(0));
         let retry_tx_shared = Arc::new(Mutex::new(retry_tx));
 
@@ -365,6 +389,7 @@ impl WasmDataSourceLoader {
             http_tx,
             pending_count: Arc::clone(&pending_count),
             retry_tx: Arc::clone(&retry_tx_shared),
+            tab_tx,
         };
 
         let mut store = Store::new(engine, state);
@@ -405,6 +430,14 @@ impl WasmDataSourceLoader {
             },
         )?;
 
+        // 4. Register the ui-tabs import (plugin-initiated tab opening).
+        thoth::plugin::ui_tabs::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s).map_err(
+            |e| ThothError::PluginLoadError {
+                path: wasm_path.to_path_buf(),
+                reason: e.to_string(),
+            },
+        )?;
+
         let bindings =
             DataSourcePlugin::instantiate(&mut store, &component, &linker).map_err(|e| {
                 ThothError::PluginLoadError {
@@ -419,6 +452,7 @@ impl WasmDataSourceLoader {
             http_rx,
             retry_rx,
             pending_count,
+            tab_rx,
             plugin_id,
         };
 
@@ -451,7 +485,7 @@ impl WasmDataSourceLoader {
 
     /// Invoke the plugin's on-setting-change lifecycle hook with the updated settings.
     /// Settings are serialized as a JSON array of `{key, value}` objects.
-    pub fn on_setting_change(&mut self, settings: &[PluginSettingData]) -> Result<()> {
+    pub fn on_setting_change(&self, settings: &[PluginSettingData]) -> Result<()> {
         let settings_json = serde_json::to_string(settings).map_err(|e| ThothError::Unknown {
             message: format!("Failed to serialize plugin settings: {e}"),
         })?;
@@ -674,7 +708,170 @@ impl WasmDataSourceLoader {
         self.pending_count.load(Ordering::Relaxed) > 0
     }
 
+    // ── tab-host export ─────────────────────────────────────────────────────────
+
+    pub fn tab_title(&self) -> Option<String> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmDataSourceInner { store, bindings } = &mut *guard;
+        refuel(store).ok()?;
+        bindings.thoth_plugin_tab_host().call_tab_title(store).ok()
+    }
+
+    pub fn tab_icon(&self) -> Option<String> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmDataSourceInner { store, bindings } = &mut *guard;
+        refuel(store).ok()?;
+        bindings
+            .thoth_plugin_tab_host()
+            .call_tab_icon(store)
+            .ok()
+            .flatten()
+    }
+
+    pub fn get_state(&self) -> Result<Option<String>> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmDataSourceInner { store, bindings } = &mut *guard;
+        refuel(store)?;
+        let blob = bindings
+            .thoth_plugin_tab_host()
+            .call_get_state(store)
+            .map_err(|e| ThothError::Unknown {
+                message: e.to_string(),
+            })?
+            .map_err(|e| ThothError::Unknown { message: e.message })?;
+        Ok(Some(blob))
+    }
+
+    pub fn init_with_state(&self, state: &str) -> Result<()> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmDataSourceInner { store, bindings } = &mut *guard;
+        refuel(store)?;
+        bindings
+            .thoth_plugin_tab_host()
+            .call_init_with_state(store, state)
+            .map_err(|e| ThothError::Unknown {
+                message: e.to_string(),
+            })?
+            .map_err(|e| ThothError::Unknown { message: e.message })
+    }
+
+    fn call_tab_lifecycle(&self, which: u8) {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmDataSourceInner { store, bindings } = &mut *guard;
+        if refuel(store).is_err() {
+            return;
+        }
+        let host = bindings.thoth_plugin_tab_host();
+        let _ = match which {
+            0 => host.call_on_tab_focused(store),
+            1 => host.call_on_tab_blurred(store),
+            _ => host.call_on_tab_closed(store),
+        };
+    }
+
+    /// Non-blocking drain of tab-open requests raised during the last WASM call.
+    pub fn drain_tab_open_requests(&self) -> Vec<TabOpenRequest> {
+        let mut out = Vec::new();
+        while let Ok(req) = self.tab_rx.try_recv() {
+            out.push(req);
+        }
+        out
+    }
+
     pub fn plugin_id(&self) -> &str {
         &self.plugin_id
+    }
+}
+
+// ── PluginUiHost — lets an ActivePluginPane hold this loader as a trait object ──
+
+fn http_req_to_plugin(r: thoth::plugin::http_client::HttpRequest) -> PluginHttpRequest {
+    PluginHttpRequest {
+        url: r.url,
+        method: r.method,
+        headers: r.headers,
+        body: r.body,
+    }
+}
+
+fn plugin_req_to_http(r: PluginHttpRequest) -> thoth::plugin::http_client::HttpRequest {
+    thoth::plugin::http_client::HttpRequest {
+        url: r.url,
+        method: r.method,
+        headers: r.headers,
+        body: r.body,
+    }
+}
+
+impl PluginUiHost for WasmDataSourceLoader {
+    fn plugin_id(&self) -> &str {
+        WasmDataSourceLoader::plugin_id(self)
+    }
+
+    fn render_ui(&self) -> Result<UiOutput> {
+        WasmDataSourceLoader::render_ui(self)
+    }
+
+    fn handle_event(&self, event: UiEvent) -> Result<UiOutput> {
+        WasmDataSourceLoader::handle_event(self, event)
+    }
+
+    fn render_sidebar(&self) -> Result<Option<UiOutput>> {
+        WasmDataSourceLoader::render_sidebar(self)
+    }
+
+    fn on_setting_change(&self, settings: &[PluginSettingData]) -> Result<()> {
+        WasmDataSourceLoader::on_setting_change(self, settings)
+    }
+
+    fn tab_title(&self) -> Option<String> {
+        WasmDataSourceLoader::tab_title(self).filter(|s| !s.is_empty())
+    }
+
+    fn tab_icon(&self) -> Option<String> {
+        WasmDataSourceLoader::tab_icon(self)
+    }
+
+    fn get_state(&self) -> Result<Option<String>> {
+        WasmDataSourceLoader::get_state(self)
+    }
+
+    fn init_with_state(&self, state: &str) -> Result<()> {
+        WasmDataSourceLoader::init_with_state(self, state)
+    }
+
+    fn on_tab_focused(&self) {
+        self.call_tab_lifecycle(0);
+    }
+
+    fn on_tab_blurred(&self) {
+        self.call_tab_lifecycle(1);
+    }
+
+    fn on_tab_closed(&self) {
+        self.call_tab_lifecycle(2);
+    }
+
+    fn drain_tab_open_requests(&self) -> Vec<TabOpenRequest> {
+        WasmDataSourceLoader::drain_tab_open_requests(self)
+    }
+
+    fn drain_http_results(&self) -> Vec<(String, HttpCallResult)> {
+        WasmDataSourceLoader::drain_http_results(self)
+    }
+
+    fn drain_retry_requests(&self) -> Vec<(String, PluginHttpRequest)> {
+        WasmDataSourceLoader::drain_retry_requests(self)
+            .into_iter()
+            .map(|(id, req)| (id, http_req_to_plugin(req)))
+            .collect()
+    }
+
+    fn dispatch_approved_request(&self, request_id: String, req: PluginHttpRequest) {
+        WasmDataSourceLoader::dispatch_approved_request(self, request_id, plugin_req_to_http(req));
+    }
+
+    fn has_pending_http(&self) -> bool {
+        WasmDataSourceLoader::has_pending_http(self)
     }
 }

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -284,13 +284,13 @@ impl thoth::plugin::ui_tabs::Host for DataSourcePluginState {
         initial_state: Option<String>,
     ) -> String {
         let request_id = next_tab_request_id();
-        let _ = self.tab_tx.send(TabOpenRequest {
-            request_id: request_id.clone(),
-            plugin_id: self.plugin_id.clone(),
+        let _ = self.tab_tx.send(TabOpenRequest::sanitized(
+            request_id.clone(),
+            self.plugin_id.clone(),
             title,
             icon,
             initial_state,
-        });
+        ));
         request_id
     }
 }

--- a/src/plugin/wasm_ui_component.rs
+++ b/src/plugin/wasm_ui_component.rs
@@ -1,0 +1,403 @@
+//! Host runtime for the `ui-component-plugin` world.
+//!
+//! Unlike [`WasmDataSourceLoader`](crate::plugin::wasm_data_source::WasmDataSourceLoader)
+//! (which has data-source + http-client), this loader hosts a *pure* interactive UI
+//! plugin. It provides the `ui-tabs` and `plugin-storage` host imports and drives the
+//! `ui-component` + `tab-host` exports, so the plugin can render in a dock tab, open
+//! more tabs, expose a title/icon, and snapshot/restore its per-tab state.
+
+use std::path::Path;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use wasmtime::component::{Component, HasSelf, Linker};
+use wasmtime::{Engine, Store};
+use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+
+use crate::app::persistent_state::PersistentState;
+use crate::error::{Result, ThothError};
+use crate::plugin::plugin_ui_host::{PluginUiHost, TabOpenRequest};
+use crate::plugin::render_node::{UiEvent, UiOutput};
+use crate::settings::PluginSettingData;
+
+/// Fuel budget per WASM call (matches the data-source loader).
+const PLUGIN_FUEL_BUDGET: u64 = 5_000_000_000;
+
+fn refuel(store: &mut Store<UiComponentPluginState>) -> Result<()> {
+    store
+        .set_fuel(PLUGIN_FUEL_BUDGET)
+        .map_err(|e| ThothError::Unknown {
+            message: format!("failed to set plugin fuel: {e}"),
+        })
+}
+
+wasmtime::component::bindgen!({
+    path: "wit/thoth-plugin.wit",
+    world: "ui-component-plugin",
+});
+
+static TAB_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn next_tab_request_id() -> String {
+    format!(
+        "tab-{}",
+        TAB_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+// ── per-store state ───────────────────────────────────────────────────────────
+
+struct UiComponentPluginState {
+    wasi: WasiCtx,
+    table: ResourceTable,
+    plugin_id: String,
+    /// Tab-open requests raised by the plugin via the `ui-tabs` import.
+    tab_tx: std::sync::mpsc::Sender<TabOpenRequest>,
+}
+
+impl WasiView for UiComponentPluginState {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi,
+            table: &mut self.table,
+        }
+    }
+}
+
+impl thoth::plugin::plugin_storage::Host for UiComponentPluginState {
+    fn read(&mut self) -> String {
+        match PersistentState::plugin_state_path(&self.plugin_id) {
+            Ok(p) => std::fs::read_to_string(&p).unwrap_or_default(),
+            Err(_) => String::new(),
+        }
+    }
+
+    fn write(&mut self, data: String) -> std::result::Result<(), String> {
+        let path =
+            PersistentState::plugin_state_path(&self.plugin_id).map_err(|err| err.to_string())?;
+        std::fs::write(&path, data.as_bytes()).map_err(|e| e.to_string())
+    }
+}
+
+impl thoth::plugin::ui_tabs::Host for UiComponentPluginState {
+    fn open_tab(
+        &mut self,
+        title: String,
+        icon: Option<String>,
+        initial_state: Option<String>,
+    ) -> String {
+        let request_id = next_tab_request_id();
+        let _ = self.tab_tx.send(TabOpenRequest {
+            request_id: request_id.clone(),
+            plugin_id: self.plugin_id.clone(),
+            title,
+            icon,
+            initial_state,
+        });
+        request_id
+    }
+}
+
+// ── inner / outer structs ─────────────────────────────────────────────────────
+
+struct WasmUiComponentInner {
+    store: Store<UiComponentPluginState>,
+    bindings: UiComponentPlugin,
+}
+
+pub struct WasmUiComponentLoader {
+    inner: Mutex<WasmUiComponentInner>,
+    tab_rx: std::sync::mpsc::Receiver<TabOpenRequest>,
+    plugin_id: String,
+}
+
+impl WasmUiComponentLoader {
+    pub fn open(
+        engine: &Engine,
+        wasm_path: &Path,
+        plugin_id: String,
+        settings: &[PluginSettingData],
+    ) -> Result<Self> {
+        let wasi = WasiCtxBuilder::new().inherit_stdio().build();
+        let (tab_tx, tab_rx) = std::sync::mpsc::channel::<TabOpenRequest>();
+
+        let state = UiComponentPluginState {
+            wasi,
+            table: ResourceTable::new(),
+            plugin_id: plugin_id.clone(),
+            tab_tx,
+        };
+
+        let mut store = Store::new(engine, state);
+        refuel(&mut store).map_err(|e| ThothError::PluginLoadError {
+            path: wasm_path.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+
+        let component =
+            Component::from_file(engine, wasm_path).map_err(|e| ThothError::PluginLoadError {
+                path: wasm_path.to_path_buf(),
+                reason: e.to_string(),
+            })?;
+
+        let mut linker = Linker::<UiComponentPluginState>::new(engine);
+
+        wasmtime_wasi::p2::add_to_linker_sync(&mut linker).map_err(|e| {
+            ThothError::PluginLoadError {
+                path: wasm_path.to_path_buf(),
+                reason: e.to_string(),
+            }
+        })?;
+
+        thoth::plugin::plugin_storage::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s).map_err(
+            |e| ThothError::PluginLoadError {
+                path: wasm_path.to_path_buf(),
+                reason: e.to_string(),
+            },
+        )?;
+
+        thoth::plugin::ui_tabs::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s).map_err(
+            |e| ThothError::PluginLoadError {
+                path: wasm_path.to_path_buf(),
+                reason: e.to_string(),
+            },
+        )?;
+
+        let bindings =
+            UiComponentPlugin::instantiate(&mut store, &component, &linker).map_err(|e| {
+                ThothError::PluginLoadError {
+                    path: wasm_path.to_path_buf(),
+                    reason: e.to_string(),
+                }
+            })?;
+
+        let mut loader = Self {
+            inner: Mutex::new(WasmUiComponentInner { store, bindings }),
+            tab_rx,
+            plugin_id,
+        };
+
+        loader.on_load(settings)?;
+        Ok(loader)
+    }
+
+    pub fn on_load(&mut self, settings: &[PluginSettingData]) -> Result<()> {
+        let settings_json = serde_json::to_string(settings).map_err(|e| ThothError::Unknown {
+            message: format!("Failed to serialize plugin settings: {e}"),
+        })?;
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        refuel(store)?;
+        bindings
+            .thoth_plugin_plugin_lifecycle()
+            .call_on_load(store, &settings_json)
+            .map_err(|e| ThothError::Unknown {
+                message: e.to_string(),
+            })
+    }
+
+    pub fn on_setting_change(&self, settings: &[PluginSettingData]) -> Result<()> {
+        let settings_json = serde_json::to_string(settings).map_err(|e| ThothError::Unknown {
+            message: format!("Failed to serialize plugin settings: {e}"),
+        })?;
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        refuel(store)?;
+        bindings
+            .thoth_plugin_plugin_lifecycle()
+            .call_on_setting_change(store, &settings_json)
+            .map_err(|e| ThothError::Unknown {
+                message: e.to_string(),
+            })
+    }
+
+    pub fn render_ui(&self) -> Result<UiOutput> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        refuel(store)?;
+        let wit_out = bindings
+            .thoth_plugin_ui_component()
+            .call_render_ui(store)
+            .map_err(|e| ThothError::Unknown {
+                message: e.to_string(),
+            })?
+            .map_err(|e| ThothError::Unknown { message: e.message })?;
+        Ok(UiOutput {
+            node_json: wit_out.node_json,
+            height_hint: wit_out.height_hint,
+        })
+    }
+
+    pub fn handle_event(&self, event: UiEvent) -> Result<UiOutput> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        refuel(store)?;
+        let wit_event = exports::thoth::plugin::ui_component::UiEvent {
+            widget_id: event.widget_id,
+            kind: event.kind,
+            value: event.value,
+        };
+        let wit_out = bindings
+            .thoth_plugin_ui_component()
+            .call_handle_event(store, &wit_event)
+            .map_err(|e| ThothError::Unknown {
+                message: e.to_string(),
+            })?
+            .map_err(|e| ThothError::Unknown { message: e.message })?;
+        Ok(UiOutput {
+            node_json: wit_out.node_json,
+            height_hint: wit_out.height_hint,
+        })
+    }
+
+    pub fn render_sidebar(&self) -> Result<Option<UiOutput>> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        refuel(store)?;
+        let result = bindings
+            .thoth_plugin_ui_component()
+            .call_render_sidebar(store)
+            .map_err(|e| ThothError::Unknown {
+                message: e.to_string(),
+            })?
+            .map_err(|e| ThothError::Unknown { message: e.message })?;
+        Ok(result.map(|o| UiOutput {
+            node_json: o.node_json,
+            height_hint: o.height_hint,
+        }))
+    }
+
+    // ── tab-host export ─────────────────────────────────────────────────────────
+
+    pub fn tab_title(&self) -> Option<String> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        refuel(store).ok()?;
+        bindings.thoth_plugin_tab_host().call_tab_title(store).ok()
+    }
+
+    pub fn tab_icon(&self) -> Option<String> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        refuel(store).ok()?;
+        bindings
+            .thoth_plugin_tab_host()
+            .call_tab_icon(store)
+            .ok()
+            .flatten()
+    }
+
+    pub fn get_state(&self) -> Result<Option<String>> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        refuel(store)?;
+        let blob = bindings
+            .thoth_plugin_tab_host()
+            .call_get_state(store)
+            .map_err(|e| ThothError::Unknown {
+                message: e.to_string(),
+            })?
+            .map_err(|e| ThothError::Unknown { message: e.message })?;
+        Ok(Some(blob))
+    }
+
+    pub fn init_with_state(&self, state: &str) -> Result<()> {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        refuel(store)?;
+        bindings
+            .thoth_plugin_tab_host()
+            .call_init_with_state(store, state)
+            .map_err(|e| ThothError::Unknown {
+                message: e.to_string(),
+            })?
+            .map_err(|e| ThothError::Unknown { message: e.message })
+    }
+
+    fn call_lifecycle(&self, which: TabLifecycle) {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let WasmUiComponentInner { store, bindings } = &mut *guard;
+        if refuel(store).is_err() {
+            return;
+        }
+        let host = bindings.thoth_plugin_tab_host();
+        let _ = match which {
+            TabLifecycle::Focused => host.call_on_tab_focused(store),
+            TabLifecycle::Blurred => host.call_on_tab_blurred(store),
+            TabLifecycle::Closed => host.call_on_tab_closed(store),
+        };
+    }
+
+    /// Non-blocking drain of tab-open requests raised during the last WASM call.
+    pub fn drain_tab_open_requests(&self) -> Vec<TabOpenRequest> {
+        let mut out = Vec::new();
+        while let Ok(req) = self.tab_rx.try_recv() {
+            out.push(req);
+        }
+        out
+    }
+
+    pub fn plugin_id(&self) -> &str {
+        &self.plugin_id
+    }
+}
+
+enum TabLifecycle {
+    Focused,
+    Blurred,
+    Closed,
+}
+
+impl PluginUiHost for WasmUiComponentLoader {
+    fn plugin_id(&self) -> &str {
+        WasmUiComponentLoader::plugin_id(self)
+    }
+
+    fn render_ui(&self) -> Result<UiOutput> {
+        WasmUiComponentLoader::render_ui(self)
+    }
+
+    fn handle_event(&self, event: UiEvent) -> Result<UiOutput> {
+        WasmUiComponentLoader::handle_event(self, event)
+    }
+
+    fn render_sidebar(&self) -> Result<Option<UiOutput>> {
+        WasmUiComponentLoader::render_sidebar(self)
+    }
+
+    fn on_setting_change(&self, settings: &[PluginSettingData]) -> Result<()> {
+        WasmUiComponentLoader::on_setting_change(self, settings)
+    }
+
+    fn tab_title(&self) -> Option<String> {
+        WasmUiComponentLoader::tab_title(self).filter(|s| !s.is_empty())
+    }
+
+    fn tab_icon(&self) -> Option<String> {
+        WasmUiComponentLoader::tab_icon(self)
+    }
+
+    fn get_state(&self) -> Result<Option<String>> {
+        WasmUiComponentLoader::get_state(self)
+    }
+
+    fn init_with_state(&self, state: &str) -> Result<()> {
+        WasmUiComponentLoader::init_with_state(self, state)
+    }
+
+    fn on_tab_focused(&self) {
+        self.call_lifecycle(TabLifecycle::Focused);
+    }
+
+    fn on_tab_blurred(&self) {
+        self.call_lifecycle(TabLifecycle::Blurred);
+    }
+
+    fn on_tab_closed(&self) {
+        self.call_lifecycle(TabLifecycle::Closed);
+    }
+
+    fn drain_tab_open_requests(&self) -> Vec<TabOpenRequest> {
+        WasmUiComponentLoader::drain_tab_open_requests(self)
+    }
+}

--- a/src/plugin/wasm_ui_component.rs
+++ b/src/plugin/wasm_ui_component.rs
@@ -87,13 +87,13 @@ impl thoth::plugin::ui_tabs::Host for UiComponentPluginState {
         initial_state: Option<String>,
     ) -> String {
         let request_id = next_tab_request_id();
-        let _ = self.tab_tx.send(TabOpenRequest {
-            request_id: request_id.clone(),
-            plugin_id: self.plugin_id.clone(),
+        let _ = self.tab_tx.send(TabOpenRequest::sanitized(
+            request_id.clone(),
+            self.plugin_id.clone(),
             title,
             icon,
             initial_state,
-        });
+        ));
         request_id
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,19 +3,26 @@ use std::path::PathBuf;
 use crate::{
     app::tab_manager::TabManager,
     components,
-    plugin::{render_node::UiOutput, wasm_data_source::WasmDataSourceLoader},
+    plugin::{plugin_ui_host::PluginUiHost, render_node::UiOutput},
     search, update,
 };
 
-/// Holds the active plugin pane shown in the main area.
-/// Created when the user activates a data-source plugin section in the sidebar.
+/// Holds the active plugin pane shown in the main area / a dock tab.
+/// Created when the user activates a data-source plugin section in the sidebar,
+/// opens a ui-component plugin, or a plugin requests a new tab.
 pub struct ActivePluginPane {
     pub plugin_id: String,
     pub display_url: String,
     /// Current interactive UI tree (from `render_ui` / `handle_event`).
     pub ui_output: UiOutput,
     /// The loader is kept here so the central panel can forward UI events.
-    pub loader: WasmDataSourceLoader,
+    /// Boxed so a pane can hold either a data-source or a ui-component loader.
+    pub loader: Box<dyn PluginUiHost>,
+    /// Cached tab title/icon from the plugin's `tab-host` export, refreshed after
+    /// `render_ui` and each `handle_event`. Read cheaply by the dock tab label
+    /// (which is queried every frame, so it must not lock the WASM store).
+    pub cached_tab_title: Option<String>,
+    pub cached_tab_icon: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -290,7 +290,9 @@ impl ThemeColors {
         ColorTheme {
             name: if is_dark { "Thoth Dark" } else { "Thoth Light" },
             dark: is_dark,
-            bg: hex(self.bg_panel),
+            // Match the surrounding panel background so the editor blends in
+            // rather than reading as a distinct sunken box.
+            bg: hex(self.bg),
             cursor: fg_hex,
             selection: hex(self.surface_raised),
             comments: hex(self.fg_muted),

--- a/wit/thoth-plugin.wit
+++ b/wit/thoth-plugin.wit
@@ -506,6 +506,63 @@ interface ui-component {
 
 
 // ---------------------------------------------------------------------------
+// ui-tabs — host-provided import for plugins that render in tab windows
+//
+// Lets a plugin ask the host to open a NEW dock tab hosting a fresh instance
+// of the same plugin. Mirrors http-client.submit: the call returns an opaque
+// tab id immediately and the host actually opens the tab on its next frame.
+// The new instance is seeded with `initial-state` via tab-host.init-with-state.
+// ---------------------------------------------------------------------------
+
+interface ui-tabs {
+    /// Request the host to open a new tab hosting this plugin.
+    /// `icon` is an optional Phosphor glyph shown in the tab label.
+    /// `initial-state` is an optional JSON blob (same shape as get-state
+    /// returns) used to seed the new tab's plugin instance.
+    /// Returns a host-assigned tab id (currently informational).
+    open-tab: func(title: string, icon: option<string>, initial-state: option<string>) -> string;
+}
+
+
+// ---------------------------------------------------------------------------
+// tab-host — implement when the plugin renders in a tab window
+//
+// Provides the host with the tab's title/icon, lets the host snapshot and
+// restore the plugin's per-tab state across app restarts (like a file tab
+// remembers its path), and delivers tab lifecycle notifications.
+// ---------------------------------------------------------------------------
+
+interface tab-host {
+    use types.{plugin-error};
+
+    /// The title shown in the dock tab label. Queried after render-ui and
+    /// after each handle-event so the title can stay live.
+    tab-title: func() -> string;
+
+    /// Optional Phosphor glyph shown before the title. `none` = no icon.
+    tab-icon: func() -> option<string>;
+
+    /// Serialize the plugin's current per-tab state to a JSON blob. The host
+    /// persists it in the session and passes it back via init-with-state when
+    /// the tab is reopened on the next launch.
+    get-state: func() -> result<string, plugin-error>;
+
+    /// Restore from a previously saved blob. Called once, instead of a blank
+    /// start, when the host reopens a persisted tab.
+    init-with-state: func(state: string) -> result<_, plugin-error>;
+
+    /// This tab became the active/focused tab.
+    on-tab-focused: func();
+
+    /// This tab lost focus (another tab became active).
+    on-tab-blurred: func();
+
+    /// This tab is being closed. Release any per-tab resources.
+    on-tab-closed: func();
+}
+
+
+// ---------------------------------------------------------------------------
 // Worlds — plugin authors implement one of these
 //
 // A world declares exactly which interfaces a plugin exports. Pick the
@@ -560,9 +617,14 @@ world file-viewer-plugin {
 }
 
 /// A plugin that renders a fully interactive panel (no file-loading required).
+/// It can live in a dock tab: the host provides ui-tabs (open more tabs) and
+/// plugin-storage, and the plugin exports tab-host (title/state/lifecycle).
 world ui-component-plugin {
     include base-plugin;
+    import ui-tabs;
+    import plugin-storage;
     export ui-component;
+    export tab-host;
 }
 
 /// A plugin that connects Thoth to an external data source and draws its own
@@ -573,8 +635,10 @@ world data-source-plugin {
     include base-plugin;
     import http-client;
     import plugin-storage;
+    import ui-tabs;
     export data-source;
     export ui-component;
+    export tab-host;
 }
 
 /// A plugin that adds a new export format or destination.


### PR DESCRIPTION
Let UI-component plugins render in dock tabs, open more tabs themselves,
and persist per-tab state across restarts.

WIT (wit/thoth-plugin.wit):
- New ui-tabs host import (open-tab) and tab-host export (tab-title/tab-icon,
  get-state/init-with-state, on-tab-focused/-blurred/-closed), added to the
  ui-component-plugin and data-source-plugin worlds.

Host:
- New PluginUiHost trait (plugin_ui_host.rs) so a tab pane holds either loader
  behind a Box<dyn>; new WasmUiComponentLoader for the ui-component-plugin world;
  WasmDataSourceLoader gains ui-tabs/tab-host.
- poll_plugin_panes drives all tabs + the sidebar runtime each frame (async HTTP
  routed to the originating tab, plugin-initiated open-tab, focus/blur lifecycle).
- Per-tab state blob persisted in PersistedTabKind::Plugin; capability-based
  loader selection on restore.
- Plugin sidebar is now tab-independent: opening/closing it never creates or
  destroys a tab; tabs are spawned explicitly via open-tab.
- Button gains a full-width prop; Select gains an optional fixed width.

url-source:
- Implements tab-host (per-tab request state, title/icon, lifecycle).
- Sidebar: Collections header, full-width 'New Request' button (phosphor + icon),
  method picker switched to a fixed-width dropdown; clicking a saved request or
  New Request opens it in a new tab.

Closes #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can open dedicated tabs with per-tab save/restore and lifecycle (focus/blur/close)
  * UI component plugins available as standalone sidebar tools and openable as tabs
  * Tab action icons on tab headers for quick actions

* **Improvements**
  * cURL import/export smarter: opens imports in new tabs when current form is non-empty
  * Request params/headers can be toggled on/off and ignored when disabled
  * HTTP method selector is now a dropdown; JSON viewer fixes nested displays
<!-- end of auto-generated comment: release notes by coderabbit.ai -->