### PR TITLE
feat(editor): SQL format action, smaller tooltips, results copy menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6006,6 +6006,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2 0.10.9",
+ "sqlformat",
  "thoth-plugin-sdk",
  "wit-bindgen-rt",
 ]
@@ -6238,6 +6239,16 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0705994df478b895f05b8e290e0d46e53187b26f8d889d37b2a0881234922d94"
+dependencies = [
+ "unicode_categories",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -7014,6 +7025,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/plugins/seshat/Cargo.toml
+++ b/plugins/seshat/Cargo.toml
@@ -25,6 +25,7 @@ sha2 = "0.10"
 # with the server's public key. `rand` (getrandom's wasi backend) seeds OAEP.
 rsa = { version = "0.9", features = ["pem"] }
 rand = "0.8"
+sqlformat = "0.5.0"
 # Type-safe UI DSL builders (no egui — plugins only describe UI, never render).
 thoth-plugin-sdk = { path = "../../thoth-plugin-sdk", features = ["plugin"] }
 

--- a/plugins/seshat/src/events.rs
+++ b/plugins/seshat/src/events.rs
@@ -243,10 +243,13 @@ pub(crate) fn apply_event(st: &mut State, event: &UiEvent) {
         }
         // Editor events: "change" carries the new SQL; "run" is a keyboard
         // shortcut (⌘Enter = statement at caret / selection, ⌘⇧Enter = all);
-        // "run-marker" is a ▶ gutter click carrying a statement's char offset.
+        // "run-marker" is a ▶ gutter click carrying a statement's char offset;
+        // "format-editor" is the ⌥⇧F format shortcut (the SDK emits it on the
+        // editor's id, unlike the toolbar button which emits its own click).
         "sql" => match event.kind.as_str() {
             "change" => st.sql = parse_str(&event.value),
             "run" => run_editor(st, &event.value),
+            "format-editor" => format_query(st),
             "run-marker" => {
                 if let Ok(offset) = event.value.parse::<usize>() {
                     if let Some(text) = sql::statement_at(&st.sql, offset) {
@@ -275,8 +278,14 @@ pub(crate) fn apply_event(st: &mut State, event: &UiEvent) {
         "save-query" => save_query(st),
         // Load a .sql file the user picks into the editor.
         "open-query" => open_query(st),
+        "format-editor" => format_query(st),
         _ => {}
     }
+}
+
+fn format_query(st: &mut State) {
+    use sqlformat::{format, FormatOptions, QueryParams};
+    st.sql = format(&st.sql, &QueryParams::default(), &FormatOptions::default());
 }
 
 /// Save the editor's SQL to a `.sql` file via the host's native save dialog.

--- a/plugins/seshat/src/lib.rs
+++ b/plugins/seshat/src/lib.rs
@@ -45,7 +45,8 @@ pub(crate) const ICON_KEY: &str = "\u{E2D6}";
 pub(crate) const ICON_CIRCLE: &str = "\u{E18A}";
 pub(crate) const ICON_FLOPPY_DISK: &str = "\u{E248}"; // save query to a .sql file
 pub(crate) const ICON_FOLDER_OPEN: &str = "\u{E256}"; // open a .sql file
-                                                      // structure-view glyphs
+pub(crate) const ICON_FORMAT: &str = "\u{E48A}"; // format the SQL query
+                                                 // structure-view glyphs
 pub(crate) const ICON_LINK: &str = "\u{E2E2}"; // foreign key
 pub(crate) const ICON_LIST_NUMBERS: &str = "\u{E2F6}"; // index
 pub(crate) const ICON_FINGERPRINT: &str = "\u{E23E}"; // unique constraint

--- a/plugins/seshat/src/ui/editor.rs
+++ b/plugins/seshat/src/ui/editor.rs
@@ -37,11 +37,9 @@ pub(crate) fn editor_view(st: &State) -> RenderNode {
         .map(|s| s.start)
         .collect();
 
-    let format_button_tooltip_shortcut = if cfg!(target_os = "macos") {
-        String::from("⌥⇧F")
-    } else {
-        String::from("Alt + Shift + F")
-    };
+    // The plugin is compiled to wasm and can't detect the host OS, so use one
+    // representation for all platforms (⌥ = Option/Alt on macOS).
+    let format_button_tooltip_shortcut = "⌥/Alt + ⇧ + F";
 
     RenderNode::Column(
         Column::builder()

--- a/plugins/seshat/src/ui/editor.rs
+++ b/plugins/seshat/src/ui/editor.rs
@@ -9,7 +9,7 @@ use thoth_plugin_sdk::render_node::RenderNode;
 use crate::constants::{KEYWORDS, SPECIAL, TYPES};
 use crate::state::State;
 use crate::ui::results::results_view;
-use crate::{ICON_FLOPPY_DISK, ICON_FOLDER_OPEN, ICON_PLAY};
+use crate::{ICON_FLOPPY_DISK, ICON_FOLDER_OPEN, ICON_FORMAT, ICON_PLAY};
 
 pub(crate) fn editor_view(st: &State) -> RenderNode {
     // The database this editor queries against — also what autocomplete is
@@ -36,6 +36,12 @@ pub(crate) fn editor_view(st: &State) -> RenderNode {
         .into_iter()
         .map(|s| s.start)
         .collect();
+
+    let format_button_tooltip_shortcut = if cfg!(target_os = "macos") {
+        String::from("⌥⇧F")
+    } else {
+        String::from("Alt + Shift + F")
+    };
 
     RenderNode::Column(
         Column::builder()
@@ -120,6 +126,18 @@ pub(crate) fn editor_view(st: &State) -> RenderNode {
                                     .frame(true)
                                     .size(Size::Small)
                                     .tooltip("Open a .sql file")
+                                    .build(),
+                            ),
+                            RenderNode::IconButton(
+                                IconButton::builder()
+                                    .id("format-editor")
+                                    .icon(ICON_FORMAT)
+                                    .frame(true)
+                                    .size(Size::Small)
+                                    .tooltip(format!(
+                                        "Format the SQL query ({})",
+                                        format_button_tooltip_shortcut
+                                    ))
                                     .build(),
                             ),
                         ])

--- a/src/components/settings_dialog/mod.rs
+++ b/src/components/settings_dialog/mod.rs
@@ -910,7 +910,8 @@ impl ContextComponent for SettingsDialog {
                                     {
                                         let _ = open::that(path);
                                     }
-                                    btn.on_hover_text(
+                                    thoth_plugin_sdk::theme::hover_text(
+                                        btn,
                                         crate::settings::Settings::settings_file_path()
                                             .map(|p| p.to_string_lossy().to_string())
                                             .unwrap_or_default(),

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -144,7 +144,7 @@ fn render_plugin_signals(ui: &mut egui::Ui) {
             } else {
                 format!("{} {} {}", short, sig.key, sig.value)
             };
-            ui.label(text).on_hover_text(&group.plugin_id);
+            thoth_plugin_sdk::theme::hover_text(ui.label(text), group.plugin_id.as_str());
         }
     }
 }

--- a/thoth-plugin-sdk/src/components/breadcrumbs/ui.rs
+++ b/thoth-plugin-sdk/src/components/breadcrumbs/ui.rs
@@ -67,8 +67,9 @@ impl Breadcrumbs {
                                 .join(delim);
                             let resp = ui
                                 .link(RichText::new(&segment.display).size(12.0).color(colors.fg))
-                                .on_hover_cursor(CursorIcon::PointingHand)
-                                .on_hover_text(format!("Navigate to {path}"));
+                                .on_hover_cursor(CursorIcon::PointingHand);
+                            let resp =
+                                crate::theme::hover_text(resp, format!("Navigate to {path}"));
                             if resp.clicked() {
                                 selected = Some(path);
                             }

--- a/thoth-plugin-sdk/src/components/button/ui.rs
+++ b/thoth-plugin-sdk/src/components/button/ui.rs
@@ -192,7 +192,7 @@ impl egui::Widget for Button {
             .inner;
 
         if let Some(hover_text) = self.hover_text {
-            response = response.on_hover_text(hover_text);
+            response = crate::theme::hover_text(response, hover_text);
         }
 
         // Copy-to-clipboard on click, handled in-widget.

--- a/thoth-plugin-sdk/src/components/code_editor/mod.rs
+++ b/thoth-plugin-sdk/src/components/code_editor/mod.rs
@@ -123,6 +123,8 @@ pub struct CodeEditorOutput {
     pub run: Option<RunRequest>,
     /// Character offset of a clicked run-marker (▶ gutter button), if any.
     pub run_marker: Option<usize>,
+    /// Set when the user pressed a format shortcut (Option/Alt+Shift+F).
+    pub format: Option<()>,
 }
 
 /// Intern a runtime string into a `&'static str`, deduping so repeated calls
@@ -268,6 +270,10 @@ impl CodeEditor {
                     let words_fingerprint = self.words_fingerprint();
                     let completer_id =
                         ui.make_persistent_id(("sdk_code_editor_completer", id_source.as_str()));
+                    // Focus flag id (computed here while `id_source` is still
+                    // owned; it's moved into the editor below).
+                    let focus_id =
+                        ui.make_persistent_id(("sdk_code_editor_focus", id_source.as_str()));
                     let mut completer = ui
                         .ctx()
                         .memory(|m| m.data.get_temp::<(u64, Completer)>(completer_id))
@@ -309,6 +315,50 @@ impl CodeEditor {
                             }
                         });
                     }
+
+                    // Format shortcut (Option/Alt+Shift+F, matching VS Code).
+                    // Must run BEFORE the text editor consumes input: on macOS
+                    // the Option key is a *compose* modifier, so the OS turns
+                    // Option+Shift+F into the character "Ï" and delivers it as an
+                    // `Event::Text` that the TextEdit would otherwise insert.
+                    // Detect by PHYSICAL key — the logical key is mangled by
+                    // composition, so `consume_key(Key::F, …)` never matches on
+                    // macOS — then drop both the key and the composed text this
+                    // frame so nothing is typed.
+                    //
+                    // Gated on this editor having had focus last frame: with
+                    // several editors visible side-by-side (split tabs) they all
+                    // render each frame and read the same global input, so an
+                    // unguarded consume would route the shortcut to whichever
+                    // renders last, not the one the user is typing in. Focus is
+                    // only known after `show()`, so we use the previous frame's
+                    // value (a keypress can't land the same frame focus changes).
+                    let had_focus = ui
+                        .ctx()
+                        .memory(|m| m.data.get_temp::<bool>(focus_id).unwrap_or(false));
+                    let format = if had_focus {
+                        ui.input_mut(|i| {
+                            let is_fmt = |e: &egui::Event| {
+                                matches!(
+                                    e,
+                                    egui::Event::Key { key, physical_key, pressed: true, modifiers, .. }
+                                        if modifiers.alt
+                                            && modifiers.shift
+                                            && (*key == egui::Key::F
+                                                || *physical_key == Some(egui::Key::F))
+                                )
+                            };
+                            let hit = i.events.iter().any(is_fmt);
+                            if hit {
+                                i.events
+                                    .retain(|e| !(is_fmt(e) || matches!(e, egui::Event::Text(_))));
+                            }
+                            hit
+                        })
+                        .then_some(())
+                    } else {
+                        None
+                    };
 
                     let output = editor.show_with_completer(ui, &mut self.value, &mut completer);
                     let changed = output.response.changed();
@@ -352,7 +402,11 @@ impl CodeEditor {
                         None
                     };
 
+                    // Remember focus so next frame's format-shortcut gate can
+                    // route the key to the editor the user is actually in.
+                    let has_focus = output.response.has_focus();
                     ui.ctx().memory_mut(|m| {
+                        m.data.insert_temp(focus_id, has_focus);
                         m.data
                             .insert_temp(completer_id, (words_fingerprint, completer))
                     });
@@ -360,6 +414,7 @@ impl CodeEditor {
                         CodeEditorOutput {
                             changed,
                             run,
+                            format,
                             run_marker: None,
                         },
                         output.galley.clone(),

--- a/thoth-plugin-sdk/src/components/icon_button/ui.rs
+++ b/thoth-plugin-sdk/src/components/icon_button/ui.rs
@@ -105,7 +105,7 @@ impl Widget for IconButton {
 
         let tooltip = self.tooltip;
         let response = match tooltip.as_deref() {
-            Some(t) => response.on_hover_text(t.to_owned()),
+            Some(t) => crate::theme::hover_text(response, t.to_owned()),
             None => response,
         };
 

--- a/thoth-plugin-sdk/src/components/table_view/ui.rs
+++ b/thoth-plugin-sdk/src/components/table_view/ui.rs
@@ -28,31 +28,10 @@ impl TableView {
         // borrow `self`; restore afterwards so cell state persists.
         let mut rows = std::mem::take(&mut self.rows);
 
-        // Plain-text of every cell, extracted once up front so the right-click
-        // "Copy row / Copy column" menu can build clipboard strings without
-        // re-borrowing `rows` (which the render closures mutate).
-        let cell_text: Vec<Vec<String>> = rows
-            .iter()
-            .map(|r| r.iter().map(node_text).collect())
-            .collect();
-        // Interactive JSON-tree cells handle their own clicks, so we don't
-        // overlay a right-click target on them (below).
-        let cell_is_tree: Vec<Vec<bool>> = rows
-            .iter()
-            .map(|r| {
-                r.iter()
-                    .map(|n| matches!(n, crate::render_node::RenderNode::JsonTree(_)))
-                    .collect()
-            })
-            .collect();
-        let header_names: Vec<String> = headers
-            .iter()
-            .map(|h| {
-                h.split_once("  ·  ")
-                    .map_or(h.as_str(), |(n, _)| n)
-                    .to_string()
-            })
-            .collect();
+        // A right-click "Copy row / Copy column" is recorded here during
+        // rendering and resolved to clipboard text once, after the grid is
+        // drawn — so we never build a text matrix every frame just in case.
+        let copy_action = std::cell::Cell::new(None::<CopyAction>);
 
         let grid = colors.surface;
         let header_border = colors.surface_raised;
@@ -144,7 +123,7 @@ impl TableView {
                             // The # gutter paints its text (no widget), so its
                             // cell response catches the right-click directly.
                             number_resp.context_menu(|ui| {
-                                cell_copy_menu(ui, &cell_text, &header_names, idx, None);
+                                copy_menu(ui, &copy_action, idx, None);
                             });
                             if number_resp.clicked() {
                                 row_clicked = true;
@@ -152,11 +131,12 @@ impl TableView {
 
                             for col in 0..num_cols {
                                 let align_right = right_aligned.get(col).copied().unwrap_or(false);
-                                let is_tree = cell_is_tree
-                                    .get(idx)
-                                    .and_then(|r| r.get(col))
-                                    .copied()
-                                    .unwrap_or(false);
+                                // Interactive JSON-tree cells handle their own clicks,
+                                // so we don't overlay a right-click target on them.
+                                let is_tree = matches!(
+                                    rows.get(idx).and_then(|r| r.get(col)),
+                                    Some(crate::render_node::RenderNode::JsonTree(_))
+                                );
                                 let (_, response) = row.col(|ui| {
                                     egui::Frame::NONE
                                         .inner_margin(egui::Margin::symmetric(CELL_PAD, 0))
@@ -194,13 +174,7 @@ impl TableView {
                                             egui::Sense::click(),
                                         );
                                         menu_resp.context_menu(|ui| {
-                                            cell_copy_menu(
-                                                ui,
-                                                &cell_text,
-                                                &header_names,
-                                                idx,
-                                                Some(col),
-                                            );
+                                            copy_menu(ui, &copy_action, idx, Some(col));
                                         });
                                     }
                                 });
@@ -208,13 +182,7 @@ impl TableView {
                                 // response catch right-clicks on their blank area.
                                 if is_tree {
                                     response.context_menu(|ui| {
-                                        cell_copy_menu(
-                                            ui,
-                                            &cell_text,
-                                            &header_names,
-                                            idx,
-                                            Some(col),
-                                        );
+                                        copy_menu(ui, &copy_action, idx, Some(col));
                                     });
                                 }
                                 if response.clicked() {
@@ -227,6 +195,34 @@ impl TableView {
                         });
                     });
             });
+
+        // Resolve a requested copy to clipboard text, now that the grid is drawn
+        // and `rows` is free to read. Row → cells tab-separated; column → the
+        // whole column newline-separated, header first.
+        if let Some(action) = copy_action.get() {
+            let text = match action {
+                CopyAction::Row(r) => rows
+                    .get(r)
+                    .map(|row| row.iter().map(node_text).collect::<Vec<_>>().join("\t"))
+                    .unwrap_or_default(),
+                CopyAction::Column(c) => {
+                    let mut lines: Vec<String> = Vec::with_capacity(rows.len() + 1);
+                    if let Some(h) = headers.get(c) {
+                        lines.push(
+                            h.split_once("  ·  ")
+                                .map_or(h.as_str(), |(n, _)| n)
+                                .to_string(),
+                        );
+                    }
+                    lines.extend(
+                        rows.iter()
+                            .map(|row| row.get(c).map(node_text).unwrap_or_default()),
+                    );
+                    lines.join("\n")
+                }
+            };
+            ui.ctx().copy_text(text);
+        }
 
         self.rows = rows;
         clicked_row
@@ -390,35 +386,31 @@ fn node_text(node: &crate::render_node::RenderNode) -> String {
     }
 }
 
-/// Right-click "Copy row / Copy column" menu for a cell at `(row, col)`. Row
-/// copies the row's cells tab-separated; column copies the whole column
-/// newline-separated, with the column header first. `col` is `None` for the
-/// row-number gutter, which offers "Copy row" only.
-fn cell_copy_menu(
+/// A copy request recorded from the right-click menu during rendering and
+/// resolved to clipboard text after the grid is drawn.
+#[derive(Clone, Copy)]
+enum CopyAction {
+    Row(usize),
+    Column(usize),
+}
+
+/// Right-click "Copy row / Copy column" menu for a cell. Records the request in
+/// `action` (resolved to text post-render); doesn't touch the clipboard itself.
+/// `col` is `None` for the row-number gutter, which offers "Copy row" only.
+fn copy_menu(
     ui: &mut egui::Ui,
-    cell_text: &[Vec<String>],
-    header_names: &[String],
+    action: &std::cell::Cell<Option<CopyAction>>,
     row: usize,
     col: Option<usize>,
 ) {
     if ui.button("Copy row").clicked() {
-        let text = cell_text.get(row).map(|r| r.join("\t")).unwrap_or_default();
-        ui.ctx().copy_text(text);
+        action.set(Some(CopyAction::Row(row)));
         ui.close();
     }
     if let Some(col) = col
         && ui.button("Copy column").clicked()
     {
-        let mut lines: Vec<String> = Vec::with_capacity(cell_text.len() + 1);
-        if let Some(name) = header_names.get(col) {
-            lines.push(name.clone());
-        }
-        lines.extend(
-            cell_text
-                .iter()
-                .map(|r| r.get(col).cloned().unwrap_or_default()),
-        );
-        ui.ctx().copy_text(lines.join("\n"));
+        action.set(Some(CopyAction::Column(col)));
         ui.close();
     }
 }

--- a/thoth-plugin-sdk/src/components/table_view/ui.rs
+++ b/thoth-plugin-sdk/src/components/table_view/ui.rs
@@ -28,6 +28,32 @@ impl TableView {
         // borrow `self`; restore afterwards so cell state persists.
         let mut rows = std::mem::take(&mut self.rows);
 
+        // Plain-text of every cell, extracted once up front so the right-click
+        // "Copy row / Copy column" menu can build clipboard strings without
+        // re-borrowing `rows` (which the render closures mutate).
+        let cell_text: Vec<Vec<String>> = rows
+            .iter()
+            .map(|r| r.iter().map(node_text).collect())
+            .collect();
+        // Interactive JSON-tree cells handle their own clicks, so we don't
+        // overlay a right-click target on them (below).
+        let cell_is_tree: Vec<Vec<bool>> = rows
+            .iter()
+            .map(|r| {
+                r.iter()
+                    .map(|n| matches!(n, crate::render_node::RenderNode::JsonTree(_)))
+                    .collect()
+            })
+            .collect();
+        let header_names: Vec<String> = headers
+            .iter()
+            .map(|h| {
+                h.split_once("  ·  ")
+                    .map_or(h.as_str(), |(n, _)| n)
+                    .to_string()
+            })
+            .collect();
+
         let grid = colors.surface;
         let header_border = colors.surface_raised;
         let header_bg = colors.bg_panel;
@@ -94,9 +120,7 @@ impl TableView {
                                         r
                                     })
                                     .inner;
-                                if r.hovered() {
-                                    r.show_tooltip_text(h);
-                                }
+                                let _ = crate::theme::hover_text(r, h.as_str());
                                 paint_cell_borders(ui, grid, header_border);
                             });
                         }
@@ -117,12 +141,22 @@ impl TableView {
                                 );
                                 paint_cell_borders(ui, grid, grid);
                             });
+                            // The # gutter paints its text (no widget), so its
+                            // cell response catches the right-click directly.
+                            number_resp.context_menu(|ui| {
+                                cell_copy_menu(ui, &cell_text, &header_names, idx, None);
+                            });
                             if number_resp.clicked() {
                                 row_clicked = true;
                             }
 
                             for col in 0..num_cols {
                                 let align_right = right_aligned.get(col).copied().unwrap_or(false);
+                                let is_tree = cell_is_tree
+                                    .get(idx)
+                                    .and_then(|r| r.get(col))
+                                    .copied()
+                                    .unwrap_or(false);
                                 let (_, response) = row.col(|ui| {
                                     egui::Frame::NONE
                                         .inner_margin(egui::Margin::symmetric(CELL_PAD, 0))
@@ -147,7 +181,42 @@ impl TableView {
                                             });
                                         });
                                     paint_cell_borders(ui, grid, grid);
+                                    // The cell's text widget senses only hover but
+                                    // still swallows the right-click before the cell
+                                    // response sees it, so overlay a full-cell click
+                                    // target on top to catch it. Skipped for JSON-tree
+                                    // cells, which need their own clicks (their blank
+                                    // area is still covered by the outer menu below).
+                                    if !is_tree {
+                                        let menu_resp = ui.interact(
+                                            ui.max_rect(),
+                                            ui.id().with("cell-copy-menu"),
+                                            egui::Sense::click(),
+                                        );
+                                        menu_resp.context_menu(|ui| {
+                                            cell_copy_menu(
+                                                ui,
+                                                &cell_text,
+                                                &header_names,
+                                                idx,
+                                                Some(col),
+                                            );
+                                        });
+                                    }
                                 });
+                                // JSON-tree cells have no overlay; let the cell
+                                // response catch right-clicks on their blank area.
+                                if is_tree {
+                                    response.context_menu(|ui| {
+                                        cell_copy_menu(
+                                            ui,
+                                            &cell_text,
+                                            &header_names,
+                                            idx,
+                                            Some(col),
+                                        );
+                                    });
+                                }
                                 if response.clicked() {
                                     row_clicked = true;
                                 }
@@ -247,9 +316,7 @@ impl TableView {
                                         r
                                     })
                                     .inner;
-                                if r.hovered() {
-                                    r.show_tooltip_text(h);
-                                }
+                                let _ = crate::theme::hover_text(r, h.as_str());
                                 paint_cell_borders(ui, grid, header_border);
                             });
                         }
@@ -306,6 +373,53 @@ impl TableView {
             });
 
         clicked_row
+    }
+}
+
+/// Best-effort plain text of a cell node, for clipboard copy. Covers the node
+/// kinds `typed_cell` produces (text, code, badge, and colored wrappers);
+/// anything else contributes nothing.
+fn node_text(node: &crate::render_node::RenderNode) -> String {
+    use crate::render_node::RenderNode as N;
+    match node {
+        N::Text(t) => t.text.clone(),
+        N::Code(c) => c.value.clone(),
+        N::Badge(b) => b.label.clone(),
+        N::Colored(c) => node_text(&c.child),
+        _ => String::new(),
+    }
+}
+
+/// Right-click "Copy row / Copy column" menu for a cell at `(row, col)`. Row
+/// copies the row's cells tab-separated; column copies the whole column
+/// newline-separated, with the column header first. `col` is `None` for the
+/// row-number gutter, which offers "Copy row" only.
+fn cell_copy_menu(
+    ui: &mut egui::Ui,
+    cell_text: &[Vec<String>],
+    header_names: &[String],
+    row: usize,
+    col: Option<usize>,
+) {
+    if ui.button("Copy row").clicked() {
+        let text = cell_text.get(row).map(|r| r.join("\t")).unwrap_or_default();
+        ui.ctx().copy_text(text);
+        ui.close();
+    }
+    if let Some(col) = col
+        && ui.button("Copy column").clicked()
+    {
+        let mut lines: Vec<String> = Vec::with_capacity(cell_text.len() + 1);
+        if let Some(name) = header_names.get(col) {
+            lines.push(name.clone());
+        }
+        lines.extend(
+            cell_text
+                .iter()
+                .map(|r| r.get(col).cloned().unwrap_or_default()),
+        );
+        ui.ctx().copy_text(lines.join("\n"));
+        ui.close();
     }
 }
 

--- a/thoth-plugin-sdk/src/components/tabs/ui.rs
+++ b/thoth-plugin-sdk/src/components/tabs/ui.rs
@@ -96,7 +96,7 @@ impl Tabs {
                             let resp = if header.is_empty() {
                                 resp
                             } else {
-                                resp.on_hover_text(header.as_str())
+                                crate::theme::hover_text(resp, header.as_str())
                             };
                             if resp.clicked() && !is_active {
                                 selected = i;

--- a/thoth-plugin-sdk/src/components/toggle_switch/ui.rs
+++ b/thoth-plugin-sdk/src/components/toggle_switch/ui.rs
@@ -40,7 +40,7 @@ impl Widget for ToggleSwitch {
 
         response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
         if let Some(hover_text) = self.hover_text {
-            response = response.on_hover_text(hover_text);
+            response = crate::theme::hover_text(response, hover_text);
         }
 
         response

--- a/thoth-plugin-sdk/src/render_node/render.rs
+++ b/thoth-plugin-sdk/src/render_node/render.rs
@@ -169,6 +169,9 @@ impl RenderNode {
                 if let Some(off) = out.run_marker {
                     emit(events, &c.id, "run-marker", off.to_string());
                 }
+                if out.format.is_some() {
+                    emit(events, &c.id, "format-editor", "".to_string());
+                }
             }
             RenderNode::List(l) => {
                 if let Some(ev) = l.show(ui) {

--- a/thoth-plugin-sdk/src/theme/mod.rs
+++ b/thoth-plugin-sdk/src/theme/mod.rs
@@ -231,6 +231,30 @@ pub fn hover_row_bg(ui: &egui::Ui) -> Color32 {
     ui.visuals().widgets.hovered.bg_fill
 }
 
+/// Tooltip text is rendered one step below body text (matching the app's
+/// "small" text scale) so tooltips read as secondary — egui's default
+/// `on_hover_text` uses full Body size, which looks oversized next to compact
+/// controls like icon buttons.
+pub const TOOLTIP_TEXT_SCALE: f32 = 0.85;
+
+/// Attach a tooltip to `response`, rendered slightly smaller than body text.
+/// Drop-in replacement for [`egui::Response::on_hover_text`] — use this for all
+/// tooltips so their sizing stays consistent.
+pub fn hover_text(response: egui::Response, text: impl Into<String>) -> egui::Response {
+    let text = text.into();
+    let size = (response
+        .ctx
+        .global_style()
+        .text_styles
+        .get(&egui::TextStyle::Body)
+        .map_or(14.0, |f| f.size)
+        * TOOLTIP_TEXT_SCALE)
+        .round();
+    response.on_hover_ui(|ui| {
+        ui.label(egui::RichText::new(text).size(size));
+    })
+}
+
 // ── Syntax token helpers ──────────────────────────────────────────────────────
 
 /// Resolved syntax colours for the active theme, one per [`TextToken`].


### PR DESCRIPTION
Editor & results UX improvements for the Seshat SQL workspace.

## SQL format
- Toolbar button **and ⌥⇧F shortcut** format the editor's SQL via `sqlformat`.
- **macOS compose-key fix:** Option is a compose modifier, so ⌥⇧F emits `Ï` as an `Event::Text` the `TextEdit` would insert. The shortcut is now detected by **physical key** (the logical key is mangled by composition) and the composed text is dropped before the editor consumes input.
- **Focus-gated:** with split tabs, all editors render and read the same global input, so the shortcut is routed using the editor's previous-frame focus — it formats the pane you're in, not whichever renders last.

## Tooltips
- New shared `thoth_plugin_sdk::theme::hover_text` helper renders tooltips one step below body text (the app's "small" scale). egui's default `on_hover_text` looked oversized next to compact controls like icon buttons. All tooltip sites route through it (icon button, button, toggle, tabs, breadcrumbs, table headers, status bar, settings).

## Results table
- Right-click **Copy row / Copy column** context menu on cells and the `#` gutter.
- Text cells overlay a full-cell click target so the menu opens over the text (not just blank padding); the `#` column offers **Copy row** only; JSON-tree cells keep their own clicks.

## Validation
- Host + SDK compile; `cargo clippy` clean; SDK formatted.
- Seshat plugin rebuilt (format handler).