### PR TITLE
feat(url-source): method + status + latency status-bar signal (#112)

### DIFF
--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -621,7 +621,7 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
                 error: Some(format!("response parse error: {e}")),
                 ..Default::default()
             });
-            signals::emit_signal("http", "", SignalStatus::Error, 0);
+            signals::emit_signal("http", &st.method, SignalStatus::Error, 0);
             return;
         }
     };
@@ -685,13 +685,21 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
             duration_ms,
             size_bytes,
         });
-        // HTTP status + payload size as a status-bar signal; >=400 reads as error.
+        // Status-bar signal: request method + HTTP status + latency; >=400 is error.
         let sig_status = if status >= 400 {
             SignalStatus::Error
         } else {
             SignalStatus::Ready
         };
-        signals::emit_signal("http", &format!("{status} · {size_bytes}B"), sig_status, 0);
+        let latency = duration_ms
+            .map(|ms| format!(" · {ms} ms"))
+            .unwrap_or_default();
+        signals::emit_signal(
+            "http",
+            &format!("{} {status}{latency}", st.method),
+            sig_status,
+            0,
+        );
     } else if let Some(err) = val.get("err") {
         let message = err
             .get("message")
@@ -702,10 +710,10 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
             error: Some(message),
             ..Default::default()
         });
-        signals::emit_signal("http", "", SignalStatus::Error, 0);
+        signals::emit_signal("http", &st.method, SignalStatus::Error, 0);
     } else {
         // Payload had neither `ok` nor `err`: still clear the sticky Loading.
-        signals::emit_signal("http", "", SignalStatus::Error, 0);
+        signals::emit_signal("http", &st.method, SignalStatus::Error, 0);
     }
 }
 
@@ -750,8 +758,9 @@ pub fn apply_event(st: &mut State, event: &UiEvent) {
             st.pending_request_id = Some(request_id);
             st.loading = true;
             st.response = None;
-            // Push a "requesting" signal; handle_http_response overwrites it.
-            signals::emit_signal("http", "", SignalStatus::Loading, 0);
+            // Push a "requesting" signal (method only); the response overwrites
+            // it with method + status + latency.
+            signals::emit_signal("http", &st.method, SignalStatus::Loading, 0);
         }
 
         _ => {}


### PR DESCRIPTION
Completes #112 — the url-source plugin surfaces its last HTTP request in the status bar.

## Change
Refines the existing `http` signal to carry the ticket's fields: **request method + HTTP status + latency**, e.g. `GET 200 · 45 ms`.

- **Sending** → `<method>` with a loading indicator.
- **Response** → `<method> <status> · <ms> ms` (latency from the response's `duration_ms`, which the host already measures); `>= 400` reads as error.
- **Error / parse failure / empty payload** → `<method>` with error status (clears the sticky loading signal).

## Notes
- Builds on the signals channel (#110) and the instance-scoped registry (#111), both merged.
- Plugin-only change (`plugins/url-source/src/ui.rs`); no WIT/host change.

## Validation
- `cargo component build` + `cargo clippy` clean; formatted.

**Releasable:** the last HTTP request's status shows in the status bar. ✅