### PR TITLE
feat(seshat): connection/database/latency signals, instance-scoped (#111)

### DIFF
--- a/plugins/seshat/src/events.rs
+++ b/plugins/seshat/src/events.rs
@@ -18,6 +18,30 @@ fn parse_str(s: &str) -> String {
     serde_json::from_str::<String>(s).unwrap_or_else(|_| s.to_string())
 }
 
+// ── status-bar signals (#111) ───────────────────────────────────────────────
+
+/// The active connection's display name, falling back to its host.
+fn conn_label(st: &State) -> String {
+    st.active
+        .as_ref()
+        .and_then(|id| st.connections.iter().find(|c| &c.id == id))
+        .map(|c| c.name.clone())
+        .or_else(|| st.active_profile.as_ref().map(|p| p.host.clone()))
+        .unwrap_or_default()
+}
+
+/// Emit the active connection's health (connecting / connected / error).
+fn emit_conn(st: &State, status: SignalStatus) {
+    signals::emit_signal("conn", &conn_label(st), status, 0);
+}
+
+/// Emit the active database name (queries + autocomplete target).
+fn emit_db(st: &State) {
+    if let Some(db) = st.active_profile.as_ref().map(|p| p.database.as_str()) {
+        signals::emit_signal("db", db, SignalStatus::Ready, 0);
+    }
+}
+
 pub(crate) fn apply_event(st: &mut State, event: &UiEvent) {
     // Async results arrive as a synthetic "query-result" event.
     if event.kind == "query-result" {
@@ -350,8 +374,9 @@ fn execute_current(st: &mut State) {
     };
     st.loading = true;
     st.result = None;
+    st.query_started = Some(std::time::Instant::now());
     // Push a "running" signal to the host status bar; the result handler
-    // overwrites it with the row count (Ready) or an Error.
+    // overwrites it with the row count + latency (Ready) or an Error.
     signals::emit_signal("rows", "", SignalStatus::Loading, 0);
     let (sql, limited) = match sql::add_limit(&base, st.row_limit + 1) {
         Some(capped) => (capped, true),
@@ -475,6 +500,8 @@ fn load_databases(st: &mut State) {
     }
     st.databases_loaded = true;
     st.schema_error = None;
+    // Listing databases doubles as the connection probe; show "connecting".
+    emit_conn(st, SignalStatus::Loading);
     submit(&Request::ListDatabases, Kind::Databases, st);
 }
 
@@ -515,6 +542,7 @@ fn select_database(st: &mut State, database: &str) {
     }
     // The previous database's results no longer apply.
     st.result = None;
+    emit_db(st);
 
     // Make sure the new database's tables are loaded for autocomplete. If its
     // schemas aren't fetched yet, request them (the Schemas handler kicks off the
@@ -1099,6 +1127,7 @@ fn handle_query_result(st: &mut State, event: &UiEvent) {
             });
             // Surface the outcome as a status-bar signal: the returned row count
             // (with a "+" when more rows are available) or an error state.
+            let elapsed_ms = st.query_started.take().map(|t| t.elapsed().as_millis());
             match &st.result {
                 Some(Ok(value)) => {
                     let n = value
@@ -1106,10 +1135,15 @@ fn handle_query_result(st: &mut State, event: &UiEvent) {
                         .and_then(|r| r.as_array())
                         .map(|a| a.len())
                         .unwrap_or(0);
-                    let shown = if st.has_more {
+                    let count = if st.has_more {
                         format!("{n}+")
                     } else {
                         n.to_string()
+                    };
+                    // Include end-to-end latency when available: "100+ · 12 ms".
+                    let shown = match elapsed_ms {
+                        Some(ms) => format!("{count} · {ms} ms"),
+                        None => count,
                     };
                     signals::emit_signal("rows", &shown, SignalStatus::Ready, 0);
                 }
@@ -1139,6 +1173,9 @@ fn handle_query_result(st: &mut State, event: &UiEvent) {
                 st.schema_error = None;
                 st.error = None;
                 st.failed = None;
+                // Connection probe succeeded: surface connected + active database.
+                emit_conn(st, SignalStatus::Ready);
+                emit_db(st);
                 // Load the connection's configured database's schemas (then, in
                 // the Schemas handler, its tables — one at a time) so the SQL
                 // editor's autocomplete is populated. The tree stays collapsed:
@@ -1166,6 +1203,8 @@ fn handle_query_result(st: &mut State, event: &UiEvent) {
                 // surface it in the error modal and mark the connection as errored
                 // instead of leaving it active.
                 let msg = m.unwrap_or_else(|| "failed to connect".into());
+                // Emit the error signal before clearing `active` (needed for the label).
+                emit_conn(st, SignalStatus::Error);
                 st.failed = st.active.take();
                 st.active_profile = None;
                 st.databases.clear();

--- a/plugins/seshat/src/state.rs
+++ b/plugins/seshat/src/state.rs
@@ -203,6 +203,9 @@ pub(crate) struct State {
     // SQL editor / results
     pub sql: String,
     pub loading: bool,
+    /// When the in-flight query was dispatched, for the status-bar latency
+    /// signal. Runtime-only; measures end-to-end (submit → result) time.
+    pub query_started: Option<std::time::Instant>,
     /// In-flight async requests: `(request-id, kind)`. A Vec because schema
     /// introspection can run concurrently with (and alongside) a query.
     pub pending: Vec<(String, Kind)>,
@@ -286,6 +289,7 @@ impl State {
             test_status: None,
             sql: "SELECT 1 AS one;".into(),
             loading: false,
+            query_started: None,
             pending: Vec::new(),
             result: None,
             last_run_sql: None,

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -1387,16 +1387,20 @@ impl ThothApp {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
-        // Reconcile the process-global signal registry with the plugins that
-        // still have a live pane, so a closed pane's signals stop showing.
-        let open_plugins: std::collections::HashSet<String> = self
+        // Reconcile the process-global signal registry with the plugin instances
+        // that still have a live pane, so a closed pane's signals stop showing.
+        let open_instances: std::collections::HashSet<String> = self
             .window_state
             .tab_manager
             .tabs
             .values()
-            .filter_map(|t| t.active_plugin_pane.as_ref().map(|p| p.plugin_id.clone()))
+            .filter_map(|t| {
+                t.active_plugin_pane
+                    .as_ref()
+                    .map(|p| p.loader.instance_id().to_string())
+            })
             .collect();
-        crate::plugin::signals::retain_plugins(&open_plugins);
+        crate::plugin::signals::retain_instances(&open_instances);
 
         let (
             file_path_opt,
@@ -1419,8 +1423,12 @@ impl ThothApp {
                 None
             };
             let sel_path = tab.central_panel.get_selected_path().cloned();
-            // A plugin pane tab: its id drives the plugin-scoped status bar.
-            let plugin_id = tab.active_plugin_pane.as_ref().map(|p| p.plugin_id.clone());
+            // A plugin pane tab: (plugin_id, instance_id) drives the
+            // instance-scoped status bar.
+            let plugin_id = tab
+                .active_plugin_pane
+                .as_ref()
+                .map(|p| (p.plugin_id.clone(), p.loader.instance_id().to_string()));
             (
                 tab.file_path.clone(),
                 tab.file_type,
@@ -1465,7 +1473,9 @@ impl ThothApp {
                 filtered_count,
                 status,
                 selected_path: selected_path.as_deref(),
-                active_plugin_id: active_plugin_id.as_deref(),
+                active_plugin: active_plugin_id
+                    .as_ref()
+                    .map(|(p, i)| (p.as_str(), i.as_str())),
             },
         );
 

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -39,10 +39,11 @@ pub struct StatusBarProps<'a> {
     /// Currently selected path in the JSON (for breadcrumbs)
     pub selected_path: Option<&'a str>,
 
-    /// Set when the active tab is a plugin pane (its plugin id). The status bar
-    /// then shows plugin-scoped info instead of file/item counts, and derives
-    /// the status indicator from that plugin's live signals.
-    pub active_plugin_id: Option<&'a str>,
+    /// Set when the active tab is a plugin pane: `(plugin_id, instance_id)`. The
+    /// status bar then shows plugin-scoped info instead of file/item counts, and
+    /// derives the status indicator from that *instance's* live signals
+    /// (instance-scoped so two tabs of the same plugin stay independent).
+    pub active_plugin: Option<(&'a str, &'a str)>,
 }
 
 /// Status indicator for the status bar
@@ -152,7 +153,7 @@ fn render_plugin_signals(ui: &mut egui::Ui) {
 /// status-bar content: a plug glyph, the plugin's short name, then `key value`
 /// chips (no per-chip source prefix, since the name is shown once). Used when a
 /// plugin tab is focused, in place of the file/item info.
-fn render_active_plugin_signals(ui: &mut egui::Ui, plugin_id: &str) {
+fn render_active_plugin_signals(ui: &mut egui::Ui, plugin_id: &str, instance_id: &str) {
     use crate::plugin::signals::SignalStatus;
 
     // "com.thoth.seshat" → "seshat"
@@ -160,8 +161,9 @@ fn render_active_plugin_signals(ui: &mut egui::Ui, plugin_id: &str) {
     ui.label(icon_rich_text(egui_phosphor::regular::PLUG, 12.0));
     ui.label(short);
 
+    // Scope to this instance so two tabs of the same plugin stay independent.
     let groups = crate::plugin::signals::snapshot();
-    let Some(group) = groups.iter().find(|g| g.plugin_id == plugin_id) else {
+    let Some(group) = groups.iter().find(|g| g.instance_id == instance_id) else {
         return;
     };
 
@@ -195,11 +197,11 @@ fn render_active_plugin_signals(ui: &mut egui::Ui, plugin_id: &str) {
 /// any signal is errored, else `Loading` if any is loading, else `Ready`.
 /// Returns `None` when the plugin has emitted no live signals (caller falls
 /// back to the default status).
-fn active_plugin_signal_status(plugin_id: &str) -> Option<StatusBarStatus> {
+fn active_plugin_signal_status(instance_id: &str) -> Option<StatusBarStatus> {
     use crate::plugin::signals::SignalStatus;
 
     let groups = crate::plugin::signals::snapshot();
-    let group = groups.iter().find(|g| g.plugin_id == plugin_id)?;
+    let group = groups.iter().find(|g| g.instance_id == instance_id)?;
     if group.signals.is_empty() {
         return None;
     }
@@ -324,10 +326,10 @@ impl ContextComponent for StatusBar {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing = egui::vec2(8.0, 0.0);
 
-                    if let Some(plugin_id) = props.active_plugin_id {
+                    if let Some((plugin_id, instance_id)) = props.active_plugin {
                         // Plugin pane tab: file/item counts are meaningless here,
                         // so show the plugin and its live signals instead.
-                        render_active_plugin_signals(ui, plugin_id);
+                        render_active_plugin_signals(ui, plugin_id, instance_id);
                     } else {
                         // File tab: filename, item count, file type, then any
                         // background plugin signals, then breadcrumbs.
@@ -396,8 +398,8 @@ impl ContextComponent for StatusBar {
                         // On a plugin tab, reflect that plugin's aggregated signal
                         // state (loading / error / ready); otherwise the file status.
                         let status = props
-                            .active_plugin_id
-                            .and_then(active_plugin_signal_status)
+                            .active_plugin
+                            .and_then(|(_, instance_id)| active_plugin_signal_status(instance_id))
                             .unwrap_or(props.status);
                         let (icon, text) = status.icon_and_text();
                         let status_color = status.color(ui.ctx());

--- a/src/plugin/plugin_ui_host.rs
+++ b/src/plugin/plugin_ui_host.rs
@@ -93,6 +93,13 @@ impl TabOpenRequest {
 pub trait PluginUiHost: Send {
     fn plugin_id(&self) -> &str;
 
+    /// Unique id for this plugin *instance* (pane). Defaults to `plugin_id` for
+    /// loaders that don't need per-instance identity; data-source loaders
+    /// override it so two tabs of the same plugin keep separate status signals.
+    fn instance_id(&self) -> &str {
+        self.plugin_id()
+    }
+
     fn render_ui(&self) -> Result<UiOutput>;
     fn handle_event(&self, event: UiEvent) -> Result<UiOutput>;
     fn render_sidebar(&self) -> Result<Option<UiOutput>>;

--- a/src/plugin/signals.rs
+++ b/src/plugin/signals.rs
@@ -6,11 +6,13 @@
 //! the plugin data ecosystem (#110); the pull half — datasets — is a separate
 //! channel (#113/#114).
 //!
-//! Semantics (per issue #110):
-//! - **Last-write-wins** per `(plugin_id, key)`.
+//! Semantics (per issue #110, extended for #111):
+//! - **Last-write-wins** per `(instance_id, key)` — keyed by plugin *instance*
+//!   (pane), so two tabs of the same plugin keep independent status.
 //! - **TTL-expiring**: a signal with `ttl_ms > 0` disappears that long after it
 //!   was received; `ttl_ms == 0` is sticky until the plugin overwrites it.
-//! - **Source-attributed**: signals are grouped by the emitting plugin.
+//! - **Source-attributed**: each signal carries its `plugin_id` for display;
+//!   signals are grouped by instance.
 //!
 //! The registry is a process-global behind a `Mutex`, mirroring the
 //! [`ConsentManager`](crate::consent::manager::ConsentManager) pattern: the
@@ -38,6 +40,8 @@ pub struct Signal {
     pub key: String,
     pub value: String,
     pub status: SignalStatus,
+    /// Source plugin id, for the display label (the registry keys on instance).
+    pub plugin_id: String,
     /// When this signal expires; `None` = sticky.
     expires_at: Option<Instant>,
 }
@@ -48,16 +52,18 @@ impl Signal {
     }
 }
 
-/// A plugin's live signals, for display (grouped by source).
+/// One plugin instance's live signals, for display (grouped by instance so two
+/// tabs of the same plugin stay independent).
 #[derive(Clone, Debug)]
 pub struct PluginSignals {
+    pub instance_id: String,
     pub plugin_id: String,
     pub signals: Vec<Signal>,
 }
 
 #[derive(Default)]
 struct Registry {
-    /// `(plugin_id, key)` → signal. Last-write-wins.
+    /// `(instance_id, key)` → signal. Last-write-wins per instance+key.
     map: HashMap<(String, String), Signal>,
     /// Stable insertion order of keys so the status bar doesn't reshuffle
     /// every frame (HashMap iteration order is unspecified).
@@ -67,11 +73,11 @@ struct Registry {
 static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(Registry::default()));
 
 // Bounds so a buggy or hostile (sandboxed) plugin can't grow the registry
-// without limit: at most this many distinct keys per plugin, and each key /
+// without limit: at most this many distinct keys per instance, and each key /
 // value truncated to this many bytes before storage. A `ttl_ms == 0` signal is
-// sticky, but its retained lifetime is still bounded — `retain_plugins` drops
+// sticky, but its retained lifetime is still bounded — `retain_instances` drops
 // it when the plugin's pane closes.
-const MAX_KEYS_PER_PLUGIN: usize = 16;
+const MAX_KEYS_PER_INSTANCE: usize = 16;
 const MAX_KEY_LEN: usize = 64;
 const MAX_VALUE_LEN: usize = 256;
 
@@ -87,19 +93,27 @@ fn truncate_bytes(s: &str, max: usize) -> String {
     s[..end].to_string()
 }
 
-/// Record a signal pushed by `plugin_id`. `ttl_ms == 0` is sticky. Over-long
-/// keys/values are truncated, and a new key beyond the per-plugin cap is
-/// dropped; last-write-wins on existing keys is unaffected.
-pub fn emit(plugin_id: &str, key: String, value: String, status: SignalStatus, ttl_ms: u32) {
+/// Record a signal pushed by plugin instance `instance_id` (of plugin
+/// `plugin_id`). `ttl_ms == 0` is sticky. Over-long keys/values are truncated,
+/// and a new key beyond the per-instance cap is dropped; last-write-wins on
+/// existing keys is unaffected.
+pub fn emit(
+    instance_id: &str,
+    plugin_id: &str,
+    key: String,
+    value: String,
+    status: SignalStatus,
+    ttl_ms: u32,
+) {
     let key = truncate_bytes(&key, MAX_KEY_LEN);
     let value = truncate_bytes(&value, MAX_VALUE_LEN);
     let expires_at = (ttl_ms > 0).then(|| Instant::now() + Duration::from_millis(ttl_ms as u64));
     if let Ok(mut reg) = REGISTRY.lock() {
-        let id = (plugin_id.to_string(), key.clone());
+        let id = (instance_id.to_string(), key.clone());
         if !reg.map.contains_key(&id) {
-            // Cap distinct keys per plugin; drop new keys past the limit.
-            let keys_for_plugin = reg.map.keys().filter(|(pid, _)| pid == plugin_id).count();
-            if keys_for_plugin >= MAX_KEYS_PER_PLUGIN {
+            // Cap distinct keys per instance; drop new keys past the limit.
+            let keys_for_instance = reg.map.keys().filter(|(iid, _)| iid == instance_id).count();
+            if keys_for_instance >= MAX_KEYS_PER_INSTANCE {
                 return;
             }
             reg.order.push(id.clone());
@@ -110,13 +124,14 @@ pub fn emit(plugin_id: &str, key: String, value: String, status: SignalStatus, t
                 key,
                 value,
                 status,
+                plugin_id: plugin_id.to_string(),
                 expires_at,
             },
         );
     }
 }
 
-/// Live (non-expired) signals grouped by plugin, in stable insertion order.
+/// Live (non-expired) signals grouped by instance, in stable insertion order.
 /// Prunes expired entries as a side effect so the map doesn't grow unbounded.
 pub fn snapshot() -> Vec<PluginSignals> {
     let now = Instant::now();
@@ -136,15 +151,16 @@ pub fn snapshot() -> Vec<PluginSignals> {
         reg.order.retain(|o| o != &id);
     }
 
-    // Group by plugin, preserving first-seen order for both plugins and keys.
+    // Group by instance, preserving first-seen order for both instances and keys.
     let mut groups: Vec<PluginSignals> = Vec::new();
     for id in &reg.order {
         let Some(sig) = reg.map.get(id) else { continue };
-        let (plugin_id, _) = id;
-        match groups.iter_mut().find(|g| &g.plugin_id == plugin_id) {
+        let (instance_id, _) = id;
+        match groups.iter_mut().find(|g| &g.instance_id == instance_id) {
             Some(g) => g.signals.push(sig.clone()),
             None => groups.push(PluginSignals {
-                plugin_id: plugin_id.clone(),
+                instance_id: instance_id.clone(),
+                plugin_id: sig.plugin_id.clone(),
                 signals: vec![sig.clone()],
             }),
         }
@@ -152,14 +168,14 @@ pub fn snapshot() -> Vec<PluginSignals> {
     groups
 }
 
-/// Drop signals for every plugin **not** in `open`. Called each frame with the
-/// set of plugin ids that still have a live pane, so a closed pane's signals
-/// stop showing in the status bar. Windows are separate OS processes, so this
-/// process's `open` set is authoritative for its own registry.
-pub fn retain_plugins(open: &std::collections::HashSet<String>) {
+/// Drop signals for every plugin instance **not** in `open`. Called each frame
+/// with the set of instance ids that still have a live pane, so a closed pane's
+/// signals stop showing in the status bar. Windows are separate OS processes,
+/// so this process's `open` set is authoritative for its own registry.
+pub fn retain_instances(open: &std::collections::HashSet<String>) {
     if let Ok(mut reg) = REGISTRY.lock() {
-        reg.map.retain(|(pid, _), _| open.contains(pid));
-        reg.order.retain(|(pid, _)| open.contains(pid));
+        reg.map.retain(|(iid, _), _| open.contains(iid));
+        reg.order.retain(|(iid, _)| open.contains(iid));
     }
 }
 
@@ -183,8 +199,22 @@ mod tests {
     #[test]
     fn last_write_wins_per_key() {
         let _guard = reset();
-        emit("p", "rows".into(), "1".into(), SignalStatus::Loading, 0);
-        emit("p", "rows".into(), "42".into(), SignalStatus::Ready, 0);
+        emit(
+            "p#1",
+            "p",
+            "rows".into(),
+            "1".into(),
+            SignalStatus::Loading,
+            0,
+        );
+        emit(
+            "p#1",
+            "p",
+            "rows".into(),
+            "42".into(),
+            SignalStatus::Ready,
+            0,
+        );
         let snap = snapshot();
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].signals.len(), 1);
@@ -193,43 +223,73 @@ mod tests {
     }
 
     #[test]
-    fn groups_by_plugin_in_stable_order() {
+    fn same_plugin_different_instances_stay_separate() {
         let _guard = reset();
-        emit("a", "x".into(), "1".into(), SignalStatus::Ready, 0);
-        emit("b", "y".into(), "2".into(), SignalStatus::Ready, 0);
-        emit("a", "z".into(), "3".into(), SignalStatus::Ready, 0);
+        // Two tabs of the same plugin must not clobber each other.
+        emit(
+            "seshat#1",
+            "seshat",
+            "rows".into(),
+            "10".into(),
+            SignalStatus::Ready,
+            0,
+        );
+        emit(
+            "seshat#2",
+            "seshat",
+            "rows".into(),
+            "20".into(),
+            SignalStatus::Ready,
+            0,
+        );
         let snap = snapshot();
         assert_eq!(snap.len(), 2);
-        assert_eq!(snap[0].plugin_id, "a");
-        assert_eq!(snap[0].signals.len(), 2);
-        assert_eq!(snap[1].plugin_id, "b");
+        assert_eq!(snap[0].instance_id, "seshat#1");
+        assert_eq!(snap[0].plugin_id, "seshat");
+        assert_eq!(snap[0].signals[0].value, "10");
+        assert_eq!(snap[1].instance_id, "seshat#2");
+        assert_eq!(snap[1].signals[0].value, "20");
     }
 
     #[test]
-    fn retain_plugins_drops_closed() {
+    fn retain_instances_drops_closed() {
         let _guard = reset();
-        emit("a", "x".into(), "1".into(), SignalStatus::Ready, 0);
-        emit("b", "y".into(), "2".into(), SignalStatus::Ready, 0);
-        let open = std::collections::HashSet::from(["b".to_string()]);
-        retain_plugins(&open);
+        emit("a#1", "a", "x".into(), "1".into(), SignalStatus::Ready, 0);
+        emit("b#1", "b", "y".into(), "2".into(), SignalStatus::Ready, 0);
+        let open = std::collections::HashSet::from(["b#1".to_string()]);
+        retain_instances(&open);
         let snap = snapshot();
         assert_eq!(snap.len(), 1);
-        assert_eq!(snap[0].plugin_id, "b");
+        assert_eq!(snap[0].instance_id, "b#1");
     }
 
     #[test]
-    fn caps_keys_per_plugin_and_truncates() {
+    fn caps_keys_per_instance_and_truncates() {
         let _guard = reset();
         // One extra key beyond the cap is dropped.
-        for i in 0..(MAX_KEYS_PER_PLUGIN + 5) {
-            emit("p", format!("k{i}"), "v".into(), SignalStatus::Ready, 0);
+        for i in 0..(MAX_KEYS_PER_INSTANCE + 5) {
+            emit(
+                "p#1",
+                "p",
+                format!("k{i}"),
+                "v".into(),
+                SignalStatus::Ready,
+                0,
+            );
         }
         let snap = snapshot();
-        assert_eq!(snap[0].signals.len(), MAX_KEYS_PER_PLUGIN);
+        assert_eq!(snap[0].signals.len(), MAX_KEYS_PER_INSTANCE);
         // Over-long value is truncated to the byte cap.
-        emit("q", "big".into(), "x".repeat(1000), SignalStatus::Ready, 0);
+        emit(
+            "q#1",
+            "q",
+            "big".into(),
+            "x".repeat(1000),
+            SignalStatus::Ready,
+            0,
+        );
         let snap = snapshot();
-        let q = snap.iter().find(|g| g.plugin_id == "q").unwrap();
+        let q = snap.iter().find(|g| g.instance_id == "q#1").unwrap();
         assert_eq!(q.signals[0].value.len(), MAX_VALUE_LEN);
     }
 }

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -60,6 +60,17 @@ use crate::plugin::plugin_ui_host::{PluginHttpRequest, PluginUiHost, TabOpenRequ
 
 static REQUEST_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
+/// Distinguishes plugin *instances* (e.g. two open Seshat tabs) so their
+/// status-bar signals don't collide — the registry keys on this, not plugin_id.
+static INSTANCE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+fn next_instance_id(plugin_id: &str) -> String {
+    format!(
+        "{plugin_id}#{}",
+        INSTANCE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    )
+}
+
 fn next_request_id() -> String {
     format!(
         "req-{}",
@@ -128,6 +139,9 @@ struct DataSourcePluginState {
     table: ResourceTable,
     policy: NetworkPolicy,
     plugin_id: String,
+    /// Unique per plugin instance (this Store). Registry key for signals so two
+    /// tabs of the same plugin keep separate status.
+    instance_id: String,
     consent_tx: std::sync::mpsc::Sender<ConsentRequest>,
     // Channel used by submit() to deliver async HTTP results back to the host.
     http_tx: std::sync::mpsc::Sender<(String, HttpCallResult)>,
@@ -717,7 +731,14 @@ impl thoth::plugin::signals::Host for DataSourcePluginState {
             thoth::plugin::signals::Status::Loading => SignalStatus::Loading,
             thoth::plugin::signals::Status::Error => SignalStatus::Error,
         };
-        crate::plugin::signals::emit(&self.plugin_id, key, value, status, ttl_ms);
+        crate::plugin::signals::emit(
+            &self.instance_id,
+            &self.plugin_id,
+            key,
+            value,
+            status,
+            ttl_ms,
+        );
     }
 }
 
@@ -849,6 +870,9 @@ pub struct WasmDataSourceLoader {
     /// In-flight async queries (for repaint-while-pending).
     query_pending: Arc<AtomicUsize>,
     plugin_id: String,
+    /// Unique per instance; exposed via `PluginUiHost::instance_id` so the host
+    /// can scope this pane's signals and reconcile them on close.
+    instance_id: String,
     /// Last rendered sidebar/main-UI trees. When a query worker owns the Store
     /// (a blocking DB query is running), the render path reuses these instead of
     /// blocking the UI thread on the Store mutex.
@@ -884,11 +908,14 @@ impl WasmDataSourceLoader {
         let query_pending = Arc::new(AtomicUsize::new(0));
         let retry_tx_shared = Arc::new(Mutex::new(retry_tx));
 
+        let instance_id = next_instance_id(&plugin_id);
+
         let state = DataSourcePluginState {
             wasi,
             table: ResourceTable::new(),
             policy,
             plugin_id: plugin_id.clone(),
+            instance_id: instance_id.clone(),
             consent_tx,
             http_tx,
             pending_count: Arc::clone(&pending_count),
@@ -1006,6 +1033,7 @@ impl WasmDataSourceLoader {
             query_result_rx,
             query_pending,
             plugin_id,
+            instance_id,
             last_sidebar: Mutex::new(None),
             last_ui: Mutex::new(None),
         };
@@ -1452,6 +1480,10 @@ fn plugin_req_to_http(r: PluginHttpRequest) -> thoth::plugin::http_client::HttpR
 impl PluginUiHost for WasmDataSourceLoader {
     fn plugin_id(&self) -> &str {
         WasmDataSourceLoader::plugin_id(self)
+    }
+
+    fn instance_id(&self) -> &str {
+        &self.instance_id
     }
 
     fn render_ui(&self) -> Result<UiOutput> {


### PR DESCRIPTION
Seshat now emits the full status-bar signal set: connection health (connecting → connected → error), the active database, and last-query rows + end-to-end latency. Connection/db come from the Databases probe and database switch; latency is measured submit→result via a runtime query_started Instant (works on wasip1 via WASI clocks).

Signals are now keyed by plugin *instance*, not plugin_id, so two open Seshat tabs keep independent status:
- Each data-source pane gets a unique instance id (INSTANCE_COUNTER), exposed via PluginUiHost::instance_id and stamped by the host when a plugin emits.
- Registry keys on (instance_id, key); each signal carries plugin_id for the display label; snapshot groups by instance; retain_instances reconciles against open panes; per-instance key cap.
- Status bar scopes the active-tab view and status dot to the instance.

Plugin-facing WIT/emit-signal is unchanged — instance identity is derived host-side, so no plugin ABI change.

Closes #111.