### PR TITLE
feat(plugins): host-brokered signals channel → status bar (#110)

### DIFF
--- a/plugins/seshat/src/bindings.rs
+++ b/plugins/seshat/src/bindings.rs
@@ -1458,6 +1458,108 @@ pub mod thoth {
                 }
             }
         }
+        /// signals — host-provided import. Plugins PUSH tiny, high-frequency status /
+        /// metric key-values (connection health, row counts, latency); the host
+        /// aggregates them in a TTL registry and renders them in the status bar with
+        /// source attribution. Kept deliberately separate from the dataset channel
+        /// (#113/#114): signals carry a short string, never a record set, so a large
+        /// result never crosses this seam. Datasets are pulled paged; signals are
+        /// pushed fire-and-forget.
+        #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+        pub mod signals {
+            #[used]
+            #[doc(hidden)]
+            static __FORCE_SECTION_REF: fn() = super::super::super::__link_custom_section_describing_imports;
+            use super::super::super::_rt;
+            /// Health of the emitting plugin's current activity.
+            #[repr(u8)]
+            #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+            pub enum Status {
+                Ready,
+                Loading,
+                Error,
+            }
+            impl ::core::fmt::Debug for Status {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::fmt::Result {
+                    match self {
+                        Status::Ready => f.debug_tuple("Status::Ready").finish(),
+                        Status::Loading => f.debug_tuple("Status::Loading").finish(),
+                        Status::Error => f.debug_tuple("Status::Error").finish(),
+                    }
+                }
+            }
+            impl Status {
+                #[doc(hidden)]
+                pub unsafe fn _lift(val: u8) -> Status {
+                    if !cfg!(debug_assertions) {
+                        return ::core::mem::transmute(val);
+                    }
+                    match val {
+                        0 => Status::Ready,
+                        1 => Status::Loading,
+                        2 => Status::Error,
+                        _ => panic!("invalid enum discriminant"),
+                    }
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
+            /// Push a signal to the host. `key` / `value` are free-form so a new signal
+            /// needs no WIT change. `ttl-ms` is how long the host keeps the signal after
+            /// receipt (0 = sticky until the plugin overwrites it). Last-write-wins per
+            /// (plugin, key); the host stamps the source plugin id.
+            pub fn emit_signal(
+                key: &str,
+                value: &str,
+                status: Status,
+                ttl_ms: u32,
+            ) -> () {
+                unsafe {
+                    let vec0 = key;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec1 = value;
+                    let ptr1 = vec1.as_ptr().cast::<u8>();
+                    let len1 = vec1.len();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/signals@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "emit-signal"]
+                        fn wit_import2(
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                            _: usize,
+                            _: i32,
+                            _: i32,
+                        );
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import2(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                        _: i32,
+                        _: i32,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe {
+                        wit_import2(
+                            ptr0.cast_mut(),
+                            len0,
+                            ptr1.cast_mut(),
+                            len1,
+                            status.clone() as i32,
+                            _rt::as_i32(&ttl_ms),
+                        )
+                    };
+                }
+            }
+        }
         /// ---------------------------------------------------------------------------
         /// file-dialog — host-provided native open/save file pickers with I/O.
         ///
@@ -4021,9 +4123,9 @@ pub(crate) use __export_data_source_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 2752] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb7\x14\x01A\x02\x01\
-A\x1e\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 2870] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xad\x15\x01A\x02\x01\
+A\x20\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
 \x0fsearch-provider\x10new-ui-component\x04\0\x0acapability\x03\0\0\x01p\x01\x01\
 ks\x01r\x08\x02ids\x04names\x07versions\x0bdescriptions\x0ccapabilities\x02\x06a\
 uthor\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplugin-info\x03\0\x04\x01r\x02\x04\
@@ -4048,43 +4150,46 @@ close\x01\x0b\x03\0\x1dthoth:plugin/tcp-client@0.1.0\x05\x05\x01B\x0b\x02\x03\x0
 s\0\x02\x04\0\x05write\x01\x03\x01ks\x01j\x01\x04\x01\x01\x01@\x01\x03keys\0\x05\
 \x04\0\x04read\x01\x06\x01@\x01\x03keys\0\x02\x04\0\x06delete\x01\x07\x03\0!thot\
 h:plugin/secure-storage@0.1.0\x05\x06\x01B\x02\x01@\x02\x06handles\x01qs\0s\x04\0\
-\x0csubmit-query\x01\0\x03\0\x1dthoth:plugin/db-runtime@0.1.0\x05\x07\x01B\x0d\x02\
-\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04paths\x08contentss\x04\
-\0\x0bopened-file\x03\0\x02\x01ps\x01k\x03\x01j\x01\x05\x01\x01\x01@\x02\x05titl\
-es\x0aextensions\x04\0\x06\x04\0\x09open-file\x01\x07\x01ks\x01j\x01\x08\x01\x01\
-\x01@\x04\x05titles\x0cdefault-names\x0aextensions\x04\x08contentss\0\x09\x04\0\x09\
-save-file\x01\x0a\x03\0\x1ethoth:plugin/file-dialog@0.1.0\x05\x08\x01B\x1c\x02\x03\
-\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04names\x0bdescriptions\x08\
-required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\x03\x04names\x09type\
--hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\x05\x01r\x02\x04name\
-s\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09node-jsons\x0bheigh\
-t-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\0\x0frequired-c\
-onfig\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\0\x07connect\x01\
-\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\0\x06schema\x01\
-\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\x01\x06handles\x01\
-\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06handles\0\x14\x04\0\x0b\
-render-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\x05\x09\x01B\x0f\x02\
-\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09widget-ids\x04kinds\x05\
-values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x09\
-ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\0\x09render-ui\x01\x07\
-\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\x01k\x05\x01j\x01\x09\
-\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\x1fthoth:plugin/ui-c\
-omponent@0.1.0\x05\x0a\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\
-\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\0\x08tab-icon\x01\x04\
-\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\x01j\0\x01\x01\x01@\x01\
-\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\x01\0\x04\0\x0eon-tab-f\
-ocused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0don-tab-closed\x01\x09\x04\
-\0\x1bthoth:plugin/tab-host@0.1.0\x05\x0b\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\
-\x03\x02\x01\x0c\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\
-\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x0d\x01B\x05\x01@\x01\x07settin\
-gs\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11\
-on-setting-change\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x0e\x01B\x07\
-\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bhei\
-ght-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\
-\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x0f\x04\
-\0%thoth:plugin/data-source-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plug\
-in\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10\
-wit-bindgen-rust\x060.41.0";
+\x0csubmit-query\x01\0\x03\0\x1dthoth:plugin/db-runtime@0.1.0\x05\x07\x01B\x04\x01\
+m\x03\x05ready\x07loading\x05error\x04\0\x06status\x03\0\0\x01@\x04\x03keys\x05v\
+alues\x06status\x01\x06ttl-msy\x01\0\x04\0\x0bemit-signal\x01\x02\x03\0\x1athoth\
+:plugin/signals@0.1.0\x05\x08\x01B\x0d\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\
+\x03\0\0\x01r\x02\x04paths\x08contentss\x04\0\x0bopened-file\x03\0\x02\x01ps\x01\
+k\x03\x01j\x01\x05\x01\x01\x01@\x02\x05titles\x0aextensions\x04\0\x06\x04\0\x09o\
+pen-file\x01\x07\x01ks\x01j\x01\x08\x01\x01\x01@\x04\x05titles\x0cdefault-names\x0a\
+extensions\x04\x08contentss\0\x09\x04\0\x09save-file\x01\x0a\x03\0\x1ethoth:plug\
+in/file-dialog@0.1.0\x05\x09\x01B\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\
+\0\0\x01r\x04\x04names\x0bdescriptions\x08required\x7f\x05values\x04\0\x0cconfig\
+-entry\x03\0\x02\x01r\x03\x04names\x09type-hints\x08nullable\x7f\x04\0\x0cfield-\
+schema\x03\0\x04\x01p\x05\x01r\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\
+\x03\0\x07\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\
+\x01p\x03\x01@\0\0\x0b\x04\0\x0frequired-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\
+\x06config\x0b\0\x0d\x04\0\x07connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\
+\x01\x06handles\0\x10\x04\0\x06schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\
+\0\x05query\x01\x12\x01@\x01\x06handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\
+\x01\x01\x01@\x01\x06handles\0\x14\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:p\
+lugin/data-source@0.1.0\x05\x0a\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-err\
+or\x03\0\0\x01r\x03\x09widget-ids\x04kinds\x05values\x04\0\x08ui-event\x03\0\x02\
+\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\
+\x01\x01\x01@\0\0\x06\x04\0\x09render-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\
+\0\x0chandle-event\x01\x08\x01k\x05\x01j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0er\
+ender-sidebar\x01\x0b\x04\0\x1fthoth:plugin/ui-component@0.1.0\x05\x0b\x01B\x11\x02\
+\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\
+\x01ks\x01@\0\0\x03\x04\0\x08tab-icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\
+\0\x09get-state\x01\x06\x01j\0\x01\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-wi\
+th-state\x01\x08\x01@\0\x01\0\x04\0\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-bl\
+urred\x01\x09\x04\0\x0don-tab-closed\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.\
+0\x05\x0c\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x0d\x04\0\x0bplugi\
+n-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plug\
+in-meta@0.1.0\x05\x0e\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\
+\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#t\
+hoth:plugin/plugin-lifecycle@0.1.0\x05\x0f\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0c\
+plugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-ou\
+tput\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\
+\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x10\x04\0%thoth:plugin/data-sourc\
+e-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\
+\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41\
+.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/seshat/src/events.rs
+++ b/plugins/seshat/src/events.rs
@@ -4,6 +4,7 @@
 use serde_json::Value;
 
 use crate::bindings::exports::thoth::plugin::ui_component::UiEvent;
+use crate::bindings::thoth::plugin::signals::{self, Status as SignalStatus};
 use crate::bindings::thoth::plugin::{file_dialog, secure_storage, ui_tabs};
 use crate::db::{self, ColumnInfo, TableInfo};
 use crate::sql;
@@ -349,6 +350,9 @@ fn execute_current(st: &mut State) {
     };
     st.loading = true;
     st.result = None;
+    // Push a "running" signal to the host status bar; the result handler
+    // overwrites it with the row count (Ready) or an Error.
+    signals::emit_signal("rows", "", SignalStatus::Loading, 0);
     let (sql, limited) = match sql::add_limit(&base, st.row_limit + 1) {
         Some(capped) => (capped, true),
         None => (base, false),
@@ -1093,6 +1097,25 @@ fn handle_query_result(st: &mut State, event: &UiEvent) {
                 (None, Some(m)) => Err(m),
                 _ => Err("query failed".into()),
             });
+            // Surface the outcome as a status-bar signal: the returned row count
+            // (with a "+" when more rows are available) or an error state.
+            match &st.result {
+                Some(Ok(value)) => {
+                    let n = value
+                        .get("rows")
+                        .and_then(|r| r.as_array())
+                        .map(|a| a.len())
+                        .unwrap_or(0);
+                    let shown = if st.has_more {
+                        format!("{n}+")
+                    } else {
+                        n.to_string()
+                    };
+                    signals::emit_signal("rows", &shown, SignalStatus::Ready, 0);
+                }
+                Some(Err(_)) => signals::emit_signal("rows", "", SignalStatus::Error, 0),
+                None => {}
+            }
         }
         Kind::QueryExplain => {
             st.explain_loading = false;

--- a/plugins/url-source/src/bindings.rs
+++ b/plugins/url-source/src/bindings.rs
@@ -1458,6 +1458,108 @@ pub mod thoth {
                 }
             }
         }
+        /// signals — host-provided import. Plugins PUSH tiny, high-frequency status /
+        /// metric key-values (connection health, row counts, latency); the host
+        /// aggregates them in a TTL registry and renders them in the status bar with
+        /// source attribution. Kept deliberately separate from the dataset channel
+        /// (#113/#114): signals carry a short string, never a record set, so a large
+        /// result never crosses this seam. Datasets are pulled paged; signals are
+        /// pushed fire-and-forget.
+        #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+        pub mod signals {
+            #[used]
+            #[doc(hidden)]
+            static __FORCE_SECTION_REF: fn() = super::super::super::__link_custom_section_describing_imports;
+            use super::super::super::_rt;
+            /// Health of the emitting plugin's current activity.
+            #[repr(u8)]
+            #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+            pub enum Status {
+                Ready,
+                Loading,
+                Error,
+            }
+            impl ::core::fmt::Debug for Status {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::fmt::Result {
+                    match self {
+                        Status::Ready => f.debug_tuple("Status::Ready").finish(),
+                        Status::Loading => f.debug_tuple("Status::Loading").finish(),
+                        Status::Error => f.debug_tuple("Status::Error").finish(),
+                    }
+                }
+            }
+            impl Status {
+                #[doc(hidden)]
+                pub unsafe fn _lift(val: u8) -> Status {
+                    if !cfg!(debug_assertions) {
+                        return ::core::mem::transmute(val);
+                    }
+                    match val {
+                        0 => Status::Ready,
+                        1 => Status::Loading,
+                        2 => Status::Error,
+                        _ => panic!("invalid enum discriminant"),
+                    }
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
+            /// Push a signal to the host. `key` / `value` are free-form so a new signal
+            /// needs no WIT change. `ttl-ms` is how long the host keeps the signal after
+            /// receipt (0 = sticky until the plugin overwrites it). Last-write-wins per
+            /// (plugin, key); the host stamps the source plugin id.
+            pub fn emit_signal(
+                key: &str,
+                value: &str,
+                status: Status,
+                ttl_ms: u32,
+            ) -> () {
+                unsafe {
+                    let vec0 = key;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec1 = value;
+                    let ptr1 = vec1.as_ptr().cast::<u8>();
+                    let len1 = vec1.len();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/signals@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "emit-signal"]
+                        fn wit_import2(
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                            _: usize,
+                            _: i32,
+                            _: i32,
+                        );
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import2(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                        _: i32,
+                        _: i32,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe {
+                        wit_import2(
+                            ptr0.cast_mut(),
+                            len0,
+                            ptr1.cast_mut(),
+                            len1,
+                            status.clone() as i32,
+                            _rt::as_i32(&ttl_ms),
+                        )
+                    };
+                }
+            }
+        }
         /// ---------------------------------------------------------------------------
         /// file-dialog — host-provided native open/save file pickers with I/O.
         ///
@@ -4021,9 +4123,9 @@ pub(crate) use __export_data_source_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 2752] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb7\x14\x01A\x02\x01\
-A\x1e\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 2870] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xad\x15\x01A\x02\x01\
+A\x20\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
 \x0fsearch-provider\x10new-ui-component\x04\0\x0acapability\x03\0\0\x01p\x01\x01\
 ks\x01r\x08\x02ids\x04names\x07versions\x0bdescriptions\x0ccapabilities\x02\x06a\
 uthor\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplugin-info\x03\0\x04\x01r\x02\x04\
@@ -4048,43 +4150,46 @@ close\x01\x0b\x03\0\x1dthoth:plugin/tcp-client@0.1.0\x05\x05\x01B\x0b\x02\x03\x0
 s\0\x02\x04\0\x05write\x01\x03\x01ks\x01j\x01\x04\x01\x01\x01@\x01\x03keys\0\x05\
 \x04\0\x04read\x01\x06\x01@\x01\x03keys\0\x02\x04\0\x06delete\x01\x07\x03\0!thot\
 h:plugin/secure-storage@0.1.0\x05\x06\x01B\x02\x01@\x02\x06handles\x01qs\0s\x04\0\
-\x0csubmit-query\x01\0\x03\0\x1dthoth:plugin/db-runtime@0.1.0\x05\x07\x01B\x0d\x02\
-\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04paths\x08contentss\x04\
-\0\x0bopened-file\x03\0\x02\x01ps\x01k\x03\x01j\x01\x05\x01\x01\x01@\x02\x05titl\
-es\x0aextensions\x04\0\x06\x04\0\x09open-file\x01\x07\x01ks\x01j\x01\x08\x01\x01\
-\x01@\x04\x05titles\x0cdefault-names\x0aextensions\x04\x08contentss\0\x09\x04\0\x09\
-save-file\x01\x0a\x03\0\x1ethoth:plugin/file-dialog@0.1.0\x05\x08\x01B\x1c\x02\x03\
-\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04names\x0bdescriptions\x08\
-required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\x03\x04names\x09type\
--hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\x05\x01r\x02\x04name\
-s\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09node-jsons\x0bheigh\
-t-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\0\x0frequired-c\
-onfig\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\0\x07connect\x01\
-\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\0\x06schema\x01\
-\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\x01\x06handles\x01\
-\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06handles\0\x14\x04\0\x0b\
-render-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\x05\x09\x01B\x0f\x02\
-\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09widget-ids\x04kinds\x05\
-values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x09\
-ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\0\x09render-ui\x01\x07\
-\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\x01k\x05\x01j\x01\x09\
-\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\x1fthoth:plugin/ui-c\
-omponent@0.1.0\x05\x0a\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\
-\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\0\x08tab-icon\x01\x04\
-\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\x01j\0\x01\x01\x01@\x01\
-\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\x01\0\x04\0\x0eon-tab-f\
-ocused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0don-tab-closed\x01\x09\x04\
-\0\x1bthoth:plugin/tab-host@0.1.0\x05\x0b\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\
-\x03\x02\x01\x0c\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\
-\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x0d\x01B\x05\x01@\x01\x07settin\
-gs\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11\
-on-setting-change\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x0e\x01B\x07\
-\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bhei\
-ght-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\
-\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x0f\x04\
-\0%thoth:plugin/data-source-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plug\
-in\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10\
-wit-bindgen-rust\x060.41.0";
+\x0csubmit-query\x01\0\x03\0\x1dthoth:plugin/db-runtime@0.1.0\x05\x07\x01B\x04\x01\
+m\x03\x05ready\x07loading\x05error\x04\0\x06status\x03\0\0\x01@\x04\x03keys\x05v\
+alues\x06status\x01\x06ttl-msy\x01\0\x04\0\x0bemit-signal\x01\x02\x03\0\x1athoth\
+:plugin/signals@0.1.0\x05\x08\x01B\x0d\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\
+\x03\0\0\x01r\x02\x04paths\x08contentss\x04\0\x0bopened-file\x03\0\x02\x01ps\x01\
+k\x03\x01j\x01\x05\x01\x01\x01@\x02\x05titles\x0aextensions\x04\0\x06\x04\0\x09o\
+pen-file\x01\x07\x01ks\x01j\x01\x08\x01\x01\x01@\x04\x05titles\x0cdefault-names\x0a\
+extensions\x04\x08contentss\0\x09\x04\0\x09save-file\x01\x0a\x03\0\x1ethoth:plug\
+in/file-dialog@0.1.0\x05\x09\x01B\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\
+\0\0\x01r\x04\x04names\x0bdescriptions\x08required\x7f\x05values\x04\0\x0cconfig\
+-entry\x03\0\x02\x01r\x03\x04names\x09type-hints\x08nullable\x7f\x04\0\x0cfield-\
+schema\x03\0\x04\x01p\x05\x01r\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\
+\x03\0\x07\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\
+\x01p\x03\x01@\0\0\x0b\x04\0\x0frequired-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\
+\x06config\x0b\0\x0d\x04\0\x07connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\
+\x01\x06handles\0\x10\x04\0\x06schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\
+\0\x05query\x01\x12\x01@\x01\x06handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\
+\x01\x01\x01@\x01\x06handles\0\x14\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:p\
+lugin/data-source@0.1.0\x05\x0a\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-err\
+or\x03\0\0\x01r\x03\x09widget-ids\x04kinds\x05values\x04\0\x08ui-event\x03\0\x02\
+\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\
+\x01\x01\x01@\0\0\x06\x04\0\x09render-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\
+\0\x0chandle-event\x01\x08\x01k\x05\x01j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0er\
+ender-sidebar\x01\x0b\x04\0\x1fthoth:plugin/ui-component@0.1.0\x05\x0b\x01B\x11\x02\
+\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\
+\x01ks\x01@\0\0\x03\x04\0\x08tab-icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\
+\0\x09get-state\x01\x06\x01j\0\x01\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-wi\
+th-state\x01\x08\x01@\0\x01\0\x04\0\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-bl\
+urred\x01\x09\x04\0\x0don-tab-closed\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.\
+0\x05\x0c\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x0d\x04\0\x0bplugi\
+n-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plug\
+in-meta@0.1.0\x05\x0e\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\
+\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#t\
+hoth:plugin/plugin-lifecycle@0.1.0\x05\x0f\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0c\
+plugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-ou\
+tput\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\
+\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x10\x04\0%thoth:plugin/data-sourc\
+e-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\
+\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41\
+.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -621,6 +621,7 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
                 error: Some(format!("response parse error: {e}")),
                 ..Default::default()
             });
+            signals::emit_signal("http", "", SignalStatus::Error, 0);
             return;
         }
     };
@@ -701,6 +702,9 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
             error: Some(message),
             ..Default::default()
         });
+        signals::emit_signal("http", "", SignalStatus::Error, 0);
+    } else {
+        // Payload had neither `ok` nor `err`: still clear the sticky Loading.
         signals::emit_signal("http", "", SignalStatus::Error, 0);
     }
 }

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -1,5 +1,11 @@
 use crate::{
-    bindings::{exports::thoth::plugin::ui_component::UiEvent, thoth::plugin::http_client},
+    bindings::{
+        exports::thoth::plugin::ui_component::UiEvent,
+        thoth::plugin::{
+            http_client,
+            signals::{self, Status as SignalStatus},
+        },
+    },
     helper::{
         is_body_method, parse_kv_list, parse_str, parse_url_into_state, status_color, status_text,
     },
@@ -678,6 +684,13 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
             duration_ms,
             size_bytes,
         });
+        // HTTP status + payload size as a status-bar signal; >=400 reads as error.
+        let sig_status = if status >= 400 {
+            SignalStatus::Error
+        } else {
+            SignalStatus::Ready
+        };
+        signals::emit_signal("http", &format!("{status} · {size_bytes}B"), sig_status, 0);
     } else if let Some(err) = val.get("err") {
         let message = err
             .get("message")
@@ -688,6 +701,7 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
             error: Some(message),
             ..Default::default()
         });
+        signals::emit_signal("http", "", SignalStatus::Error, 0);
     }
 }
 
@@ -732,6 +746,8 @@ pub fn apply_event(st: &mut State, event: &UiEvent) {
             st.pending_request_id = Some(request_id);
             st.loading = true;
             st.response = None;
+            // Push a "requesting" signal; handle_http_response overwrites it.
+            signals::emit_signal("http", "", SignalStatus::Loading, 0);
         }
 
         _ => {}

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -1387,6 +1387,17 @@ impl ThothApp {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
+        // Reconcile the process-global signal registry with the plugins that
+        // still have a live pane, so a closed pane's signals stop showing.
+        let open_plugins: std::collections::HashSet<String> = self
+            .window_state
+            .tab_manager
+            .tabs
+            .values()
+            .filter_map(|t| t.active_plugin_pane.as_ref().map(|p| p.plugin_id.clone()))
+            .collect();
+        crate::plugin::signals::retain_plugins(&open_plugins);
+
         let (
             file_path_opt,
             file_type,

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -1396,6 +1396,7 @@ impl ThothApp {
             _search_results_len,
             filtered_count,
             selected_path,
+            active_plugin_id,
         ) = if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
             let search = &tab.search_engine_state.search;
             let scanning = search.scanning;
@@ -1407,6 +1408,8 @@ impl ThothApp {
                 None
             };
             let sel_path = tab.central_panel.get_selected_path().cloned();
+            // A plugin pane tab: its id drives the plugin-scoped status bar.
+            let plugin_id = tab.active_plugin_pane.as_ref().map(|p| p.plugin_id.clone());
             (
                 tab.file_path.clone(),
                 tab.file_type,
@@ -1416,6 +1419,7 @@ impl ThothApp {
                 results_len,
                 filtered,
                 sel_path,
+                plugin_id,
             )
         } else {
             (
@@ -1425,6 +1429,7 @@ impl ThothApp {
                 false,
                 false,
                 0,
+                None,
                 None,
                 None,
             )
@@ -1449,6 +1454,7 @@ impl ThothApp {
                 filtered_count,
                 status,
                 selected_path: selected_path.as_deref(),
+                active_plugin_id: active_plugin_id.as_deref(),
             },
         );
 
@@ -1481,9 +1487,12 @@ impl ThothApp {
                 .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
         });
 
-        let dock_style = colors
+        let mut dock_style = colors
             .map(|c| c.dock_style(ui.style()))
             .unwrap_or_else(|| egui_dock::Style::from_egui(ui.style()));
+        // Hide egui_dock's thick (hardcoded 7.5px) tab-bar overflow scroll bar.
+        // Overflowing tabs still scroll via wheel/trackpad while hovering the bar.
+        dock_style.tab_bar.show_scroll_bar_on_overflow = false;
 
         let (dock_state, tabs) = self.window_state.tab_manager.borrow_parts();
 

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -38,13 +38,17 @@ pub struct StatusBarProps<'a> {
 
     /// Currently selected path in the JSON (for breadcrumbs)
     pub selected_path: Option<&'a str>,
+
+    /// Set when the active tab is a plugin pane (its plugin id). The status bar
+    /// then shows plugin-scoped info instead of file/item counts, and derives
+    /// the status indicator from that plugin's live signals.
+    pub active_plugin_id: Option<&'a str>,
 }
 
 /// Status indicator for the status bar
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatusBarStatus {
     Ready,
-    #[allow(dead_code)]
     Loading,
     Error,
     Searching,
@@ -95,6 +99,126 @@ pub enum StatusBarEvent {
 /// Output from status bar component
 pub struct StatusBarOutput {
     pub events: Vec<StatusBarEvent>,
+}
+
+/// Render the live plugin signals from the host [`SignalRegistry`] as compact,
+/// source-attributed chips: a status-colored dot, the plugin's short name, and
+/// each `key value`. Draws nothing when no plugin has emitted a signal.
+///
+/// [`SignalRegistry`]: crate::plugin::signals
+fn render_plugin_signals(ui: &mut egui::Ui) {
+    use crate::plugin::signals::SignalStatus;
+
+    let groups = crate::plugin::signals::snapshot();
+    if groups.is_empty() {
+        return;
+    }
+
+    let colors = ui.ctx().memory(|mem| {
+        mem.data
+            .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
+            .unwrap_or_else(|| {
+                let dark_mode = ui.ctx().global_style().visuals.dark_mode;
+                crate::theme::Theme::for_dark_mode(dark_mode).colors()
+            })
+    });
+
+    for group in groups {
+        // "com.thoth.seshat" → "seshat"
+        let short = group
+            .plugin_id
+            .rsplit('.')
+            .next()
+            .unwrap_or(group.plugin_id.as_str());
+        for sig in &group.signals {
+            ui.separator();
+            let dot_color = match sig.status {
+                SignalStatus::Ready => colors.success,
+                SignalStatus::Loading => colors.warning,
+                SignalStatus::Error => colors.error,
+            };
+            ui.colored_label(dot_color, "●");
+            let text = if sig.value.is_empty() {
+                format!("{} {}", short, sig.key)
+            } else {
+                format!("{} {} {}", short, sig.key, sig.value)
+            };
+            ui.label(text).on_hover_text(&group.plugin_id);
+        }
+    }
+}
+
+/// Render the active plugin pane's identity and its live signals as the primary
+/// status-bar content: a plug glyph, the plugin's short name, then `key value`
+/// chips (no per-chip source prefix, since the name is shown once). Used when a
+/// plugin tab is focused, in place of the file/item info.
+fn render_active_plugin_signals(ui: &mut egui::Ui, plugin_id: &str) {
+    use crate::plugin::signals::SignalStatus;
+
+    // "com.thoth.seshat" → "seshat"
+    let short = plugin_id.rsplit('.').next().unwrap_or(plugin_id);
+    ui.label(icon_rich_text(egui_phosphor::regular::PLUG, 12.0));
+    ui.label(short);
+
+    let groups = crate::plugin::signals::snapshot();
+    let Some(group) = groups.iter().find(|g| g.plugin_id == plugin_id) else {
+        return;
+    };
+
+    let colors = ui.ctx().memory(|mem| {
+        mem.data
+            .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
+            .unwrap_or_else(|| {
+                let dark_mode = ui.ctx().global_style().visuals.dark_mode;
+                crate::theme::Theme::for_dark_mode(dark_mode).colors()
+            })
+    });
+
+    for sig in &group.signals {
+        ui.separator();
+        let dot_color = match sig.status {
+            SignalStatus::Ready => colors.success,
+            SignalStatus::Loading => colors.warning,
+            SignalStatus::Error => colors.error,
+        };
+        ui.colored_label(dot_color, "●");
+        let text = if sig.value.is_empty() {
+            sig.key.clone()
+        } else {
+            format!("{} {}", sig.key, sig.value)
+        };
+        ui.label(text);
+    }
+}
+
+/// Aggregate a plugin's live signals into one status-bar indicator: `Error` if
+/// any signal is errored, else `Loading` if any is loading, else `Ready`.
+/// Returns `None` when the plugin has emitted no live signals (caller falls
+/// back to the default status).
+fn active_plugin_signal_status(plugin_id: &str) -> Option<StatusBarStatus> {
+    use crate::plugin::signals::SignalStatus;
+
+    let groups = crate::plugin::signals::snapshot();
+    let group = groups.iter().find(|g| g.plugin_id == plugin_id)?;
+    if group.signals.is_empty() {
+        return None;
+    }
+    let status = if group
+        .signals
+        .iter()
+        .any(|s| s.status == SignalStatus::Error)
+    {
+        StatusBarStatus::Error
+    } else if group
+        .signals
+        .iter()
+        .any(|s| s.status == SignalStatus::Loading)
+    {
+        StatusBarStatus::Loading
+    } else {
+        StatusBarStatus::Ready
+    };
+    Some(status)
 }
 
 impl ContextComponent for StatusBar {
@@ -200,53 +324,66 @@ impl ContextComponent for StatusBar {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing = egui::vec2(8.0, 0.0);
 
-                    // Filename with icon
-                    if let Some(path) = props.file_path {
-                        let filename = path
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or("Untitled");
-                        ui.label(icon_rich_text(egui_phosphor::regular::FILE_TEXT, 12.0));
-                        ui.label(filename);
-                        ui.separator();
-                    }
-
-                    // Item count with icon
-                    if let Some(filtered) = props.filtered_count {
-                        ui.label(icon_rich_text(egui_phosphor::regular::FUNNEL, 12.0));
-                        ui.label(format!("{} of {} items", filtered, props.item_count));
-                    } else if props.item_count > 0 {
-                        ui.label(icon_rich_text(egui_phosphor::regular::LIST_BULLETS, 12.0));
-                        ui.label(format!("{} items", props.item_count));
+                    if let Some(plugin_id) = props.active_plugin_id {
+                        // Plugin pane tab: file/item counts are meaningless here,
+                        // so show the plugin and its live signals instead.
+                        render_active_plugin_signals(ui, plugin_id);
                     } else {
-                        ui.label(icon_rich_text(egui_phosphor::regular::LIST_BULLETS, 12.0));
-                        ui.label("No items");
-                    }
+                        // File tab: filename, item count, file type, then any
+                        // background plugin signals, then breadcrumbs.
 
-                    ui.separator();
+                        // Filename with icon
+                        if let Some(path) = props.file_path {
+                            let filename = path
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .unwrap_or("Untitled");
+                            ui.label(icon_rich_text(egui_phosphor::regular::FILE_TEXT, 12.0));
+                            ui.label(filename);
+                            ui.separator();
+                        }
 
-                    // File type with icon
-                    let file_type_icon = match props.file_type {
-                        FileKind::Json => egui_phosphor::regular::BRACKETS_CURLY,
-                        FileKind::Ndjson => egui_phosphor::regular::LIST_DASHES,
-                        FileKind::Plugin => egui_phosphor::regular::PLUG,
-                        FileKind::PluginTable => egui_phosphor::regular::TABLE,
-                    };
-                    ui.label(icon_rich_text(file_type_icon, 12.0));
-                    ui.label(format!("{:?}", props.file_type));
+                        // Item count with icon
+                        if let Some(filtered) = props.filtered_count {
+                            ui.label(icon_rich_text(egui_phosphor::regular::FUNNEL, 12.0));
+                            ui.label(format!("{} of {} items", filtered, props.item_count));
+                        } else if props.item_count > 0 {
+                            ui.label(icon_rich_text(egui_phosphor::regular::LIST_BULLETS, 12.0));
+                            ui.label(format!("{} items", props.item_count));
+                        } else {
+                            ui.label(icon_rich_text(egui_phosphor::regular::LIST_BULLETS, 12.0));
+                            ui.label("No items");
+                        }
 
-                    // Breadcrumbs navigation
-                    if props.selected_path.is_some() {
                         ui.separator();
-                        let clicked = Breadcrumbs::builder()
-                            .maybe_path(props.selected_path.map(|s| s.to_string()))
-                            .build()
-                            .show(ui)
-                            .inner;
 
-                        // Convert breadcrumb click to status bar event
-                        if let Some(path) = clicked {
-                            events.push(StatusBarEvent::NavigateToPath(path));
+                        // File type with icon
+                        let file_type_icon = match props.file_type {
+                            FileKind::Json => egui_phosphor::regular::BRACKETS_CURLY,
+                            FileKind::Ndjson => egui_phosphor::regular::LIST_DASHES,
+                            FileKind::Plugin => egui_phosphor::regular::PLUG,
+                            FileKind::PluginTable => egui_phosphor::regular::TABLE,
+                        };
+                        ui.label(icon_rich_text(file_type_icon, 12.0));
+                        ui.label(format!("{:?}", props.file_type));
+
+                        // Live plugin signals (push channel), grouped by source.
+                        // Renders nothing when no plugin has emitted.
+                        render_plugin_signals(ui);
+
+                        // Breadcrumbs navigation
+                        if props.selected_path.is_some() {
+                            ui.separator();
+                            let clicked = Breadcrumbs::builder()
+                                .maybe_path(props.selected_path.map(|s| s.to_string()))
+                                .build()
+                                .show(ui)
+                                .inner;
+
+                            // Convert breadcrumb click to status bar event
+                            if let Some(path) = clicked {
+                                events.push(StatusBarEvent::NavigateToPath(path));
+                            }
                         }
                     }
 
@@ -256,8 +393,14 @@ impl ContextComponent for StatusBar {
                         ui.add_space(0.0);
                         self.notification_dropdown
                             .render(ui, NotificationDropdownProps {});
-                        let (icon, text) = props.status.icon_and_text();
-                        let status_color = props.status.color(ui.ctx());
+                        // On a plugin tab, reflect that plugin's aggregated signal
+                        // state (loading / error / ready); otherwise the file status.
+                        let status = props
+                            .active_plugin_id
+                            .and_then(active_plugin_signal_status)
+                            .unwrap_or(props.status);
+                        let (icon, text) = status.icon_and_text();
+                        let status_color = status.color(ui.ctx());
                         ui.colored_label(status_color, format!("{} {}", icon, text));
                     });
                 });

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -9,6 +9,7 @@ pub mod network_policy;
 pub mod plugin_registry;
 pub mod plugin_ui_host;
 pub mod render_node;
+pub mod signals;
 pub mod theme_plugin;
 pub mod wasm_data_source;
 pub mod wasm_file_viewer_loader;

--- a/src/plugin/signals.rs
+++ b/src/plugin/signals.rs
@@ -1,0 +1,186 @@
+//! Host-side registry for the plugin **signals** channel.
+//!
+//! Plugins push tiny status/metric key-values via the `signals` WIT import
+//! (see [`wasm_data_source`]); the host aggregates them here and the status bar
+//! renders them ([`crate::components::status_bar`]). This is the push half of
+//! the plugin data ecosystem (#110); the pull half — datasets — is a separate
+//! channel (#113/#114).
+//!
+//! Semantics (per issue #110):
+//! - **Last-write-wins** per `(plugin_id, key)`.
+//! - **TTL-expiring**: a signal with `ttl_ms > 0` disappears that long after it
+//!   was received; `ttl_ms == 0` is sticky until the plugin overwrites it.
+//! - **Source-attributed**: signals are grouped by the emitting plugin.
+//!
+//! The registry is a process-global behind a `Mutex`, mirroring the
+//! [`ConsentManager`](crate::consent::manager::ConsentManager) pattern: the
+//! plugin host writes to it during a WASM call (possibly on a worker thread) and
+//! the UI thread reads a snapshot each frame.
+//!
+//! [`wasm_data_source`]: crate::plugin::wasm_data_source
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+/// Health of a plugin's current activity, mirroring the `signals.status` WIT
+/// enum. Host-owned so the registry doesn't depend on any world's bindgen.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SignalStatus {
+    Ready,
+    Loading,
+    Error,
+}
+
+/// One live signal value.
+#[derive(Clone, Debug)]
+pub struct Signal {
+    pub key: String,
+    pub value: String,
+    pub status: SignalStatus,
+    /// When this signal expires; `None` = sticky.
+    expires_at: Option<Instant>,
+}
+
+impl Signal {
+    fn is_expired(&self, now: Instant) -> bool {
+        self.expires_at.is_some_and(|deadline| now >= deadline)
+    }
+}
+
+/// A plugin's live signals, for display (grouped by source).
+#[derive(Clone, Debug)]
+pub struct PluginSignals {
+    pub plugin_id: String,
+    pub signals: Vec<Signal>,
+}
+
+#[derive(Default)]
+struct Registry {
+    /// `(plugin_id, key)` → signal. Last-write-wins.
+    map: HashMap<(String, String), Signal>,
+    /// Stable insertion order of keys so the status bar doesn't reshuffle
+    /// every frame (HashMap iteration order is unspecified).
+    order: Vec<(String, String)>,
+}
+
+static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(Registry::default()));
+
+/// Record a signal pushed by `plugin_id`. `ttl_ms == 0` is sticky.
+pub fn emit(plugin_id: &str, key: String, value: String, status: SignalStatus, ttl_ms: u32) {
+    let expires_at = (ttl_ms > 0).then(|| Instant::now() + Duration::from_millis(ttl_ms as u64));
+    if let Ok(mut reg) = REGISTRY.lock() {
+        let id = (plugin_id.to_string(), key.clone());
+        if !reg.map.contains_key(&id) {
+            reg.order.push(id.clone());
+        }
+        reg.map.insert(
+            id,
+            Signal {
+                key,
+                value,
+                status,
+                expires_at,
+            },
+        );
+    }
+}
+
+/// Live (non-expired) signals grouped by plugin, in stable insertion order.
+/// Prunes expired entries as a side effect so the map doesn't grow unbounded.
+pub fn snapshot() -> Vec<PluginSignals> {
+    let now = Instant::now();
+    let Ok(mut reg) = REGISTRY.lock() else {
+        return Vec::new();
+    };
+
+    // Drop expired entries from both the map and the order list.
+    let expired: Vec<(String, String)> = reg
+        .map
+        .iter()
+        .filter(|(_, s)| s.is_expired(now))
+        .map(|(id, _)| id.clone())
+        .collect();
+    for id in expired {
+        reg.map.remove(&id);
+        reg.order.retain(|o| o != &id);
+    }
+
+    // Group by plugin, preserving first-seen order for both plugins and keys.
+    let mut groups: Vec<PluginSignals> = Vec::new();
+    for id in &reg.order {
+        let Some(sig) = reg.map.get(id) else { continue };
+        let (plugin_id, _) = id;
+        match groups.iter_mut().find(|g| &g.plugin_id == plugin_id) {
+            Some(g) => g.signals.push(sig.clone()),
+            None => groups.push(PluginSignals {
+                plugin_id: plugin_id.clone(),
+                signals: vec![sig.clone()],
+            }),
+        }
+    }
+    groups
+}
+
+/// Drop every signal emitted by `plugin_id` (e.g. when it is fully unloaded).
+#[allow(dead_code)] // wired up as plugin-lifecycle grows; harmless until then
+pub fn clear_plugin(plugin_id: &str) {
+    if let Ok(mut reg) = REGISTRY.lock() {
+        reg.map.retain(|(pid, _), _| pid != plugin_id);
+        reg.order.retain(|(pid, _)| pid != plugin_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The registry is a process-global; tests run in parallel, so serialize
+    // them and clear state up front under the same lock.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn reset() -> std::sync::MutexGuard<'static, ()> {
+        let guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        if let Ok(mut reg) = REGISTRY.lock() {
+            reg.map.clear();
+            reg.order.clear();
+        }
+        guard
+    }
+
+    #[test]
+    fn last_write_wins_per_key() {
+        let _guard = reset();
+        emit("p", "rows".into(), "1".into(), SignalStatus::Loading, 0);
+        emit("p", "rows".into(), "42".into(), SignalStatus::Ready, 0);
+        let snap = snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].signals.len(), 1);
+        assert_eq!(snap[0].signals[0].value, "42");
+        assert_eq!(snap[0].signals[0].status, SignalStatus::Ready);
+    }
+
+    #[test]
+    fn groups_by_plugin_in_stable_order() {
+        let _guard = reset();
+        emit("a", "x".into(), "1".into(), SignalStatus::Ready, 0);
+        emit("b", "y".into(), "2".into(), SignalStatus::Ready, 0);
+        emit("a", "z".into(), "3".into(), SignalStatus::Ready, 0);
+        let snap = snapshot();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].plugin_id, "a");
+        assert_eq!(snap[0].signals.len(), 2);
+        assert_eq!(snap[1].plugin_id, "b");
+    }
+
+    #[test]
+    fn clear_plugin_removes_its_signals() {
+        let _guard = reset();
+        emit("a", "x".into(), "1".into(), SignalStatus::Ready, 0);
+        emit("b", "y".into(), "2".into(), SignalStatus::Ready, 0);
+        clear_plugin("a");
+        let snap = snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].plugin_id, "b");
+    }
+}

--- a/src/plugin/signals.rs
+++ b/src/plugin/signals.rs
@@ -66,12 +66,42 @@ struct Registry {
 
 static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(Registry::default()));
 
-/// Record a signal pushed by `plugin_id`. `ttl_ms == 0` is sticky.
+// Bounds so a buggy or hostile (sandboxed) plugin can't grow the registry
+// without limit: at most this many distinct keys per plugin, and each key /
+// value truncated to this many bytes before storage. A `ttl_ms == 0` signal is
+// sticky, but its retained lifetime is still bounded — `retain_plugins` drops
+// it when the plugin's pane closes.
+const MAX_KEYS_PER_PLUGIN: usize = 16;
+const MAX_KEY_LEN: usize = 64;
+const MAX_VALUE_LEN: usize = 256;
+
+/// Truncate `s` to at most `max` bytes, landing on a char boundary.
+fn truncate_bytes(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
+/// Record a signal pushed by `plugin_id`. `ttl_ms == 0` is sticky. Over-long
+/// keys/values are truncated, and a new key beyond the per-plugin cap is
+/// dropped; last-write-wins on existing keys is unaffected.
 pub fn emit(plugin_id: &str, key: String, value: String, status: SignalStatus, ttl_ms: u32) {
+    let key = truncate_bytes(&key, MAX_KEY_LEN);
+    let value = truncate_bytes(&value, MAX_VALUE_LEN);
     let expires_at = (ttl_ms > 0).then(|| Instant::now() + Duration::from_millis(ttl_ms as u64));
     if let Ok(mut reg) = REGISTRY.lock() {
         let id = (plugin_id.to_string(), key.clone());
         if !reg.map.contains_key(&id) {
+            // Cap distinct keys per plugin; drop new keys past the limit.
+            let keys_for_plugin = reg.map.keys().filter(|(pid, _)| pid == plugin_id).count();
+            if keys_for_plugin >= MAX_KEYS_PER_PLUGIN {
+                return;
+            }
             reg.order.push(id.clone());
         }
         reg.map.insert(
@@ -122,12 +152,14 @@ pub fn snapshot() -> Vec<PluginSignals> {
     groups
 }
 
-/// Drop every signal emitted by `plugin_id` (e.g. when it is fully unloaded).
-#[allow(dead_code)] // wired up as plugin-lifecycle grows; harmless until then
-pub fn clear_plugin(plugin_id: &str) {
+/// Drop signals for every plugin **not** in `open`. Called each frame with the
+/// set of plugin ids that still have a live pane, so a closed pane's signals
+/// stop showing in the status bar. Windows are separate OS processes, so this
+/// process's `open` set is authoritative for its own registry.
+pub fn retain_plugins(open: &std::collections::HashSet<String>) {
     if let Ok(mut reg) = REGISTRY.lock() {
-        reg.map.retain(|(pid, _), _| pid != plugin_id);
-        reg.order.retain(|(pid, _)| pid != plugin_id);
+        reg.map.retain(|(pid, _), _| open.contains(pid));
+        reg.order.retain(|(pid, _)| open.contains(pid));
     }
 }
 
@@ -174,13 +206,30 @@ mod tests {
     }
 
     #[test]
-    fn clear_plugin_removes_its_signals() {
+    fn retain_plugins_drops_closed() {
         let _guard = reset();
         emit("a", "x".into(), "1".into(), SignalStatus::Ready, 0);
         emit("b", "y".into(), "2".into(), SignalStatus::Ready, 0);
-        clear_plugin("a");
+        let open = std::collections::HashSet::from(["b".to_string()]);
+        retain_plugins(&open);
         let snap = snapshot();
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].plugin_id, "b");
+    }
+
+    #[test]
+    fn caps_keys_per_plugin_and_truncates() {
+        let _guard = reset();
+        // One extra key beyond the cap is dropped.
+        for i in 0..(MAX_KEYS_PER_PLUGIN + 5) {
+            emit("p", format!("k{i}"), "v".into(), SignalStatus::Ready, 0);
+        }
+        let snap = snapshot();
+        assert_eq!(snap[0].signals.len(), MAX_KEYS_PER_PLUGIN);
+        // Over-long value is truncated to the byte cap.
+        emit("q", "big".into(), "x".repeat(1000), SignalStatus::Ready, 0);
+        let snap = snapshot();
+        let q = snap.iter().find(|g| g.plugin_id == "q").unwrap();
+        assert_eq!(q.signals[0].value.len(), MAX_VALUE_LEN);
     }
 }

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -701,6 +701,26 @@ impl thoth::plugin::db_runtime::Host for DataSourcePluginState {
     }
 }
 
+// ── signals WIT import — plugin PUSHes status/metric key-values ───────────────
+
+impl thoth::plugin::signals::Host for DataSourcePluginState {
+    fn emit_signal(
+        &mut self,
+        key: String,
+        value: String,
+        status: thoth::plugin::signals::Status,
+        ttl_ms: u32,
+    ) {
+        use crate::plugin::signals::SignalStatus;
+        let status = match status {
+            thoth::plugin::signals::Status::Ready => SignalStatus::Ready,
+            thoth::plugin::signals::Status::Loading => SignalStatus::Loading,
+            thoth::plugin::signals::Status::Error => SignalStatus::Error,
+        };
+        crate::plugin::signals::emit(&self.plugin_id, key, value, status, ttl_ms);
+    }
+}
+
 // ── file-dialog WIT import — native open/save pickers (host-mediated I/O) ─────
 
 fn fd_err(message: impl Into<String>) -> thoth::plugin::file_dialog::PluginError {
@@ -952,6 +972,14 @@ impl WasmDataSourceLoader {
 
         // 7. Register the file-dialog import (native open/save pickers).
         thoth::plugin::file_dialog::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s).map_err(
+            |e| ThothError::PluginLoadError {
+                path: wasm_path.to_path_buf(),
+                reason: e.to_string(),
+            },
+        )?;
+
+        // 8. Register the signals import (plugin PUSHes status-bar signals).
+        thoth::plugin::signals::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s).map_err(
             |e| ThothError::PluginLoadError {
                 path: wasm_path.to_path_buf(),
                 reason: e.to_string(),

--- a/wit/thoth-plugin.wit
+++ b/wit/thoth-plugin.wit
@@ -710,6 +710,28 @@ interface plugin-settings {
     render-settings: func() -> result<settings-output, plugin-error>;
 }
 
+// signals — host-provided import. Plugins PUSH tiny, high-frequency status /
+// metric key-values (connection health, row counts, latency); the host
+// aggregates them in a TTL registry and renders them in the status bar with
+// source attribution. Kept deliberately separate from the dataset channel
+// (#113/#114): signals carry a short string, never a record set, so a large
+// result never crosses this seam. Datasets are pulled paged; signals are
+// pushed fire-and-forget.
+interface signals {
+    /// Health of the emitting plugin's current activity.
+    enum status {
+        ready,
+        loading,
+        error,
+    }
+
+    /// Push a signal to the host. `key` / `value` are free-form so a new signal
+    /// needs no WIT change. `ttl-ms` is how long the host keeps the signal after
+    /// receipt (0 = sticky until the plugin overwrites it). Last-write-wins per
+    /// (plugin, key); the host stamps the source plugin id.
+    emit-signal: func(key: string, value: string, status: status, ttl-ms: u32);
+}
+
 
 /// Every plugin must satisfy this base world.
 world base-plugin {
@@ -762,6 +784,7 @@ world data-source-plugin {
     import tcp-client;
     import secure-storage;
     import db-runtime;
+    import signals;
     export data-source;
     export ui-component;
     export tab-host;


### PR DESCRIPTION
Flip the plugin signals design from pull to push, per #110. Plugins now PUSH tiny status/metric key-values to the host, which aggregates them in a TTL registry and surfaces them in the status bar with source attribution. Kept separate from the dataset (pull) channel #113/#114.

WIT: replace the `plugin-signals` export with a `signals` host import — `emit-signal(key, value, status, ttl-ms)`. Free-form key/value (no WIT change per new signal); dropped the fixed signal-kind enum and all-records (record sets belong to datasets).

Host:
- SignalRegistry (src/plugin/signals.rs): last-write-wins per (plugin, key), TTL-expiring, grouped snapshot. Unit-tested.
- Wire signals::add_to_linker + impl signals::Host for the data-source world (the missing linker registration would fail instantiation).
- Status bar renders live signals; on a plugin-pane tab it swaps the file/item info for the plugin's identity + signals, and derives the status indicator (loading/error/ready) from that plugin's signals.

Plugins: Seshat emits row-count/loading/error at the query lifecycle; url-source emits status+size/loading/error at the response lifecycle. Regenerated bindings.

Also hide egui_dock's thick (hardcoded 7.5px) tab-bar overflow scroll bar; overflowing tabs still scroll via wheel/trackpad.

closes #110 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live plugin signals for loading, ready, and error states.
  * Status bar now displays plugin-specific metrics and activity indicators.
  * Query execution reports loading, result counts, and errors.
  * HTTP actions report request progress, response status, and payload size.
  * Signals can expire automatically or remain visible until replaced.

* **UI Improvements**
  * Reduced tab-bar overflow scrolling in the central panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->