### PR TITLE
feat(url-source): WebSocket support (#126)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6486,6 +6492,7 @@ dependencies = [
  "egui_extras",
  "flate2",
  "fontdb",
+ "futures-util",
  "image",
  "keyring",
  "memchr",
@@ -6509,6 +6516,7 @@ dependencies = [
  "tempfile",
  "thoth-plugin-sdk",
  "tokio",
+ "tokio-tungstenite",
  "toml 0.8.2",
  "tracing",
  "tracing-subscriber",
@@ -6710,6 +6718,22 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.35",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6944,6 +6968,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7072,6 +7116,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,9 @@ wasmtime-wasi-http = "43"
 # Host-terminated TLS for the plugin tcp-client import.
 rustls = "0.23"
 webpki-roots = "0.26"
+# WebSocket connections brokered for the plugin `websocket` import.
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"
 # OS keychain for the plugin secure-storage import.
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 wit-bindgen = "0.54.0"

--- a/plugins/seshat/src/bindings.rs
+++ b/plugins/seshat/src/bindings.rs
@@ -1560,6 +1560,346 @@ pub mod thoth {
                 }
             }
         }
+        /// websocket — host-provided import. The host owns WebSocket connections (via
+        /// tokio-tungstenite), enforces the same network policy / consent as http, and
+        /// answers server pings + sends periodic keepalive pings. Incoming frames and
+        /// lifecycle events are streamed to the plugin through handle-event (matching
+        /// the async http `submit` pattern), so the plugin never blocks on the socket.
+        #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+        pub mod websocket {
+            #[used]
+            #[doc(hidden)]
+            static __FORCE_SECTION_REF: fn() = super::super::super::__link_custom_section_describing_imports;
+            use super::super::super::_rt;
+            pub type PluginError = super::super::super::thoth::plugin::types::PluginError;
+            #[allow(unused_unsafe, clippy::all)]
+            /// Open a WebSocket to `url` (ws:// or wss://) with optional extra request
+            /// headers (e.g. auth). Returns an opaque connection id immediately; the
+            /// connection completes asynchronously. The host then delivers lifecycle and
+            /// messages via handle-event with widget-id = <connection-id> and:
+            ///   kind = "ws-open"                                     (connected)
+            ///   kind = "ws-message", value = JSON {"text":"..."}
+            ///                              or JSON {"binary":"<base64>"}
+            ///   kind = "ws-error",   value = message
+            ///   kind = "ws-close",   value = JSON {"code":u16,"reason":"..."}
+            pub fn connect(
+                url: &str,
+                headers: &[(_rt::String, _rt::String)],
+            ) -> Result<_rt::String, PluginError> {
+                unsafe {
+                    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                    struct RetArea(
+                        [::core::mem::MaybeUninit<
+                            u8,
+                        >; 4 * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let mut ret_area = RetArea(
+                        [::core::mem::MaybeUninit::uninit(); 4
+                            * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let vec0 = url;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec4 = headers;
+                    let len4 = vec4.len();
+                    let layout4 = _rt::alloc::Layout::from_size_align_unchecked(
+                        vec4.len() * (4 * ::core::mem::size_of::<*const u8>()),
+                        ::core::mem::size_of::<*const u8>(),
+                    );
+                    let result4 = if layout4.size() != 0 {
+                        let ptr = _rt::alloc::alloc(layout4).cast::<u8>();
+                        if ptr.is_null() {
+                            _rt::alloc::handle_alloc_error(layout4);
+                        }
+                        ptr
+                    } else {
+                        ::core::ptr::null_mut()
+                    };
+                    for (i, e) in vec4.into_iter().enumerate() {
+                        let base = result4
+                            .add(i * (4 * ::core::mem::size_of::<*const u8>()));
+                        {
+                            let (t1_0, t1_1) = e;
+                            let vec2 = t1_0;
+                            let ptr2 = vec2.as_ptr().cast::<u8>();
+                            let len2 = vec2.len();
+                            *base
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len2;
+                            *base.add(0).cast::<*mut u8>() = ptr2.cast_mut();
+                            let vec3 = t1_1;
+                            let ptr3 = vec3.as_ptr().cast::<u8>();
+                            let len3 = vec3.len();
+                            *base
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len3;
+                            *base
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr3.cast_mut();
+                        }
+                    }
+                    let ptr5 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/websocket@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "connect"]
+                        fn wit_import6(
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                        );
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import6(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe { wit_import6(ptr0.cast_mut(), len0, result4, len4, ptr5) };
+                    let l7 = i32::from(*ptr5.add(0).cast::<u8>());
+                    let result15 = match l7 {
+                        0 => {
+                            let e = {
+                                let l8 = *ptr5
+                                    .add(::core::mem::size_of::<*const u8>())
+                                    .cast::<*mut u8>();
+                                let l9 = *ptr5
+                                    .add(2 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<usize>();
+                                let len10 = l9;
+                                let bytes10 = _rt::Vec::from_raw_parts(
+                                    l8.cast(),
+                                    len10,
+                                    len10,
+                                );
+                                _rt::string_lift(bytes10)
+                            };
+                            Ok(e)
+                        }
+                        1 => {
+                            let e = {
+                                let l11 = *ptr5
+                                    .add(::core::mem::size_of::<*const u8>())
+                                    .cast::<i32>();
+                                let l12 = *ptr5
+                                    .add(2 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<*mut u8>();
+                                let l13 = *ptr5
+                                    .add(3 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<usize>();
+                                let len14 = l13;
+                                let bytes14 = _rt::Vec::from_raw_parts(
+                                    l12.cast(),
+                                    len14,
+                                    len14,
+                                );
+                                super::super::super::thoth::plugin::types::PluginError {
+                                    code: l11 as u32,
+                                    message: _rt::string_lift(bytes14),
+                                }
+                            };
+                            Err(e)
+                        }
+                        _ => _rt::invalid_enum_discriminant(),
+                    };
+                    if layout4.size() != 0 {
+                        _rt::alloc::dealloc(result4.cast(), layout4);
+                    }
+                    result15
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
+            /// Send a UTF-8 text frame on the connection.
+            pub fn send_text(id: &str, text: &str) -> Result<(), PluginError> {
+                unsafe {
+                    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                    struct RetArea(
+                        [::core::mem::MaybeUninit<
+                            u8,
+                        >; 4 * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let mut ret_area = RetArea(
+                        [::core::mem::MaybeUninit::uninit(); 4
+                            * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let vec0 = id;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec1 = text;
+                    let ptr1 = vec1.as_ptr().cast::<u8>();
+                    let len1 = vec1.len();
+                    let ptr2 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/websocket@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "send-text"]
+                        fn wit_import3(
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                        );
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import3(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe {
+                        wit_import3(ptr0.cast_mut(), len0, ptr1.cast_mut(), len1, ptr2)
+                    };
+                    let l4 = i32::from(*ptr2.add(0).cast::<u8>());
+                    let result9 = match l4 {
+                        0 => {
+                            let e = ();
+                            Ok(e)
+                        }
+                        1 => {
+                            let e = {
+                                let l5 = *ptr2
+                                    .add(::core::mem::size_of::<*const u8>())
+                                    .cast::<i32>();
+                                let l6 = *ptr2
+                                    .add(2 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<*mut u8>();
+                                let l7 = *ptr2
+                                    .add(3 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<usize>();
+                                let len8 = l7;
+                                let bytes8 = _rt::Vec::from_raw_parts(
+                                    l6.cast(),
+                                    len8,
+                                    len8,
+                                );
+                                super::super::super::thoth::plugin::types::PluginError {
+                                    code: l5 as u32,
+                                    message: _rt::string_lift(bytes8),
+                                }
+                            };
+                            Err(e)
+                        }
+                        _ => _rt::invalid_enum_discriminant(),
+                    };
+                    result9
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
+            /// Send a binary frame on the connection.
+            pub fn send_binary(id: &str, bytes: &[u8]) -> Result<(), PluginError> {
+                unsafe {
+                    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                    struct RetArea(
+                        [::core::mem::MaybeUninit<
+                            u8,
+                        >; 4 * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let mut ret_area = RetArea(
+                        [::core::mem::MaybeUninit::uninit(); 4
+                            * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let vec0 = id;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec1 = bytes;
+                    let ptr1 = vec1.as_ptr().cast::<u8>();
+                    let len1 = vec1.len();
+                    let ptr2 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/websocket@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "send-binary"]
+                        fn wit_import3(
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                        );
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import3(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe {
+                        wit_import3(ptr0.cast_mut(), len0, ptr1.cast_mut(), len1, ptr2)
+                    };
+                    let l4 = i32::from(*ptr2.add(0).cast::<u8>());
+                    let result9 = match l4 {
+                        0 => {
+                            let e = ();
+                            Ok(e)
+                        }
+                        1 => {
+                            let e = {
+                                let l5 = *ptr2
+                                    .add(::core::mem::size_of::<*const u8>())
+                                    .cast::<i32>();
+                                let l6 = *ptr2
+                                    .add(2 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<*mut u8>();
+                                let l7 = *ptr2
+                                    .add(3 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<usize>();
+                                let len8 = l7;
+                                let bytes8 = _rt::Vec::from_raw_parts(
+                                    l6.cast(),
+                                    len8,
+                                    len8,
+                                );
+                                super::super::super::thoth::plugin::types::PluginError {
+                                    code: l5 as u32,
+                                    message: _rt::string_lift(bytes8),
+                                }
+                            };
+                            Err(e)
+                        }
+                        _ => _rt::invalid_enum_discriminant(),
+                    };
+                    result9
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
+            /// Close the connection (sends a normal close frame). Idempotent.
+            pub fn close(id: &str) -> () {
+                unsafe {
+                    let vec0 = id;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/websocket@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "close"]
+                        fn wit_import1(_: *mut u8, _: usize);
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import1(_: *mut u8, _: usize) {
+                        unreachable!()
+                    }
+                    unsafe { wit_import1(ptr0.cast_mut(), len0) };
+                }
+            }
+        }
         /// ---------------------------------------------------------------------------
         /// file-dialog — host-provided native open/save file pickers with I/O.
         ///
@@ -4123,73 +4463,77 @@ pub(crate) use __export_data_source_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 2870] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xad\x15\x01A\x02\x01\
-A\x20\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
-\x0fsearch-provider\x10new-ui-component\x04\0\x0acapability\x03\0\0\x01p\x01\x01\
-ks\x01r\x08\x02ids\x04names\x07versions\x0bdescriptions\x0ccapabilities\x02\x06a\
-uthor\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplugin-info\x03\0\x04\x01r\x02\x04\
-codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\x01r\x02\x03keys\x05values\x04\
-\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugin/types@0.1.0\x05\0\x02\x03\0\0\
-\x0cplugin-error\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01o\
-\x02ss\x01p\x02\x01p}\x01k\x04\x01r\x04\x03urls\x06methods\x07headers\x03\x04bod\
-y\x05\x04\0\x0chttp-request\x03\0\x06\x01r\x03\x06status{\x07headers\x03\x04body\
-\x04\x04\0\x0dhttp-response\x03\0\x08\x01j\x01\x09\x01\x01\x01@\x01\x03req\x07\0\
-\x0a\x04\0\x05fetch\x01\x0b\x01@\x01\x03req\x07\0s\x04\0\x06submit\x01\x0c\x03\0\
-\x1ethoth:plugin/http-client@0.1.0\x05\x02\x01B\x05\x01@\0\0s\x04\0\x04read\x01\0\
-\x01j\0\x01s\x01@\x01\x04datas\0\x01\x04\0\x05write\x01\x02\x03\0!thoth:plugin/p\
-lugin-storage@0.1.0\x05\x03\x01B\x03\x01ks\x01@\x03\x05titles\x04icon\0\x0diniti\
-al-state\0\0s\x04\0\x08open-tab\x01\x01\x03\0\x1athoth:plugin/ui-tabs@0.1.0\x05\x04\
-\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01j\x01w\x01\x01\x01\
-@\x03\x04hosts\x04port{\x03tls\x7f\0\x02\x04\0\x07connect\x01\x03\x01p}\x01j\x01\
-\x04\x01\x01\x01@\x02\x02idw\x03maxy\0\x05\x04\0\x04read\x01\x06\x01j\x01y\x01\x01\
-\x01@\x02\x02idw\x05bytes\x04\0\x07\x04\0\x05write\x01\x08\x01j\0\x01\x01\x01@\x02\
-\x02idw\x04hosts\0\x09\x04\0\x09start-tls\x01\x0a\x01@\x01\x02idw\x01\0\x04\0\x05\
-close\x01\x0b\x03\0\x1dthoth:plugin/tcp-client@0.1.0\x05\x05\x01B\x0b\x02\x03\x02\
-\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01j\0\x01\x01\x01@\x02\x03keys\x06secret\
-s\0\x02\x04\0\x05write\x01\x03\x01ks\x01j\x01\x04\x01\x01\x01@\x01\x03keys\0\x05\
-\x04\0\x04read\x01\x06\x01@\x01\x03keys\0\x02\x04\0\x06delete\x01\x07\x03\0!thot\
-h:plugin/secure-storage@0.1.0\x05\x06\x01B\x02\x01@\x02\x06handles\x01qs\0s\x04\0\
-\x0csubmit-query\x01\0\x03\0\x1dthoth:plugin/db-runtime@0.1.0\x05\x07\x01B\x04\x01\
-m\x03\x05ready\x07loading\x05error\x04\0\x06status\x03\0\0\x01@\x04\x03keys\x05v\
-alues\x06status\x01\x06ttl-msy\x01\0\x04\0\x0bemit-signal\x01\x02\x03\0\x1athoth\
-:plugin/signals@0.1.0\x05\x08\x01B\x0d\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\
-\x03\0\0\x01r\x02\x04paths\x08contentss\x04\0\x0bopened-file\x03\0\x02\x01ps\x01\
-k\x03\x01j\x01\x05\x01\x01\x01@\x02\x05titles\x0aextensions\x04\0\x06\x04\0\x09o\
-pen-file\x01\x07\x01ks\x01j\x01\x08\x01\x01\x01@\x04\x05titles\x0cdefault-names\x0a\
-extensions\x04\x08contentss\0\x09\x04\0\x09save-file\x01\x0a\x03\0\x1ethoth:plug\
-in/file-dialog@0.1.0\x05\x09\x01B\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\
-\0\0\x01r\x04\x04names\x0bdescriptions\x08required\x7f\x05values\x04\0\x0cconfig\
--entry\x03\0\x02\x01r\x03\x04names\x09type-hints\x08nullable\x7f\x04\0\x0cfield-\
-schema\x03\0\x04\x01p\x05\x01r\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\
-\x03\0\x07\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\
-\x01p\x03\x01@\0\0\x0b\x04\0\x0frequired-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\
-\x06config\x0b\0\x0d\x04\0\x07connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\
-\x01\x06handles\0\x10\x04\0\x06schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\
-\0\x05query\x01\x12\x01@\x01\x06handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\
-\x01\x01\x01@\x01\x06handles\0\x14\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:p\
-lugin/data-source@0.1.0\x05\x0a\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-err\
-or\x03\0\0\x01r\x03\x09widget-ids\x04kinds\x05values\x04\0\x08ui-event\x03\0\x02\
-\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\
-\x01\x01\x01@\0\0\x06\x04\0\x09render-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\
-\0\x0chandle-event\x01\x08\x01k\x05\x01j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0er\
-ender-sidebar\x01\x0b\x04\0\x1fthoth:plugin/ui-component@0.1.0\x05\x0b\x01B\x11\x02\
-\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\
-\x01ks\x01@\0\0\x03\x04\0\x08tab-icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\
-\0\x09get-state\x01\x06\x01j\0\x01\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-wi\
-th-state\x01\x08\x01@\0\x01\0\x04\0\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-bl\
-urred\x01\x09\x04\0\x0don-tab-closed\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.\
-0\x05\x0c\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x0d\x04\0\x0bplugi\
-n-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plug\
-in-meta@0.1.0\x05\x0e\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\
-\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#t\
-hoth:plugin/plugin-lifecycle@0.1.0\x05\x0f\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-ou\
-tput\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\
-\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x10\x04\0%thoth:plugin/data-sourc\
-e-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\
-\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41\
-.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3062] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xed\x16\x01A\x02\x01\
+A\"\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
+search-provider\x10new-ui-component\x04\0\x0acapability\x03\0\0\x01p\x01\x01ks\x01\
+r\x08\x02ids\x04names\x07versions\x0bdescriptions\x0ccapabilities\x02\x06author\x03\
+\x08homepage\x03\x04icon\x03\x04\0\x0bplugin-info\x03\0\x04\x01r\x02\x04codey\x07\
+messages\x04\0\x0cplugin-error\x03\0\x06\x01r\x02\x03keys\x05values\x04\0\x0cset\
+ting-data\x03\0\x08\x03\0\x18thoth:plugin/types@0.1.0\x05\0\x02\x03\0\0\x0cplugi\
+n-error\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01o\x02ss\x01\
+p\x02\x01p}\x01k\x04\x01r\x04\x03urls\x06methods\x07headers\x03\x04body\x05\x04\0\
+\x0chttp-request\x03\0\x06\x01r\x03\x06status{\x07headers\x03\x04body\x04\x04\0\x0d\
+http-response\x03\0\x08\x01j\x01\x09\x01\x01\x01@\x01\x03req\x07\0\x0a\x04\0\x05\
+fetch\x01\x0b\x01@\x01\x03req\x07\0s\x04\0\x06submit\x01\x0c\x03\0\x1ethoth:plug\
+in/http-client@0.1.0\x05\x02\x01B\x05\x01@\0\0s\x04\0\x04read\x01\0\x01j\0\x01s\x01\
+@\x01\x04datas\0\x01\x04\0\x05write\x01\x02\x03\0!thoth:plugin/plugin-storage@0.\
+1.0\x05\x03\x01B\x03\x01ks\x01@\x03\x05titles\x04icon\0\x0dinitial-state\0\0s\x04\
+\0\x08open-tab\x01\x01\x03\0\x1athoth:plugin/ui-tabs@0.1.0\x05\x04\x01B\x11\x02\x03\
+\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01j\x01w\x01\x01\x01@\x03\x04hosts\x04\
+port{\x03tls\x7f\0\x02\x04\0\x07connect\x01\x03\x01p}\x01j\x01\x04\x01\x01\x01@\x02\
+\x02idw\x03maxy\0\x05\x04\0\x04read\x01\x06\x01j\x01y\x01\x01\x01@\x02\x02idw\x05\
+bytes\x04\0\x07\x04\0\x05write\x01\x08\x01j\0\x01\x01\x01@\x02\x02idw\x04hosts\0\
+\x09\x04\0\x09start-tls\x01\x0a\x01@\x01\x02idw\x01\0\x04\0\x05close\x01\x0b\x03\
+\0\x1dthoth:plugin/tcp-client@0.1.0\x05\x05\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x0c\
+plugin-error\x03\0\0\x01j\0\x01\x01\x01@\x02\x03keys\x06secrets\0\x02\x04\0\x05w\
+rite\x01\x03\x01ks\x01j\x01\x04\x01\x01\x01@\x01\x03keys\0\x05\x04\0\x04read\x01\
+\x06\x01@\x01\x03keys\0\x02\x04\0\x06delete\x01\x07\x03\0!thoth:plugin/secure-st\
+orage@0.1.0\x05\x06\x01B\x02\x01@\x02\x06handles\x01qs\0s\x04\0\x0csubmit-query\x01\
+\0\x03\0\x1dthoth:plugin/db-runtime@0.1.0\x05\x07\x01B\x04\x01m\x03\x05ready\x07\
+loading\x05error\x04\0\x06status\x03\0\0\x01@\x04\x03keys\x05values\x06status\x01\
+\x06ttl-msy\x01\0\x04\0\x0bemit-signal\x01\x02\x03\0\x1athoth:plugin/signals@0.1\
+.0\x05\x08\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01o\x02ss\
+\x01p\x02\x01j\x01s\x01\x01\x01@\x02\x03urls\x07headers\x03\0\x04\x04\0\x07conne\
+ct\x01\x05\x01j\0\x01\x01\x01@\x02\x02ids\x04texts\0\x06\x04\0\x09send-text\x01\x07\
+\x01p}\x01@\x02\x02ids\x05bytes\x08\0\x06\x04\0\x0bsend-binary\x01\x09\x01@\x01\x02\
+ids\x01\0\x04\0\x05close\x01\x0a\x03\0\x1cthoth:plugin/websocket@0.1.0\x05\x09\x01\
+B\x0d\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04paths\x08con\
+tentss\x04\0\x0bopened-file\x03\0\x02\x01ps\x01k\x03\x01j\x01\x05\x01\x01\x01@\x02\
+\x05titles\x0aextensions\x04\0\x06\x04\0\x09open-file\x01\x07\x01ks\x01j\x01\x08\
+\x01\x01\x01@\x04\x05titles\x0cdefault-names\x0aextensions\x04\x08contentss\0\x09\
+\x04\0\x09save-file\x01\x0a\x03\0\x1ethoth:plugin/file-dialog@0.1.0\x05\x0a\x01B\
+\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04names\x0bdesc\
+riptions\x08required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\x03\x04n\
+ames\x09type-hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\x05\x01r\
+\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09node-js\
+ons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\0\x0f\
+required-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\0\x07\
+connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\0\x06\
+schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\x01\x06\
+handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06handles\0\x14\
+\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\x05\x0b\x01\
+B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09widget-ids\x04\
+kinds\x05values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\x0bheight-hin\
+ty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\0\x09rende\
+r-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\x01k\x05\x01\
+j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\x1fthoth:pl\
+ugin/ui-component@0.1.0\x05\x0c\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-err\
+or\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\0\x08tab-\
+icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\x01j\0\x01\
+\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\x01\0\x04\0\
+\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0don-tab-close\
+d\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.0\x05\x0d\x02\x03\0\0\x0bplugin-inf\
+o\x01B\x04\x02\x03\x02\x01\x0e\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08\
+get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x0f\x01B\x05\x01@\x01\
+\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\
+\x04\0\x11on-setting-change\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x10\
+\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jso\
+ns\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\
+\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.\
+0\x05\x11\x04\0%thoth:plugin/data-source-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12dat\
+a-source-plugin\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\
+\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/seshat/src/bindings.rs
+++ b/plugins/seshat/src/bindings.rs
@@ -1579,7 +1579,7 @@ pub mod thoth {
             /// messages via handle-event with widget-id = <connection-id> and:
             ///   kind = "ws-open"                                     (connected)
             ///   kind = "ws-message", value = JSON {"text":"..."}
-            ///                              or JSON {"binary":"<base64>"}
+            ///                              or JSON {"binary":"<hex>","len":<frame-bytes>}
             ///   kind = "ws-error",   value = message
             ///   kind = "ws-close",   value = JSON {"code":u16,"reason":"..."}
             pub fn connect(

--- a/plugins/url-source/src/bindings.rs
+++ b/plugins/url-source/src/bindings.rs
@@ -1560,6 +1560,346 @@ pub mod thoth {
                 }
             }
         }
+        /// websocket — host-provided import. The host owns WebSocket connections (via
+        /// tokio-tungstenite), enforces the same network policy / consent as http, and
+        /// answers server pings + sends periodic keepalive pings. Incoming frames and
+        /// lifecycle events are streamed to the plugin through handle-event (matching
+        /// the async http `submit` pattern), so the plugin never blocks on the socket.
+        #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+        pub mod websocket {
+            #[used]
+            #[doc(hidden)]
+            static __FORCE_SECTION_REF: fn() = super::super::super::__link_custom_section_describing_imports;
+            use super::super::super::_rt;
+            pub type PluginError = super::super::super::thoth::plugin::types::PluginError;
+            #[allow(unused_unsafe, clippy::all)]
+            /// Open a WebSocket to `url` (ws:// or wss://) with optional extra request
+            /// headers (e.g. auth). Returns an opaque connection id immediately; the
+            /// connection completes asynchronously. The host then delivers lifecycle and
+            /// messages via handle-event with widget-id = <connection-id> and:
+            ///   kind = "ws-open"                                     (connected)
+            ///   kind = "ws-message", value = JSON {"text":"..."}
+            ///                              or JSON {"binary":"<base64>"}
+            ///   kind = "ws-error",   value = message
+            ///   kind = "ws-close",   value = JSON {"code":u16,"reason":"..."}
+            pub fn connect(
+                url: &str,
+                headers: &[(_rt::String, _rt::String)],
+            ) -> Result<_rt::String, PluginError> {
+                unsafe {
+                    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                    struct RetArea(
+                        [::core::mem::MaybeUninit<
+                            u8,
+                        >; 4 * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let mut ret_area = RetArea(
+                        [::core::mem::MaybeUninit::uninit(); 4
+                            * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let vec0 = url;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec4 = headers;
+                    let len4 = vec4.len();
+                    let layout4 = _rt::alloc::Layout::from_size_align_unchecked(
+                        vec4.len() * (4 * ::core::mem::size_of::<*const u8>()),
+                        ::core::mem::size_of::<*const u8>(),
+                    );
+                    let result4 = if layout4.size() != 0 {
+                        let ptr = _rt::alloc::alloc(layout4).cast::<u8>();
+                        if ptr.is_null() {
+                            _rt::alloc::handle_alloc_error(layout4);
+                        }
+                        ptr
+                    } else {
+                        ::core::ptr::null_mut()
+                    };
+                    for (i, e) in vec4.into_iter().enumerate() {
+                        let base = result4
+                            .add(i * (4 * ::core::mem::size_of::<*const u8>()));
+                        {
+                            let (t1_0, t1_1) = e;
+                            let vec2 = t1_0;
+                            let ptr2 = vec2.as_ptr().cast::<u8>();
+                            let len2 = vec2.len();
+                            *base
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len2;
+                            *base.add(0).cast::<*mut u8>() = ptr2.cast_mut();
+                            let vec3 = t1_1;
+                            let ptr3 = vec3.as_ptr().cast::<u8>();
+                            let len3 = vec3.len();
+                            *base
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len3;
+                            *base
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr3.cast_mut();
+                        }
+                    }
+                    let ptr5 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/websocket@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "connect"]
+                        fn wit_import6(
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                        );
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import6(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe { wit_import6(ptr0.cast_mut(), len0, result4, len4, ptr5) };
+                    let l7 = i32::from(*ptr5.add(0).cast::<u8>());
+                    let result15 = match l7 {
+                        0 => {
+                            let e = {
+                                let l8 = *ptr5
+                                    .add(::core::mem::size_of::<*const u8>())
+                                    .cast::<*mut u8>();
+                                let l9 = *ptr5
+                                    .add(2 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<usize>();
+                                let len10 = l9;
+                                let bytes10 = _rt::Vec::from_raw_parts(
+                                    l8.cast(),
+                                    len10,
+                                    len10,
+                                );
+                                _rt::string_lift(bytes10)
+                            };
+                            Ok(e)
+                        }
+                        1 => {
+                            let e = {
+                                let l11 = *ptr5
+                                    .add(::core::mem::size_of::<*const u8>())
+                                    .cast::<i32>();
+                                let l12 = *ptr5
+                                    .add(2 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<*mut u8>();
+                                let l13 = *ptr5
+                                    .add(3 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<usize>();
+                                let len14 = l13;
+                                let bytes14 = _rt::Vec::from_raw_parts(
+                                    l12.cast(),
+                                    len14,
+                                    len14,
+                                );
+                                super::super::super::thoth::plugin::types::PluginError {
+                                    code: l11 as u32,
+                                    message: _rt::string_lift(bytes14),
+                                }
+                            };
+                            Err(e)
+                        }
+                        _ => _rt::invalid_enum_discriminant(),
+                    };
+                    if layout4.size() != 0 {
+                        _rt::alloc::dealloc(result4.cast(), layout4);
+                    }
+                    result15
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
+            /// Send a UTF-8 text frame on the connection.
+            pub fn send_text(id: &str, text: &str) -> Result<(), PluginError> {
+                unsafe {
+                    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                    struct RetArea(
+                        [::core::mem::MaybeUninit<
+                            u8,
+                        >; 4 * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let mut ret_area = RetArea(
+                        [::core::mem::MaybeUninit::uninit(); 4
+                            * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let vec0 = id;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec1 = text;
+                    let ptr1 = vec1.as_ptr().cast::<u8>();
+                    let len1 = vec1.len();
+                    let ptr2 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/websocket@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "send-text"]
+                        fn wit_import3(
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                        );
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import3(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe {
+                        wit_import3(ptr0.cast_mut(), len0, ptr1.cast_mut(), len1, ptr2)
+                    };
+                    let l4 = i32::from(*ptr2.add(0).cast::<u8>());
+                    let result9 = match l4 {
+                        0 => {
+                            let e = ();
+                            Ok(e)
+                        }
+                        1 => {
+                            let e = {
+                                let l5 = *ptr2
+                                    .add(::core::mem::size_of::<*const u8>())
+                                    .cast::<i32>();
+                                let l6 = *ptr2
+                                    .add(2 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<*mut u8>();
+                                let l7 = *ptr2
+                                    .add(3 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<usize>();
+                                let len8 = l7;
+                                let bytes8 = _rt::Vec::from_raw_parts(
+                                    l6.cast(),
+                                    len8,
+                                    len8,
+                                );
+                                super::super::super::thoth::plugin::types::PluginError {
+                                    code: l5 as u32,
+                                    message: _rt::string_lift(bytes8),
+                                }
+                            };
+                            Err(e)
+                        }
+                        _ => _rt::invalid_enum_discriminant(),
+                    };
+                    result9
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
+            /// Send a binary frame on the connection.
+            pub fn send_binary(id: &str, bytes: &[u8]) -> Result<(), PluginError> {
+                unsafe {
+                    #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                    #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                    struct RetArea(
+                        [::core::mem::MaybeUninit<
+                            u8,
+                        >; 4 * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let mut ret_area = RetArea(
+                        [::core::mem::MaybeUninit::uninit(); 4
+                            * ::core::mem::size_of::<*const u8>()],
+                    );
+                    let vec0 = id;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec1 = bytes;
+                    let ptr1 = vec1.as_ptr().cast::<u8>();
+                    let len1 = vec1.len();
+                    let ptr2 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/websocket@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "send-binary"]
+                        fn wit_import3(
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                        );
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import3(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe {
+                        wit_import3(ptr0.cast_mut(), len0, ptr1.cast_mut(), len1, ptr2)
+                    };
+                    let l4 = i32::from(*ptr2.add(0).cast::<u8>());
+                    let result9 = match l4 {
+                        0 => {
+                            let e = ();
+                            Ok(e)
+                        }
+                        1 => {
+                            let e = {
+                                let l5 = *ptr2
+                                    .add(::core::mem::size_of::<*const u8>())
+                                    .cast::<i32>();
+                                let l6 = *ptr2
+                                    .add(2 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<*mut u8>();
+                                let l7 = *ptr2
+                                    .add(3 * ::core::mem::size_of::<*const u8>())
+                                    .cast::<usize>();
+                                let len8 = l7;
+                                let bytes8 = _rt::Vec::from_raw_parts(
+                                    l6.cast(),
+                                    len8,
+                                    len8,
+                                );
+                                super::super::super::thoth::plugin::types::PluginError {
+                                    code: l5 as u32,
+                                    message: _rt::string_lift(bytes8),
+                                }
+                            };
+                            Err(e)
+                        }
+                        _ => _rt::invalid_enum_discriminant(),
+                    };
+                    result9
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
+            /// Close the connection (sends a normal close frame). Idempotent.
+            pub fn close(id: &str) -> () {
+                unsafe {
+                    let vec0 = id;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/websocket@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "close"]
+                        fn wit_import1(_: *mut u8, _: usize);
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import1(_: *mut u8, _: usize) {
+                        unreachable!()
+                    }
+                    unsafe { wit_import1(ptr0.cast_mut(), len0) };
+                }
+            }
+        }
         /// ---------------------------------------------------------------------------
         /// file-dialog — host-provided native open/save file pickers with I/O.
         ///
@@ -4123,73 +4463,77 @@ pub(crate) use __export_data_source_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 2870] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xad\x15\x01A\x02\x01\
-A\x20\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
-\x0fsearch-provider\x10new-ui-component\x04\0\x0acapability\x03\0\0\x01p\x01\x01\
-ks\x01r\x08\x02ids\x04names\x07versions\x0bdescriptions\x0ccapabilities\x02\x06a\
-uthor\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplugin-info\x03\0\x04\x01r\x02\x04\
-codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\x01r\x02\x03keys\x05values\x04\
-\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugin/types@0.1.0\x05\0\x02\x03\0\0\
-\x0cplugin-error\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01o\
-\x02ss\x01p\x02\x01p}\x01k\x04\x01r\x04\x03urls\x06methods\x07headers\x03\x04bod\
-y\x05\x04\0\x0chttp-request\x03\0\x06\x01r\x03\x06status{\x07headers\x03\x04body\
-\x04\x04\0\x0dhttp-response\x03\0\x08\x01j\x01\x09\x01\x01\x01@\x01\x03req\x07\0\
-\x0a\x04\0\x05fetch\x01\x0b\x01@\x01\x03req\x07\0s\x04\0\x06submit\x01\x0c\x03\0\
-\x1ethoth:plugin/http-client@0.1.0\x05\x02\x01B\x05\x01@\0\0s\x04\0\x04read\x01\0\
-\x01j\0\x01s\x01@\x01\x04datas\0\x01\x04\0\x05write\x01\x02\x03\0!thoth:plugin/p\
-lugin-storage@0.1.0\x05\x03\x01B\x03\x01ks\x01@\x03\x05titles\x04icon\0\x0diniti\
-al-state\0\0s\x04\0\x08open-tab\x01\x01\x03\0\x1athoth:plugin/ui-tabs@0.1.0\x05\x04\
-\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01j\x01w\x01\x01\x01\
-@\x03\x04hosts\x04port{\x03tls\x7f\0\x02\x04\0\x07connect\x01\x03\x01p}\x01j\x01\
-\x04\x01\x01\x01@\x02\x02idw\x03maxy\0\x05\x04\0\x04read\x01\x06\x01j\x01y\x01\x01\
-\x01@\x02\x02idw\x05bytes\x04\0\x07\x04\0\x05write\x01\x08\x01j\0\x01\x01\x01@\x02\
-\x02idw\x04hosts\0\x09\x04\0\x09start-tls\x01\x0a\x01@\x01\x02idw\x01\0\x04\0\x05\
-close\x01\x0b\x03\0\x1dthoth:plugin/tcp-client@0.1.0\x05\x05\x01B\x0b\x02\x03\x02\
-\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01j\0\x01\x01\x01@\x02\x03keys\x06secret\
-s\0\x02\x04\0\x05write\x01\x03\x01ks\x01j\x01\x04\x01\x01\x01@\x01\x03keys\0\x05\
-\x04\0\x04read\x01\x06\x01@\x01\x03keys\0\x02\x04\0\x06delete\x01\x07\x03\0!thot\
-h:plugin/secure-storage@0.1.0\x05\x06\x01B\x02\x01@\x02\x06handles\x01qs\0s\x04\0\
-\x0csubmit-query\x01\0\x03\0\x1dthoth:plugin/db-runtime@0.1.0\x05\x07\x01B\x04\x01\
-m\x03\x05ready\x07loading\x05error\x04\0\x06status\x03\0\0\x01@\x04\x03keys\x05v\
-alues\x06status\x01\x06ttl-msy\x01\0\x04\0\x0bemit-signal\x01\x02\x03\0\x1athoth\
-:plugin/signals@0.1.0\x05\x08\x01B\x0d\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\
-\x03\0\0\x01r\x02\x04paths\x08contentss\x04\0\x0bopened-file\x03\0\x02\x01ps\x01\
-k\x03\x01j\x01\x05\x01\x01\x01@\x02\x05titles\x0aextensions\x04\0\x06\x04\0\x09o\
-pen-file\x01\x07\x01ks\x01j\x01\x08\x01\x01\x01@\x04\x05titles\x0cdefault-names\x0a\
-extensions\x04\x08contentss\0\x09\x04\0\x09save-file\x01\x0a\x03\0\x1ethoth:plug\
-in/file-dialog@0.1.0\x05\x09\x01B\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\
-\0\0\x01r\x04\x04names\x0bdescriptions\x08required\x7f\x05values\x04\0\x0cconfig\
--entry\x03\0\x02\x01r\x03\x04names\x09type-hints\x08nullable\x7f\x04\0\x0cfield-\
-schema\x03\0\x04\x01p\x05\x01r\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\
-\x03\0\x07\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\
-\x01p\x03\x01@\0\0\x0b\x04\0\x0frequired-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\
-\x06config\x0b\0\x0d\x04\0\x07connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\
-\x01\x06handles\0\x10\x04\0\x06schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\
-\0\x05query\x01\x12\x01@\x01\x06handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\
-\x01\x01\x01@\x01\x06handles\0\x14\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:p\
-lugin/data-source@0.1.0\x05\x0a\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-err\
-or\x03\0\0\x01r\x03\x09widget-ids\x04kinds\x05values\x04\0\x08ui-event\x03\0\x02\
-\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\
-\x01\x01\x01@\0\0\x06\x04\0\x09render-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\
-\0\x0chandle-event\x01\x08\x01k\x05\x01j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0er\
-ender-sidebar\x01\x0b\x04\0\x1fthoth:plugin/ui-component@0.1.0\x05\x0b\x01B\x11\x02\
-\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\
-\x01ks\x01@\0\0\x03\x04\0\x08tab-icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\
-\0\x09get-state\x01\x06\x01j\0\x01\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-wi\
-th-state\x01\x08\x01@\0\x01\0\x04\0\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-bl\
-urred\x01\x09\x04\0\x0don-tab-closed\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.\
-0\x05\x0c\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x0d\x04\0\x0bplugi\
-n-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plug\
-in-meta@0.1.0\x05\x0e\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\
-\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#t\
-hoth:plugin/plugin-lifecycle@0.1.0\x05\x0f\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-ou\
-tput\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\
-\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x10\x04\0%thoth:plugin/data-sourc\
-e-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\
-\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41\
-.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3062] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xed\x16\x01A\x02\x01\
+A\"\x01B\x0a\x01m\x06\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
+search-provider\x10new-ui-component\x04\0\x0acapability\x03\0\0\x01p\x01\x01ks\x01\
+r\x08\x02ids\x04names\x07versions\x0bdescriptions\x0ccapabilities\x02\x06author\x03\
+\x08homepage\x03\x04icon\x03\x04\0\x0bplugin-info\x03\0\x04\x01r\x02\x04codey\x07\
+messages\x04\0\x0cplugin-error\x03\0\x06\x01r\x02\x03keys\x05values\x04\0\x0cset\
+ting-data\x03\0\x08\x03\0\x18thoth:plugin/types@0.1.0\x05\0\x02\x03\0\0\x0cplugi\
+n-error\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01o\x02ss\x01\
+p\x02\x01p}\x01k\x04\x01r\x04\x03urls\x06methods\x07headers\x03\x04body\x05\x04\0\
+\x0chttp-request\x03\0\x06\x01r\x03\x06status{\x07headers\x03\x04body\x04\x04\0\x0d\
+http-response\x03\0\x08\x01j\x01\x09\x01\x01\x01@\x01\x03req\x07\0\x0a\x04\0\x05\
+fetch\x01\x0b\x01@\x01\x03req\x07\0s\x04\0\x06submit\x01\x0c\x03\0\x1ethoth:plug\
+in/http-client@0.1.0\x05\x02\x01B\x05\x01@\0\0s\x04\0\x04read\x01\0\x01j\0\x01s\x01\
+@\x01\x04datas\0\x01\x04\0\x05write\x01\x02\x03\0!thoth:plugin/plugin-storage@0.\
+1.0\x05\x03\x01B\x03\x01ks\x01@\x03\x05titles\x04icon\0\x0dinitial-state\0\0s\x04\
+\0\x08open-tab\x01\x01\x03\0\x1athoth:plugin/ui-tabs@0.1.0\x05\x04\x01B\x11\x02\x03\
+\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01j\x01w\x01\x01\x01@\x03\x04hosts\x04\
+port{\x03tls\x7f\0\x02\x04\0\x07connect\x01\x03\x01p}\x01j\x01\x04\x01\x01\x01@\x02\
+\x02idw\x03maxy\0\x05\x04\0\x04read\x01\x06\x01j\x01y\x01\x01\x01@\x02\x02idw\x05\
+bytes\x04\0\x07\x04\0\x05write\x01\x08\x01j\0\x01\x01\x01@\x02\x02idw\x04hosts\0\
+\x09\x04\0\x09start-tls\x01\x0a\x01@\x01\x02idw\x01\0\x04\0\x05close\x01\x0b\x03\
+\0\x1dthoth:plugin/tcp-client@0.1.0\x05\x05\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x0c\
+plugin-error\x03\0\0\x01j\0\x01\x01\x01@\x02\x03keys\x06secrets\0\x02\x04\0\x05w\
+rite\x01\x03\x01ks\x01j\x01\x04\x01\x01\x01@\x01\x03keys\0\x05\x04\0\x04read\x01\
+\x06\x01@\x01\x03keys\0\x02\x04\0\x06delete\x01\x07\x03\0!thoth:plugin/secure-st\
+orage@0.1.0\x05\x06\x01B\x02\x01@\x02\x06handles\x01qs\0s\x04\0\x0csubmit-query\x01\
+\0\x03\0\x1dthoth:plugin/db-runtime@0.1.0\x05\x07\x01B\x04\x01m\x03\x05ready\x07\
+loading\x05error\x04\0\x06status\x03\0\0\x01@\x04\x03keys\x05values\x06status\x01\
+\x06ttl-msy\x01\0\x04\0\x0bemit-signal\x01\x02\x03\0\x1athoth:plugin/signals@0.1\
+.0\x05\x08\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01o\x02ss\
+\x01p\x02\x01j\x01s\x01\x01\x01@\x02\x03urls\x07headers\x03\0\x04\x04\0\x07conne\
+ct\x01\x05\x01j\0\x01\x01\x01@\x02\x02ids\x04texts\0\x06\x04\0\x09send-text\x01\x07\
+\x01p}\x01@\x02\x02ids\x05bytes\x08\0\x06\x04\0\x0bsend-binary\x01\x09\x01@\x01\x02\
+ids\x01\0\x04\0\x05close\x01\x0a\x03\0\x1cthoth:plugin/websocket@0.1.0\x05\x09\x01\
+B\x0d\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04paths\x08con\
+tentss\x04\0\x0bopened-file\x03\0\x02\x01ps\x01k\x03\x01j\x01\x05\x01\x01\x01@\x02\
+\x05titles\x0aextensions\x04\0\x06\x04\0\x09open-file\x01\x07\x01ks\x01j\x01\x08\
+\x01\x01\x01@\x04\x05titles\x0cdefault-names\x0aextensions\x04\x08contentss\0\x09\
+\x04\0\x09save-file\x01\x0a\x03\0\x1ethoth:plugin/file-dialog@0.1.0\x05\x0a\x01B\
+\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04names\x0bdesc\
+riptions\x08required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\x03\x04n\
+ames\x09type-hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\x05\x01r\
+\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09node-js\
+ons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\0\x0f\
+required-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\0\x07\
+connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\0\x06\
+schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\x01\x06\
+handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06handles\0\x14\
+\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\x05\x0b\x01\
+B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09widget-ids\x04\
+kinds\x05values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\x0bheight-hin\
+ty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\0\x09rende\
+r-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\x01k\x05\x01\
+j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\x1fthoth:pl\
+ugin/ui-component@0.1.0\x05\x0c\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-err\
+or\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\0\x08tab-\
+icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\x01j\0\x01\
+\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\x01\0\x04\0\
+\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0don-tab-close\
+d\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.0\x05\x0d\x02\x03\0\0\x0bplugin-inf\
+o\x01B\x04\x02\x03\x02\x01\x0e\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08\
+get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x0f\x01B\x05\x01@\x01\
+\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\
+\x04\0\x11on-setting-change\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x10\
+\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jso\
+ns\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\
+\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.\
+0\x05\x11\x04\0%thoth:plugin/data-source-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12dat\
+a-source-plugin\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\
+\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/url-source/src/bindings.rs
+++ b/plugins/url-source/src/bindings.rs
@@ -1579,7 +1579,7 @@ pub mod thoth {
             /// messages via handle-event with widget-id = <connection-id> and:
             ///   kind = "ws-open"                                     (connected)
             ///   kind = "ws-message", value = JSON {"text":"..."}
-            ///                              or JSON {"binary":"<base64>"}
+            ///                              or JSON {"binary":"<hex>","len":<frame-bytes>}
             ///   kind = "ws-error",   value = message
             ///   kind = "ws-close",   value = JSON {"code":u16,"reason":"..."}
             pub fn connect(

--- a/plugins/url-source/src/lib.rs
+++ b/plugins/url-source/src/lib.rs
@@ -99,6 +99,11 @@ struct State {
     /// The outgoing-message input box.
     #[serde(skip)]
     ws_send_text: String,
+    /// Total bytes sent / received on the current connection (for the status bar).
+    #[serde(skip)]
+    ws_bytes_sent: usize,
+    #[serde(skip)]
+    ws_bytes_recv: usize,
 }
 
 /// Direction of a WebSocket log entry.
@@ -144,6 +149,8 @@ impl State {
             ws_connected: false,
             ws_log: Vec::new(),
             ws_send_text: String::new(),
+            ws_bytes_sent: 0,
+            ws_bytes_recv: 0,
         }
     }
 }

--- a/plugins/url-source/src/lib.rs
+++ b/plugins/url-source/src/lib.rs
@@ -85,6 +85,34 @@ struct State {
     // ── Response cache (transient — never persisted) ──────────────────────
     #[serde(skip)]
     response: Option<ResponseState>,
+
+    // ── WebSocket state (transient — never persisted) ─────────────────────
+    /// Active connection id from `websocket::connect`, while connecting/open.
+    #[serde(skip)]
+    ws_conn_id: Option<String>,
+    /// True once the host reports the socket open.
+    #[serde(skip)]
+    ws_connected: bool,
+    /// Sent / received / system message log, newest last.
+    #[serde(skip)]
+    ws_log: Vec<WsLogEntry>,
+    /// The outgoing-message input box.
+    #[serde(skip)]
+    ws_send_text: String,
+}
+
+/// Direction of a WebSocket log entry.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum WsDir {
+    Sent,
+    Recv,
+    System,
+}
+
+#[derive(Clone, Debug)]
+pub struct WsLogEntry {
+    pub dir: WsDir,
+    pub text: String,
 }
 
 impl State {
@@ -112,6 +140,10 @@ impl State {
             consent_pending: false,
             pending_request_id: None,
             response: None,
+            ws_conn_id: None,
+            ws_connected: false,
+            ws_log: Vec::new(),
+            ws_send_text: String::new(),
         }
     }
 }

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -864,6 +864,27 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
 // WebSocket handlers
 // =============================================================================
 
+/// Human-readable byte count for the status bar.
+fn fmt_bytes(n: usize) -> String {
+    if n < 1024 {
+        format!("{n} B")
+    } else if n < 1024 * 1024 {
+        format!("{:.1} KB", n as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", n as f64 / (1024.0 * 1024.0))
+    }
+}
+
+/// Push the WebSocket status-bar signal: total bytes sent / received.
+fn emit_ws_signal(st: &State, status: SignalStatus) {
+    let value = format!(
+        "↑{} ↓{}",
+        fmt_bytes(st.ws_bytes_sent),
+        fmt_bytes(st.ws_bytes_recv)
+    );
+    signals::emit_signal("ws", &value, status, 0);
+}
+
 /// Append a log line, capping the log so it can't grow without bound.
 fn ws_log(st: &mut State, dir: WsDir, text: impl Into<String>) {
     const MAX: usize = 500;
@@ -912,7 +933,10 @@ fn ws_connect(st: &mut State) {
         Ok(id) => {
             st.ws_conn_id = Some(id);
             st.ws_connected = false;
+            st.ws_bytes_sent = 0;
+            st.ws_bytes_recv = 0;
             ws_log(st, WsDir::System, format!("connecting to {url}…"));
+            emit_ws_signal(st, SignalStatus::Loading);
         }
         Err(e) => ws_log(st, WsDir::System, format!("connect failed: {}", e.message)),
     }
@@ -936,8 +960,10 @@ fn ws_send(st: &mut State) {
     }
     match websocket::send_text(&id, &text) {
         Ok(()) => {
+            st.ws_bytes_sent += text.len();
             ws_log(st, WsDir::Sent, text);
             st.ws_send_text.clear();
+            emit_ws_signal(st, SignalStatus::Ready);
         }
         Err(e) => ws_log(st, WsDir::System, format!("send failed: {}", e.message)),
     }
@@ -953,20 +979,25 @@ fn handle_ws_event(st: &mut State, event: &UiEvent) {
         "ws-open" => {
             st.ws_connected = true;
             ws_log(st, WsDir::System, "connected");
+            emit_ws_signal(st, SignalStatus::Ready);
         }
         "ws-message" => {
             let v: Value = serde_json::from_str(&event.value).unwrap_or(Value::Null);
             if let Some(t) = v.get("text").and_then(|t| t.as_str()) {
+                st.ws_bytes_recv += t.len();
                 ws_log(st, WsDir::Recv, t.to_string());
             } else if let Some(hex) = v.get("binary").and_then(|b| b.as_str()) {
                 let len = v.get("len").and_then(|l| l.as_u64()).unwrap_or(0);
+                st.ws_bytes_recv += len as usize;
                 ws_log(st, WsDir::Recv, format!("<binary {len} bytes> {hex}"));
             }
+            emit_ws_signal(st, SignalStatus::Ready);
         }
         "ws-error" => {
             st.ws_connected = false;
             let msg = event.value.clone();
             ws_log(st, WsDir::System, format!("error: {msg}"));
+            emit_ws_signal(st, SignalStatus::Error);
         }
         "ws-close" => {
             let v: Value = serde_json::from_str(&event.value).unwrap_or(Value::Null);
@@ -984,6 +1015,8 @@ fn handle_ws_event(st: &mut State, event: &UiEvent) {
                 format!("closed ({code}): {reason}")
             };
             ws_log(st, WsDir::System, msg);
+            // Keep the final byte totals visible, but mark the socket idle.
+            emit_ws_signal(st, SignalStatus::Ready);
         }
         _ => {}
     }
@@ -1021,6 +1054,14 @@ pub fn apply_event(st: &mut State, event: &UiEvent) {
         "url" => {
             let raw = parse_str(&event.value);
             parse_url_into_state(st, raw);
+            // Typing/pasting a ws(s):// URL switches the method to WS/WSS so the
+            // UI enters WebSocket mode.
+            let scheme = st.url.trim_start().to_ascii_lowercase();
+            if scheme.starts_with("wss://") {
+                st.method = "WSS".to_string();
+            } else if scheme.starts_with("ws://") {
+                st.method = "WS".to_string();
+            }
         }
 
         "req-tabs" if parse_str(&event.value) == "Body" && !is_body_method(&st.method) => {

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -994,10 +994,14 @@ fn handle_ws_event(st: &mut State, event: &UiEvent) {
             emit_ws_signal(st, SignalStatus::Ready);
         }
         "ws-error" => {
+            // Errors are terminal (the host task ends), so reset like a close.
             st.ws_connected = false;
+            st.ws_conn_id = None;
             let msg = event.value.clone();
             ws_log(st, WsDir::System, format!("error: {msg}"));
             emit_ws_signal(st, SignalStatus::Error);
+            // Release the host-side connection entry.
+            websocket::close(&event.widget_id);
         }
         "ws-close" => {
             let v: Value = serde_json::from_str(&event.value).unwrap_or(Value::Null);
@@ -1017,6 +1021,8 @@ fn handle_ws_event(st: &mut State, event: &UiEvent) {
             ws_log(st, WsDir::System, msg);
             // Keep the final byte totals visible, but mark the socket idle.
             emit_ws_signal(st, SignalStatus::Ready);
+            // Release the host-side connection entry (server-initiated close).
+            websocket::close(&event.widget_id);
         }
         _ => {}
     }
@@ -1061,6 +1067,10 @@ pub fn apply_event(st: &mut State, event: &UiEvent) {
                 st.method = "WSS".to_string();
             } else if scheme.starts_with("ws://") {
                 st.method = "WS".to_string();
+            } else if st.ws_conn_id.is_some() && !is_ws_url(&st.url) {
+                // Navigated away from a WebSocket endpoint while connected —
+                // close the socket so it isn't orphaned.
+                ws_disconnect(st);
             }
         }
 

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -17,8 +17,8 @@ use serde_json::Value;
 use thoth_plugin_sdk::components::{
     Align, Badge, BgColor, Button, ButtonColor, Code, CodeEditor, Column, DataRow, DataRowIcon,
     IconButton, Input, JsonTree, KeyValueList, KvEntry, List, ListItem, ListItemAction,
-    ListItemBadge, Modal, Radio, Row, Scroll, Select, SelectOption, Separator, Spinner, Split,
-    TabAction, TableView, Tabs, Typography, TypographyVariant,
+    ListItemBadge, Modal, Radio, Row, Scroll, Select, SelectOption, Separator, Spacer, Spinner,
+    Split, TabAction, TableView, Tabs, Typography, TypographyVariant,
 };
 use thoth_plugin_sdk::render_node::RenderNode;
 
@@ -380,6 +380,7 @@ fn build_ws_panel(st: &State) -> RenderNode {
                                 st.ws_connected && !st.ws_send_text.is_empty(),
                                 ButtonColor::Primary,
                             ),
+                            RenderNode::Spacer(Spacer::builder().size(8.0).build()),
                         ])
                         .build(),
                 ),
@@ -1006,7 +1007,13 @@ pub fn apply_event(st: &mut State, event: &UiEvent) {
 
     match event.widget_id.as_str() {
         "ws-toggle" => ws_toggle(st),
-        "ws-send-text" => st.ws_send_text = parse_str(&event.value),
+        "ws-send-text" => {
+            st.ws_send_text = parse_str(&event.value);
+            // Enter in the box sends.
+            if event.kind == "submit" {
+                ws_send(st);
+            }
+        }
         "ws-send" => ws_send(st),
         "request-name" => st.request_name = parse_str(&event.value),
 

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -281,7 +281,7 @@ fn build_request_column(st: &State) -> RenderNode {
 }
 
 fn build_response_column(st: &State) -> RenderNode {
-    if is_ws_url(&st.url) {
+    if is_ws_mode(st) {
         return build_ws_panel(st);
     }
 
@@ -408,7 +408,7 @@ fn ws_log_row(entry: &WsLogEntry) -> RenderNode {
 }
 
 fn build_url_bar(st: &State) -> RenderNode {
-    let method_options: Vec<SelectOption> = ["GET", "POST", "PUT", "PATCH", "DELETE"]
+    let method_options: Vec<SelectOption> = ["GET", "POST", "PUT", "PATCH", "DELETE", "WS", "WSS"]
         .iter()
         .map(|m| SelectOption::builder().value(*m).label(*m).build())
         .collect();
@@ -444,15 +444,37 @@ fn build_url_bar(st: &State) -> RenderNode {
     )
 }
 
-/// True when the URL targets a WebSocket endpoint.
+/// True when the URL scheme is ws:// or wss://.
 pub fn is_ws_url(url: &str) -> bool {
     let u = url.trim_start().to_ascii_lowercase();
     u.starts_with("ws://") || u.starts_with("wss://")
 }
 
+/// WebSocket mode is active when the method is WS/WSS or the URL already uses a
+/// ws(s):// scheme (e.g. a pasted URL).
+pub fn is_ws_mode(st: &State) -> bool {
+    st.method == "WS" || st.method == "WSS" || is_ws_url(&st.url)
+}
+
+/// The URL to connect to, normalised to a ws(s):// scheme. If the URL already
+/// has a ws(s):// scheme it's used as-is; otherwise the scheme is derived from
+/// the selected method (WS → ws://, else wss://), replacing any http(s)://.
+fn ws_connect_url(st: &State) -> String {
+    let u = st.url.trim();
+    if is_ws_url(u) {
+        return u.to_string();
+    }
+    let scheme = if st.method == "WS" { "ws://" } else { "wss://" };
+    let bare = u
+        .strip_prefix("https://")
+        .or_else(|| u.strip_prefix("http://"))
+        .unwrap_or(u);
+    format!("{scheme}{bare}")
+}
+
 /// Connect/Disconnect for ws(s):// URLs; ⚡ Send otherwise.
 fn ws_or_send_button(st: &State) -> RenderNode {
-    if is_ws_url(&st.url) {
+    if is_ws_mode(st) {
         if st.ws_conn_id.is_some() {
             btn("ws-toggle", "Disconnect", true, ButtonColor::Danger)
         } else {
@@ -866,12 +888,12 @@ fn ws_connect(st: &mut State) {
     if st.url.is_empty() {
         return;
     }
+    let url = ws_connect_url(st);
     let headers = ws_headers(st);
-    match websocket::connect(&st.url, &headers) {
+    match websocket::connect(&url, &headers) {
         Ok(id) => {
             st.ws_conn_id = Some(id);
             st.ws_connected = false;
-            let url = st.url.clone();
             ws_log(st, WsDir::System, format!("connecting to {url}…"));
         }
         Err(e) => ws_log(st, WsDir::System, format!("connect failed: {}", e.message)),

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -15,10 +15,10 @@ use crate::{
 };
 use serde_json::Value;
 use thoth_plugin_sdk::components::{
-    Align, Badge, BgColor, Button, ButtonColor, Code, CodeEditor, Column, IconButton, Input,
-    JsonTree, KeyValueList, KvEntry, List, ListItem, ListItemAction, ListItemBadge, Modal, Radio,
-    Row, Scroll, Select, SelectOption, Separator, Spinner, Split, TabAction, TableView, Tabs,
-    Typography, TypographyVariant,
+    Align, Badge, BgColor, Button, ButtonColor, Code, CodeEditor, Column, DataRow, DataRowIcon,
+    IconButton, Input, JsonTree, KeyValueList, KvEntry, List, ListItem, ListItemAction,
+    ListItemBadge, Modal, Radio, Row, Scroll, Select, SelectOption, Separator, Spinner, Split,
+    TabAction, TableView, Tabs, Typography, TypographyVariant,
 };
 use thoth_plugin_sdk::render_node::RenderNode;
 
@@ -339,7 +339,11 @@ fn build_ws_panel(st: &State) -> RenderNode {
     let log_rows: Vec<RenderNode> = if st.ws_log.is_empty() {
         vec![muted("No messages yet. Connect, then send a frame.")]
     } else {
-        st.ws_log.iter().map(ws_log_row).collect()
+        st.ws_log
+            .iter()
+            .enumerate()
+            .map(|(i, e)| ws_log_row(i, e))
+            .collect()
     };
 
     RenderNode::Column(
@@ -393,18 +397,31 @@ fn build_ws_panel(st: &State) -> RenderNode {
     )
 }
 
-/// One message-log line: direction arrow + text.
-fn ws_log_row(entry: &WsLogEntry) -> RenderNode {
-    let prefix = match entry.dir {
-        WsDir::Sent => "→ ",
-        WsDir::Recv => "← ",
-        WsDir::System => "• ",
+// Phosphor (regular) arrows for the WebSocket log direction.
+const ICON_ARROW_UP: &str = "\u{E08E}"; // ARROW_UP — sent
+const ICON_ARROW_DOWN: &str = "\u{E03E}"; // ARROW_DOWN — received
+const ICON_DOT: &str = "\u{E18A}"; // CIRCLE — system
+
+/// One message-log line as a DataRow with a colour-coded direction arrow:
+/// sent (↑, blue), received (↓, green), system (•, muted).
+fn ws_log_row(idx: usize, entry: &WsLogEntry) -> RenderNode {
+    let (glyph, color) = match entry.dir {
+        WsDir::Sent => (ICON_ARROW_UP, Some("#89b4fa".to_string())),
+        WsDir::Recv => (ICON_ARROW_DOWN, Some("#a6e3a1".to_string())),
+        WsDir::System => (ICON_DOT, None),
     };
-    let line = format!("{prefix}{}", entry.text);
-    match entry.dir {
-        WsDir::System => muted(&line),
-        _ => text(&line),
-    }
+    RenderNode::DataRow(
+        DataRow::builder()
+            .row_id(format!("ws-log-{idx}"))
+            .display_text(entry.text.clone())
+            .leading_icon(
+                DataRowIcon::builder()
+                    .glyph(glyph)
+                    .maybe_color(color)
+                    .build(),
+            )
+            .build(),
+    )
 }
 
 fn build_url_bar(st: &State) -> RenderNode {

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -4,13 +4,14 @@ use crate::{
         thoth::plugin::{
             http_client,
             signals::{self, Status as SignalStatus},
+            websocket,
         },
     },
     helper::{
         is_body_method, parse_kv_list, parse_str, parse_url_into_state, status_color, status_text,
     },
     http::build_request,
-    KvPair, ResponseState, State,
+    KvPair, ResponseState, State, WsDir, WsLogEntry,
 };
 use serde_json::Value;
 use thoth_plugin_sdk::components::{
@@ -280,6 +281,10 @@ fn build_request_column(st: &State) -> RenderNode {
 }
 
 fn build_response_column(st: &State) -> RenderNode {
+    if is_ws_url(&st.url) {
+        return build_ws_panel(st);
+    }
+
     if st.loading {
         let label = if st.consent_pending {
             "Waiting for consent approval…"
@@ -320,6 +325,88 @@ fn build_response_column(st: &State) -> RenderNode {
     }
 }
 
+/// WebSocket panel: status header, send box, then the message log (fills the
+/// rest and scrolls). Shown in the response column for ws(s):// URLs.
+fn build_ws_panel(st: &State) -> RenderNode {
+    let status = if st.ws_connected {
+        "● connected"
+    } else if st.ws_conn_id.is_some() {
+        "○ connecting…"
+    } else {
+        "○ disconnected"
+    };
+
+    let log_rows: Vec<RenderNode> = if st.ws_log.is_empty() {
+        vec![muted("No messages yet. Connect, then send a frame.")]
+    } else {
+        st.ws_log.iter().map(ws_log_row).collect()
+    };
+
+    RenderNode::Column(
+        Column::builder()
+            .gap(0.0)
+            .children(vec![
+                RenderNode::Row(
+                    Row::builder()
+                        .bg_color(BgColor::BgPanel)
+                        .max_width(true)
+                        .padding(8.0)
+                        .children(vec![muted(status)])
+                        .build(),
+                ),
+                RenderNode::Row(
+                    Row::builder()
+                        .gap(4.0)
+                        .padding(4.0)
+                        .max_width(true)
+                        .align(Align::Fill)
+                        .children(vec![
+                            RenderNode::Input(
+                                Input::builder()
+                                    .id("ws-send-text")
+                                    .value(st.ws_send_text.clone())
+                                    .placeholder("Message to send…")
+                                    .grow(true)
+                                    .disabled(!st.ws_connected)
+                                    .build(),
+                            ),
+                            btn(
+                                "ws-send",
+                                "Send",
+                                st.ws_connected && !st.ws_send_text.is_empty(),
+                                ButtonColor::Primary,
+                            ),
+                        ])
+                        .build(),
+                ),
+                RenderNode::Separator(Separator::plain()),
+                RenderNode::Scroll(
+                    Scroll::builder()
+                        .id("ws-log-scroll")
+                        .child(RenderNode::Column(
+                            Column::builder().gap(2.0).children(log_rows).build(),
+                        ))
+                        .build(),
+                ),
+            ])
+            .build(),
+    )
+}
+
+/// One message-log line: direction arrow + text.
+fn ws_log_row(entry: &WsLogEntry) -> RenderNode {
+    let prefix = match entry.dir {
+        WsDir::Sent => "→ ",
+        WsDir::Recv => "← ",
+        WsDir::System => "• ",
+    };
+    let line = format!("{prefix}{}", entry.text);
+    match entry.dir {
+        WsDir::System => muted(&line),
+        _ => text(&line),
+    }
+}
+
 fn build_url_bar(st: &State) -> RenderNode {
     let method_options: Vec<SelectOption> = ["GET", "POST", "PUT", "PATCH", "DELETE"]
         .iter()
@@ -351,10 +438,34 @@ fn build_url_bar(st: &State) -> RenderNode {
                         .build(),
                 ),
                 btn("clear", "Clear", true, ButtonColor::Danger),
-                btn("send", "⚡ Send", !st.url.is_empty(), ButtonColor::Primary),
+                ws_or_send_button(st),
             ])
             .build(),
     )
+}
+
+/// True when the URL targets a WebSocket endpoint.
+pub fn is_ws_url(url: &str) -> bool {
+    let u = url.trim_start().to_ascii_lowercase();
+    u.starts_with("ws://") || u.starts_with("wss://")
+}
+
+/// Connect/Disconnect for ws(s):// URLs; ⚡ Send otherwise.
+fn ws_or_send_button(st: &State) -> RenderNode {
+    if is_ws_url(&st.url) {
+        if st.ws_conn_id.is_some() {
+            btn("ws-toggle", "Disconnect", true, ButtonColor::Danger)
+        } else {
+            btn(
+                "ws-toggle",
+                "Connect",
+                !st.url.is_empty(),
+                ButtonColor::Primary,
+            )
+        }
+    } else {
+        btn("send", "⚡ Send", !st.url.is_empty(), ButtonColor::Primary)
+    }
 }
 
 fn build_req_tabs(st: &State) -> RenderNode {
@@ -710,6 +821,135 @@ fn handle_http_response(st: &mut State, event: &UiEvent) {
 }
 
 // =============================================================================
+// WebSocket handlers
+// =============================================================================
+
+/// Append a log line, capping the log so it can't grow without bound.
+fn ws_log(st: &mut State, dir: WsDir, text: impl Into<String>) {
+    const MAX: usize = 500;
+    st.ws_log.push(WsLogEntry {
+        dir,
+        text: text.into(),
+    });
+    if st.ws_log.len() > MAX {
+        let excess = st.ws_log.len() - MAX;
+        st.ws_log.drain(0..excess);
+    }
+}
+
+/// Connect headers: enabled custom request headers, plus bearer auth.
+fn ws_headers(st: &State) -> Vec<(String, String)> {
+    let mut headers: Vec<(String, String)> = st
+        .req_headers
+        .iter()
+        .filter(|h| h.enabled && !h.key.is_empty())
+        .map(|h| (h.key.clone(), h.value.clone()))
+        .collect();
+    if st.auth_type == "bearer" && !st.auth_token.is_empty() {
+        headers.push((
+            "Authorization".to_string(),
+            format!("Bearer {}", st.auth_token),
+        ));
+    }
+    headers
+}
+
+fn ws_toggle(st: &mut State) {
+    if st.ws_conn_id.is_some() {
+        ws_disconnect(st);
+    } else {
+        ws_connect(st);
+    }
+}
+
+fn ws_connect(st: &mut State) {
+    if st.url.is_empty() {
+        return;
+    }
+    let headers = ws_headers(st);
+    match websocket::connect(&st.url, &headers) {
+        Ok(id) => {
+            st.ws_conn_id = Some(id);
+            st.ws_connected = false;
+            let url = st.url.clone();
+            ws_log(st, WsDir::System, format!("connecting to {url}…"));
+        }
+        Err(e) => ws_log(st, WsDir::System, format!("connect failed: {}", e.message)),
+    }
+}
+
+fn ws_disconnect(st: &mut State) {
+    if let Some(id) = st.ws_conn_id.take() {
+        websocket::close(&id);
+    }
+    st.ws_connected = false;
+    ws_log(st, WsDir::System, "disconnected");
+}
+
+fn ws_send(st: &mut State) {
+    let Some(id) = st.ws_conn_id.clone() else {
+        return;
+    };
+    let text = st.ws_send_text.clone();
+    if text.is_empty() {
+        return;
+    }
+    match websocket::send_text(&id, &text) {
+        Ok(()) => {
+            ws_log(st, WsDir::Sent, text);
+            st.ws_send_text.clear();
+        }
+        Err(e) => ws_log(st, WsDir::System, format!("send failed: {}", e.message)),
+    }
+}
+
+/// Fold a host WebSocket event (ws-open/message/error/close) into state.
+fn handle_ws_event(st: &mut State, event: &UiEvent) {
+    // Only events for the current connection matter (ignore a stale one).
+    if st.ws_conn_id.as_deref() != Some(event.widget_id.as_str()) {
+        return;
+    }
+    match event.kind.as_str() {
+        "ws-open" => {
+            st.ws_connected = true;
+            ws_log(st, WsDir::System, "connected");
+        }
+        "ws-message" => {
+            let v: Value = serde_json::from_str(&event.value).unwrap_or(Value::Null);
+            if let Some(t) = v.get("text").and_then(|t| t.as_str()) {
+                ws_log(st, WsDir::Recv, t.to_string());
+            } else if let Some(hex) = v.get("binary").and_then(|b| b.as_str()) {
+                let len = v.get("len").and_then(|l| l.as_u64()).unwrap_or(0);
+                ws_log(st, WsDir::Recv, format!("<binary {len} bytes> {hex}"));
+            }
+        }
+        "ws-error" => {
+            st.ws_connected = false;
+            let msg = event.value.clone();
+            ws_log(st, WsDir::System, format!("error: {msg}"));
+        }
+        "ws-close" => {
+            let v: Value = serde_json::from_str(&event.value).unwrap_or(Value::Null);
+            let code = v.get("code").and_then(|c| c.as_u64()).unwrap_or(0);
+            let reason = v
+                .get("reason")
+                .and_then(|r| r.as_str())
+                .unwrap_or("")
+                .to_string();
+            st.ws_connected = false;
+            st.ws_conn_id = None;
+            let msg = if reason.is_empty() {
+                format!("closed ({code})")
+            } else {
+                format!("closed ({code}): {reason}")
+            };
+            ws_log(st, WsDir::System, msg);
+        }
+        _ => {}
+    }
+}
+
+// =============================================================================
 // Event → state mutations
 // =============================================================================
 
@@ -718,8 +958,17 @@ pub fn apply_event(st: &mut State, event: &UiEvent) {
         handle_http_response(st, event);
         return;
     }
+    // WebSocket lifecycle/message events are keyed by connection id, not a
+    // known widget id, so route them by kind.
+    if event.kind.starts_with("ws-") {
+        handle_ws_event(st, event);
+        return;
+    }
 
     match event.widget_id.as_str() {
+        "ws-toggle" => ws_toggle(st),
+        "ws-send-text" => st.ws_send_text = parse_str(&event.value),
+        "ws-send" => ws_send(st),
         "request-name" => st.request_name = parse_str(&event.value),
 
         "method" => st.method = parse_str(&event.value),

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -94,6 +94,38 @@ fn build_query_result_event(
     }
 }
 
+/// Build the plugin UiEvent for a WebSocket lifecycle/message event. The
+/// `widget_id` is the connection id; `kind`/`value` mirror the `websocket` WIT
+/// contract (ws-open / ws-message / ws-error / ws-close).
+fn build_ws_event(
+    conn_id: String,
+    event: crate::plugin::websocket::WsEvent,
+) -> crate::plugin::render_node::UiEvent {
+    use crate::plugin::websocket::WsEvent;
+    let (kind, value) = match event {
+        WsEvent::Open => ("ws-open", String::new()),
+        WsEvent::Text(t) => ("ws-message", serde_json::json!({ "text": t }).to_string()),
+        WsEvent::Binary(b) => {
+            // Hex-encode binary frames for display (no extra dependency).
+            let hex: String = b.iter().map(|byte| format!("{byte:02x}")).collect();
+            (
+                "ws-message",
+                serde_json::json!({ "binary": hex, "len": b.len() }).to_string(),
+            )
+        }
+        WsEvent::Error(m) => ("ws-error", m),
+        WsEvent::Closed { code, reason } => (
+            "ws-close",
+            serde_json::json!({ "code": code, "reason": reason }).to_string(),
+        ),
+    };
+    crate::plugin::render_node::UiEvent {
+        widget_id: conn_id,
+        kind: kind.to_string(),
+        value,
+    }
+}
+
 /// A plugin's sidebar instance, independent of any dock tab. Created when the user
 /// opens the plugin's sidebar and kept alive while the sidebar is toggled, so its
 /// state survives collapse/expand and never affects (or requires) a tab. Tabs are
@@ -251,6 +283,10 @@ impl App for ThothApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut Frame) {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
+
+        // Publish the context once so off-thread workers (WebSocket tasks) can
+        // request a repaint when data arrives.
+        let _ = crate::EGUI_CTX.set(ctx.clone());
 
         if UpdateHandler::should_check_updates(&self.update_state, &self.settings) {
             UpdateHandler::check_for_updates(&mut self.update_state);
@@ -929,6 +965,7 @@ impl ThothApp {
         let ids: Vec<TabId> = self.window_state.tab_manager.tabs.keys().copied().collect();
         let mut http_dispatch: Vec<(TabId, UiEvent)> = Vec::new();
         let mut query_dispatch: Vec<(TabId, UiEvent)> = Vec::new();
+        let mut ws_dispatch: Vec<(TabId, UiEvent)> = Vec::new();
         let mut retry_dispatch: Vec<(TabId, String, PluginHttpRequest)> = Vec::new();
         let mut tab_open_reqs: Vec<TabOpenRequest> = Vec::new();
         let mut needs_repaint = false;
@@ -953,6 +990,9 @@ impl ThothApp {
                 for (request_id, result) in pane.loader.drain_query_results() {
                     query_dispatch.push((*id, build_query_result_event(request_id, result)));
                 }
+                for (conn_id, event) in pane.loader.drain_ws_events() {
+                    ws_dispatch.push((*id, build_ws_event(conn_id, event)));
+                }
             }
             for (request_id, req) in pane.loader.drain_retry_requests() {
                 retry_dispatch.push((*id, request_id, req));
@@ -966,6 +1006,7 @@ impl ThothApp {
         // The mounted plugin sidebar runs independently of tabs — drive it too.
         let mut sidebar_http: Vec<UiEvent> = Vec::new();
         let mut sidebar_query: Vec<UiEvent> = Vec::new();
+        let mut sidebar_ws: Vec<UiEvent> = Vec::new();
         let mut sidebar_retry: Vec<(String, PluginHttpRequest)> = Vec::new();
         if let Some(rt) = self.sidebar_plugin.as_ref() {
             rt.loader.pump_queries();
@@ -977,6 +1018,9 @@ impl ThothApp {
                 }
                 for (request_id, result) in rt.loader.drain_query_results() {
                     sidebar_query.push(build_query_result_event(request_id, result));
+                }
+                for (conn_id, event) in rt.loader.drain_ws_events() {
+                    sidebar_ws.push(build_ws_event(conn_id, event));
                 }
             }
             // Consent-approved retries must be replayed here too, or a sidebar
@@ -996,10 +1040,16 @@ impl ThothApp {
         for (id, event) in query_dispatch {
             self.dispatch_plugin_event_for(id, event);
         }
+        for (id, event) in ws_dispatch {
+            self.dispatch_plugin_event_for(id, event);
+        }
         for event in sidebar_http {
             self.dispatch_sidebar_event(event);
         }
         for event in sidebar_query {
+            self.dispatch_sidebar_event(event);
+        }
+        for event in sidebar_ws {
             self.dispatch_sidebar_event(event);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,11 @@ pub static NOTIFICATION_MANAGER: OnceLock<std::sync::Mutex<notification::Notific
 pub static CONSENT_MANAGER: OnceLock<std::sync::Mutex<consent::manager::ConsentManager>> =
     OnceLock::new();
 
+/// The egui context, published once on the first frame so background workers
+/// (e.g. the WebSocket connection tasks) can request a repaint when data
+/// arrives off the UI thread.
+pub static EGUI_CTX: OnceLock<eframe::egui::Context> = OnceLock::new();
+
 /// Set to `true` by the "Update Now" notification action callback.
 /// Polled each frame by ThothApp and cleared after opening the updates settings tab.
 pub static OPEN_UPDATES_REQUESTED: AtomicBool = AtomicBool::new(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,13 @@ fn main() -> Result<()> {
     #[cfg(feature = "profiling")]
     puffin::set_scopes_on(true);
 
+    // Install a process-wide rustls crypto provider before any TLS handshake.
+    // Both aws-lc-rs and ring are present in the tree, so rustls 0.23 can't
+    // auto-select one for the WebSocket broker's `wss://` connections
+    // (tokio-tungstenite) — pin aws-lc-rs explicitly. Ignore the error if a
+    // provider was already installed.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Parse command-line arguments for file path
     let args: Vec<String> = std::env::args().collect();
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -16,6 +16,7 @@ pub mod wasm_file_viewer_loader;
 pub mod wasm_loader;
 pub mod wasm_plugin_settings;
 pub mod wasm_ui_component;
+pub mod websocket;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct NetworkDeclarations {

--- a/src/plugin/plugin_ui_host.rs
+++ b/src/plugin/plugin_ui_host.rs
@@ -168,4 +168,11 @@ pub trait PluginUiHost: Send {
     fn has_pending_query(&self) -> bool {
         false
     }
+
+    // ── websocket events (only data-source implements; default is a no-op) ───────
+
+    /// Drain WebSocket lifecycle + message events: `(connection_id, event)`.
+    fn drain_ws_events(&self) -> Vec<(String, crate::plugin::websocket::WsEvent)> {
+        Vec::new()
+    }
 }

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -177,8 +177,10 @@ struct DataSourcePluginState {
     query_pending: Arc<AtomicUsize>,
     // WebSocket connections opened via the `websocket` import. Events flow back
     // on `ws_event_tx`; `ws_conns` maps a connection id to its command channel.
+    // `ws_conns` is shared so a consent-approval callback (which can't borrow
+    // `self`) can insert a connection once the user allows it.
     ws_event_tx: std::sync::mpsc::Sender<(String, WsEvent)>,
-    ws_conns: HashMap<String, tokio::sync::mpsc::UnboundedSender<WsCommand>>,
+    ws_conns: Arc<Mutex<HashMap<String, tokio::sync::mpsc::UnboundedSender<WsCommand>>>>,
 }
 
 impl WasiView for DataSourcePluginState {
@@ -764,40 +766,75 @@ impl thoth::plugin::websocket::Host for DataSourcePluginState {
     ) -> std::result::Result<String, thoth::plugin::websocket::PluginError> {
         let ws_err =
             |code: u32, message: String| thoth::plugin::websocket::PluginError { code, message };
+        let conn_id = next_ws_id();
         match self.policy.check(&url) {
             Ok(CheckOutcome::Allowed) => {
-                let conn_id = next_ws_id();
                 let cmd_tx = crate::plugin::websocket::spawn(
                     url,
                     headers,
                     conn_id.clone(),
                     self.ws_event_tx.clone(),
                 );
-                self.ws_conns.insert(conn_id.clone(), cmd_tx);
+                if let Ok(mut map) = self.ws_conns.lock() {
+                    map.insert(conn_id.clone(), cmd_tx);
+                }
                 Ok(conn_id)
             }
             Ok(CheckOutcome::NeedsConsent { domain }) => {
-                // Inform + gate; the user re-connects after approving the host.
+                // Optimistically hand back the id (the plugin shows "connecting…")
+                // and defer the actual connect until the user decides. On ALLOW —
+                // one-time or remembered — spawn the connection; only "remember"
+                // updates the runtime allowlist. On DENY, emit a close so the
+                // plugin resets. Mirrors the async http consent path.
                 let _ = self.consent_tx.send(ConsentRequest {
                     domain: domain.clone(),
                     plugin_id: self.plugin_id.clone(),
                 });
                 let runtime_allowed = self.policy.runtime_allowed_handle();
-                let dom = domain.clone();
-                ConsentManager::push_http_consent(
-                    &domain,
-                    &self.plugin_id,
-                    Arc::new(move |remember: bool| {
-                        if remember && let Ok(mut list) = runtime_allowed.lock() {
-                            list.push(dom.clone());
-                        }
-                    }),
-                    Arc::new(|_| {}),
-                );
-                Err(ws_err(
-                    403,
-                    format!("domain '{domain}' not approved — waiting for user consent"),
-                ))
+                let conns = Arc::clone(&self.ws_conns);
+                // `mpsc::Sender` is not `Sync`, so wrap it for the consent closures.
+                let ev_tx = Arc::new(Mutex::new(self.ws_event_tx.clone()));
+
+                let (a_url, a_headers, a_id) = (url.clone(), headers.clone(), conn_id.clone());
+                let (a_conns, a_ev, a_dom) =
+                    (Arc::clone(&conns), Arc::clone(&ev_tx), domain.clone());
+                let on_allow = Arc::new(move |remember: bool| {
+                    let tx = match a_ev.lock() {
+                        Ok(t) => t.clone(),
+                        Err(_) => return,
+                    };
+                    let cmd_tx = crate::plugin::websocket::spawn(
+                        a_url.clone(),
+                        a_headers.clone(),
+                        a_id.clone(),
+                        tx,
+                    );
+                    if let Ok(mut map) = a_conns.lock() {
+                        map.insert(a_id.clone(), cmd_tx);
+                    }
+                    if remember && let Ok(mut list) = runtime_allowed.lock() {
+                        list.push(a_dom.clone());
+                    }
+                });
+
+                let (d_id, d_ev) = (conn_id.clone(), Arc::clone(&ev_tx));
+                let on_deny = Arc::new(move |_remember: bool| {
+                    if let Ok(tx) = d_ev.lock() {
+                        let _ = tx.send((
+                            d_id.clone(),
+                            WsEvent::Closed {
+                                code: 1008,
+                                reason: "connection denied".to_string(),
+                            },
+                        ));
+                    }
+                    if let Some(ctx) = crate::EGUI_CTX.get() {
+                        ctx.request_repaint();
+                    }
+                });
+
+                ConsentManager::push_http_consent(&domain, &self.plugin_id, on_allow, on_deny);
+                Ok(conn_id)
             }
             Err(violation) => Err(ws_err(403, format!("blocked: {violation:?}"))),
         }
@@ -822,7 +859,9 @@ impl thoth::plugin::websocket::Host for DataSourcePluginState {
     fn close(&mut self, id: String) {
         // Dropping the sender (remove) also closes; send Close first so the task
         // emits a clean close frame + event.
-        if let Some(tx) = self.ws_conns.remove(&id) {
+        if let Ok(mut map) = self.ws_conns.lock()
+            && let Some(tx) = map.remove(&id)
+        {
             let _ = tx.send(WsCommand::Close);
         }
     }
@@ -834,13 +873,13 @@ impl DataSourcePluginState {
         id: &str,
         cmd: WsCommand,
     ) -> std::result::Result<(), thoth::plugin::websocket::PluginError> {
-        match self.ws_conns.get(id) {
-            Some(tx) => tx
-                .send(cmd)
-                .map_err(|_| thoth::plugin::websocket::PluginError {
-                    code: 1,
-                    message: "connection closed".to_string(),
-                }),
+        let ws_err = |message: &str| thoth::plugin::websocket::PluginError {
+            code: 1,
+            message: message.to_string(),
+        };
+        let map = self.ws_conns.lock().map_err(|_| ws_err("lock poisoned"))?;
+        match map.get(id) {
+            Some(tx) => tx.send(cmd).map_err(|_| ws_err("connection closed")),
             None => Err(thoth::plugin::websocket::PluginError {
                 code: 1,
                 message: format!("no such connection: {id}"),
@@ -1038,7 +1077,7 @@ impl WasmDataSourceLoader {
             query_result_tx: query_result_tx.clone(),
             query_pending: Arc::clone(&query_pending),
             ws_event_tx,
-            ws_conns: HashMap::new(),
+            ws_conns: Arc::new(Mutex::new(HashMap::new())),
         };
 
         let mut store = Store::new(engine, state);

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -40,6 +40,7 @@ wasmtime::component::bindgen!({
 pub use exports::thoth::plugin::data_source::{ConfigEntry, PluginError, SourceSchema};
 
 use crate::plugin::render_node::{UiEvent, UiNode, UiOutput};
+use crate::plugin::websocket::{WsCommand, WsEvent};
 
 // ── consent request ───────────────────────────────────────────────────────────
 
@@ -74,6 +75,13 @@ fn next_instance_id(plugin_id: &str) -> String {
 fn next_request_id() -> String {
     format!(
         "req-{}",
+        REQUEST_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    )
+}
+
+fn next_ws_id() -> String {
+    format!(
+        "ws-{}",
         REQUEST_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     )
 }
@@ -167,6 +175,10 @@ struct DataSourcePluginState {
     // leaving its UI waiting forever.
     query_result_tx: std::sync::mpsc::Sender<(String, QueryResult)>,
     query_pending: Arc<AtomicUsize>,
+    // WebSocket connections opened via the `websocket` import. Events flow back
+    // on `ws_event_tx`; `ws_conns` maps a connection id to its command channel.
+    ws_event_tx: std::sync::mpsc::Sender<(String, WsEvent)>,
+    ws_conns: HashMap<String, tokio::sync::mpsc::UnboundedSender<WsCommand>>,
 }
 
 impl WasiView for DataSourcePluginState {
@@ -742,6 +754,101 @@ impl thoth::plugin::signals::Host for DataSourcePluginState {
     }
 }
 
+// ── websocket WIT import — host owns the connection, streams frames back ──────
+
+impl thoth::plugin::websocket::Host for DataSourcePluginState {
+    fn connect(
+        &mut self,
+        url: String,
+        headers: Vec<(String, String)>,
+    ) -> std::result::Result<String, thoth::plugin::websocket::PluginError> {
+        let ws_err =
+            |code: u32, message: String| thoth::plugin::websocket::PluginError { code, message };
+        match self.policy.check(&url) {
+            Ok(CheckOutcome::Allowed) => {
+                let conn_id = next_ws_id();
+                let cmd_tx = crate::plugin::websocket::spawn(
+                    url,
+                    headers,
+                    conn_id.clone(),
+                    self.ws_event_tx.clone(),
+                );
+                self.ws_conns.insert(conn_id.clone(), cmd_tx);
+                Ok(conn_id)
+            }
+            Ok(CheckOutcome::NeedsConsent { domain }) => {
+                // Inform + gate; the user re-connects after approving the host.
+                let _ = self.consent_tx.send(ConsentRequest {
+                    domain: domain.clone(),
+                    plugin_id: self.plugin_id.clone(),
+                });
+                let runtime_allowed = self.policy.runtime_allowed_handle();
+                let dom = domain.clone();
+                ConsentManager::push_http_consent(
+                    &domain,
+                    &self.plugin_id,
+                    Arc::new(move |remember: bool| {
+                        if remember && let Ok(mut list) = runtime_allowed.lock() {
+                            list.push(dom.clone());
+                        }
+                    }),
+                    Arc::new(|_| {}),
+                );
+                Err(ws_err(
+                    403,
+                    format!("domain '{domain}' not approved — waiting for user consent"),
+                ))
+            }
+            Err(violation) => Err(ws_err(403, format!("blocked: {violation:?}"))),
+        }
+    }
+
+    fn send_text(
+        &mut self,
+        id: String,
+        text: String,
+    ) -> std::result::Result<(), thoth::plugin::websocket::PluginError> {
+        self.ws_send(&id, WsCommand::Text(text))
+    }
+
+    fn send_binary(
+        &mut self,
+        id: String,
+        bytes: Vec<u8>,
+    ) -> std::result::Result<(), thoth::plugin::websocket::PluginError> {
+        self.ws_send(&id, WsCommand::Binary(bytes))
+    }
+
+    fn close(&mut self, id: String) {
+        // Dropping the sender (remove) also closes; send Close first so the task
+        // emits a clean close frame + event.
+        if let Some(tx) = self.ws_conns.remove(&id) {
+            let _ = tx.send(WsCommand::Close);
+        }
+    }
+}
+
+impl DataSourcePluginState {
+    fn ws_send(
+        &self,
+        id: &str,
+        cmd: WsCommand,
+    ) -> std::result::Result<(), thoth::plugin::websocket::PluginError> {
+        match self.ws_conns.get(id) {
+            Some(tx) => tx
+                .send(cmd)
+                .map_err(|_| thoth::plugin::websocket::PluginError {
+                    code: 1,
+                    message: "connection closed".to_string(),
+                }),
+            None => Err(thoth::plugin::websocket::PluginError {
+                code: 1,
+                message: format!("no such connection: {id}"),
+            }),
+        }
+    }
+}
+
 // ── file-dialog WIT import — native open/save pickers (host-mediated I/O) ─────
 
 fn fd_err(message: impl Into<String>) -> thoth::plugin::file_dialog::PluginError {
@@ -869,6 +976,8 @@ pub struct WasmDataSourceLoader {
     query_result_rx: std::sync::mpsc::Receiver<(String, QueryResult)>,
     /// In-flight async queries (for repaint-while-pending).
     query_pending: Arc<AtomicUsize>,
+    /// Receives WebSocket lifecycle + message events from connection tasks.
+    ws_event_rx: std::sync::mpsc::Receiver<(String, WsEvent)>,
     plugin_id: String,
     /// Unique per instance; exposed via `PluginUiHost::instance_id` so the host
     /// can scope this pane's signals and reconcile them on close.
@@ -904,6 +1013,7 @@ impl WasmDataSourceLoader {
         let (query_request_tx, query_request_rx) = std::sync::mpsc::channel::<QueryRequest>();
         let (query_result_tx, query_result_rx) =
             std::sync::mpsc::channel::<(String, QueryResult)>();
+        let (ws_event_tx, ws_event_rx) = std::sync::mpsc::channel::<(String, WsEvent)>();
         let pending_count = Arc::new(AtomicUsize::new(0));
         let query_pending = Arc::new(AtomicUsize::new(0));
         let retry_tx_shared = Arc::new(Mutex::new(retry_tx));
@@ -927,6 +1037,8 @@ impl WasmDataSourceLoader {
             current_query: None,
             query_result_tx: query_result_tx.clone(),
             query_pending: Arc::clone(&query_pending),
+            ws_event_tx,
+            ws_conns: HashMap::new(),
         };
 
         let mut store = Store::new(engine, state);
@@ -1013,6 +1125,14 @@ impl WasmDataSourceLoader {
             },
         )?;
 
+        // 9. Register the websocket import (host-owned WS connections).
+        thoth::plugin::websocket::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s).map_err(
+            |e| ThothError::PluginLoadError {
+                path: wasm_path.to_path_buf(),
+                reason: e.to_string(),
+            },
+        )?;
+
         let bindings =
             DataSourcePlugin::instantiate(&mut store, &component, &linker).map_err(|e| {
                 ThothError::PluginLoadError {
@@ -1032,6 +1152,7 @@ impl WasmDataSourceLoader {
             query_result_tx,
             query_result_rx,
             query_pending,
+            ws_event_rx,
             plugin_id,
             instance_id,
             last_sidebar: Mutex::new(None),
@@ -1572,6 +1693,10 @@ impl PluginUiHost for WasmDataSourceLoader {
 
     fn has_pending_query(&self) -> bool {
         WasmDataSourceLoader::has_pending_query(self)
+    }
+
+    fn drain_ws_events(&self) -> Vec<(String, WsEvent)> {
+        self.ws_event_rx.try_iter().collect()
     }
 }
 

--- a/src/plugin/websocket.rs
+++ b/src/plugin/websocket.rs
@@ -1,0 +1,161 @@
+//! Host-side WebSocket connection manager for the plugin `websocket` import.
+//!
+//! Plugins are sandboxed and can't open sockets, so the host owns each
+//! WebSocket connection (via `tokio-tungstenite`) and streams frames back to
+//! the plugin through the async `handle-event` path — mirroring the `http`
+//! `submit` model. Each connection runs as a task on a shared multi-thread
+//! runtime; the plugin controls it with a command channel and receives
+//! lifecycle + message events on an mpsc channel drained by the app each frame.
+
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::{HeaderName, HeaderValue};
+
+/// Dedicated runtime for WebSocket tasks (kept off the blocking HTTP threads).
+static WS_RT: LazyLock<Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("build websocket runtime")
+});
+
+/// Keepalive ping cadence.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// A lifecycle / message event delivered from a connection task to the app.
+#[derive(Debug)]
+pub enum WsEvent {
+    Open,
+    Text(String),
+    Binary(Vec<u8>),
+    Error(String),
+    Closed { code: u16, reason: String },
+}
+
+/// A command the plugin issues on an open connection.
+pub enum WsCommand {
+    Text(String),
+    Binary(Vec<u8>),
+    Close,
+}
+
+/// Spawn a WebSocket connection task for `url` (already policy-approved by the
+/// caller). Lifecycle + messages are sent on `event_tx` tagged with `conn_id`;
+/// the returned sender drives `send`/`close`. Dropping the sender closes it.
+pub fn spawn(
+    url: String,
+    headers: Vec<(String, String)>,
+    conn_id: String,
+    event_tx: std::sync::mpsc::Sender<(String, WsEvent)>,
+) -> UnboundedSender<WsCommand> {
+    let (cmd_tx, mut cmd_rx) = unbounded_channel::<WsCommand>();
+
+    WS_RT.spawn(async move {
+        let request = match url.into_client_request() {
+            Ok(mut req) => {
+                for (k, v) in &headers {
+                    if let (Ok(name), Ok(val)) = (
+                        HeaderName::from_bytes(k.as_bytes()),
+                        HeaderValue::from_str(v),
+                    ) {
+                        req.headers_mut().insert(name, val);
+                    }
+                }
+                req
+            }
+            Err(e) => {
+                emit(&event_tx, &conn_id, WsEvent::Error(e.to_string()));
+                return;
+            }
+        };
+
+        let ws = match tokio_tungstenite::connect_async(request).await {
+            Ok((ws, _resp)) => ws,
+            Err(e) => {
+                emit(&event_tx, &conn_id, WsEvent::Error(e.to_string()));
+                return;
+            }
+        };
+        emit(&event_tx, &conn_id, WsEvent::Open);
+
+        let (mut write, mut read) = ws.split();
+        let mut ping = tokio::time::interval(PING_INTERVAL);
+        ping.tick().await; // consume the immediate first tick
+
+        loop {
+            tokio::select! {
+                incoming = read.next() => match incoming {
+                    Some(Ok(Message::Text(t))) => {
+                        emit(&event_tx, &conn_id, WsEvent::Text(t));
+                    }
+                    Some(Ok(Message::Binary(b))) => {
+                        emit(&event_tx, &conn_id, WsEvent::Binary(b));
+                    }
+                    Some(Ok(Message::Close(frame))) => {
+                        let (code, reason) = frame
+                            .map(|c| (u16::from(c.code), c.reason.to_string()))
+                            .unwrap_or((1005, String::new()));
+                        emit(&event_tx, &conn_id, WsEvent::Closed { code, reason });
+                        break;
+                    }
+                    // Ping/Pong are handled by tungstenite; ignore other frames.
+                    Some(Ok(_)) => {}
+                    Some(Err(e)) => {
+                        emit(&event_tx, &conn_id, WsEvent::Error(e.to_string()));
+                        break;
+                    }
+                    None => {
+                        emit(&event_tx, &conn_id, WsEvent::Closed {
+                            code: 1006,
+                            reason: "connection closed".to_string(),
+                        });
+                        break;
+                    }
+                },
+                cmd = cmd_rx.recv() => match cmd {
+                    Some(WsCommand::Text(t)) => {
+                        if write.send(Message::Text(t)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(WsCommand::Binary(b)) => {
+                        if write.send(Message::Binary(b)).await.is_err() {
+                            break;
+                        }
+                    }
+                    // Explicit close, or the plugin dropped the sender.
+                    Some(WsCommand::Close) | None => {
+                        let _ = write.send(Message::Close(None)).await;
+                        emit(&event_tx, &conn_id, WsEvent::Closed {
+                            code: 1000,
+                            reason: "closed by client".to_string(),
+                        });
+                        break;
+                    }
+                },
+                _ = ping.tick() => {
+                    if write.send(Message::Ping(Vec::new())).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    cmd_tx
+}
+
+/// Deliver an event to the app and wake the UI to render it.
+fn emit(tx: &std::sync::mpsc::Sender<(String, WsEvent)>, conn_id: &str, event: WsEvent) {
+    let _ = tx.send((conn_id.to_string(), event));
+    if let Some(ctx) = crate::EGUI_CTX.get() {
+        ctx.request_repaint();
+    }
+}

--- a/src/plugin/websocket.rs
+++ b/src/plugin/websocket.rs
@@ -29,6 +29,9 @@ static WS_RT: LazyLock<Runtime> = LazyLock::new(|| {
 /// Keepalive ping cadence.
 const PING_INTERVAL: Duration = Duration::from_secs(30);
 
+/// Bound the initial handshake so a dead host doesn't leave the task hanging.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
 /// A lifecycle / message event delivered from a connection task to the app.
 #[derive(Debug)]
 pub enum WsEvent {
@@ -58,28 +61,47 @@ pub fn spawn(
     let (cmd_tx, mut cmd_rx) = unbounded_channel::<WsCommand>();
 
     WS_RT.spawn(async move {
-        let request = match url.into_client_request() {
-            Ok(mut req) => {
-                for (k, v) in &headers {
-                    if let (Ok(name), Ok(val)) = (
-                        HeaderName::from_bytes(k.as_bytes()),
-                        HeaderValue::from_str(v),
-                    ) {
-                        req.headers_mut().insert(name, val);
-                    }
-                }
-                req
-            }
+        let mut request = match url.into_client_request() {
+            Ok(req) => req,
             Err(e) => {
                 emit(&event_tx, &conn_id, WsEvent::Error(e.to_string()));
                 return;
             }
         };
+        // Fail fast on a malformed header rather than silently dropping it
+        // (e.g. a bad Authorization value would otherwise connect unauthed).
+        for (k, v) in &headers {
+            match (
+                HeaderName::from_bytes(k.as_bytes()),
+                HeaderValue::from_str(v),
+            ) {
+                (Ok(name), Ok(val)) => {
+                    request.headers_mut().insert(name, val);
+                }
+                _ => {
+                    emit(
+                        &event_tx,
+                        &conn_id,
+                        WsEvent::Error(format!("invalid header: {k}")),
+                    );
+                    return;
+                }
+            }
+        }
 
-        let ws = match tokio_tungstenite::connect_async(request).await {
-            Ok((ws, _resp)) => ws,
-            Err(e) => {
+        let connect = tokio_tungstenite::connect_async(request);
+        let ws = match tokio::time::timeout(CONNECT_TIMEOUT, connect).await {
+            Ok(Ok((ws, _resp))) => ws,
+            Ok(Err(e)) => {
                 emit(&event_tx, &conn_id, WsEvent::Error(e.to_string()));
+                return;
+            }
+            Err(_) => {
+                emit(
+                    &event_tx,
+                    &conn_id,
+                    WsEvent::Error("connection timed out".to_string()),
+                );
                 return;
             }
         };

--- a/thoth-plugin-sdk/src/render_node/render.rs
+++ b/thoth-plugin-sdk/src/render_node/render.rs
@@ -97,10 +97,11 @@ impl RenderNode {
                 // A single-line field loses focus when Enter is pressed; emit a
                 // "submit" so plugins can act on it (e.g. send). Multiline fields
                 // keep focus on Enter (newline), so they never submit here.
-                if out.response.lost_focus()
-                    && ui.input(|inp| inp.key_pressed(egui::Key::Enter))
-                {
+                // Re-request focus so the field stays active for the next entry
+                // (a chat-style send box keeps typing without re-clicking).
+                if out.response.lost_focus() && ui.input(|inp| inp.key_pressed(egui::Key::Enter)) {
                     emit(events, &i.id, "submit", i.value.clone());
+                    out.response.request_focus();
                 }
             }
             RenderNode::Select(s) => {

--- a/thoth-plugin-sdk/src/render_node/render.rs
+++ b/thoth-plugin-sdk/src/render_node/render.rs
@@ -88,10 +88,19 @@ impl RenderNode {
                 h.show(ui);
             }
 
-            // ── Input widgets (emit "change") ────────────────────────────────
+            // ── Input widgets (emit "change"; "submit" on Enter) ─────────────
             RenderNode::Input(i) => {
-                if i.show(ui).inner {
+                let out = i.show(ui);
+                if out.inner {
                     emit(events, &i.id, "change", i.value.clone());
+                }
+                // A single-line field loses focus when Enter is pressed; emit a
+                // "submit" so plugins can act on it (e.g. send). Multiline fields
+                // keep focus on Enter (newline), so they never submit here.
+                if out.response.lost_focus()
+                    && ui.input(|inp| inp.key_pressed(egui::Key::Enter))
+                {
+                    emit(events, &i.id, "submit", i.value.clone());
                 }
             }
             RenderNode::Select(s) => {

--- a/wit/thoth-plugin.wit
+++ b/wit/thoth-plugin.wit
@@ -733,6 +733,37 @@ interface signals {
 }
 
 
+// websocket — host-provided import. The host owns WebSocket connections (via
+// tokio-tungstenite), enforces the same network policy / consent as http, and
+// answers server pings + sends periodic keepalive pings. Incoming frames and
+// lifecycle events are streamed to the plugin through handle-event (matching
+// the async http `submit` pattern), so the plugin never blocks on the socket.
+interface websocket {
+    use types.{plugin-error};
+
+    /// Open a WebSocket to `url` (ws:// or wss://) with optional extra request
+    /// headers (e.g. auth). Returns an opaque connection id immediately; the
+    /// connection completes asynchronously. The host then delivers lifecycle and
+    /// messages via handle-event with widget-id = <connection-id> and:
+    ///   kind = "ws-open"                                     (connected)
+    ///   kind = "ws-message", value = JSON {"text":"..."}
+    ///                              or JSON {"binary":"<base64>"}
+    ///   kind = "ws-error",   value = message
+    ///   kind = "ws-close",   value = JSON {"code":u16,"reason":"..."}
+    connect: func(url: string, headers: list<tuple<string, string>>)
+        -> result<string, plugin-error>;
+
+    /// Send a UTF-8 text frame on the connection.
+    send-text: func(id: string, text: string) -> result<_, plugin-error>;
+
+    /// Send a binary frame on the connection.
+    send-binary: func(id: string, bytes: list<u8>) -> result<_, plugin-error>;
+
+    /// Close the connection (sends a normal close frame). Idempotent.
+    close: func(id: string);
+}
+
+
 /// Every plugin must satisfy this base world.
 world base-plugin {
     export plugin-meta;
@@ -785,6 +816,7 @@ world data-source-plugin {
     import secure-storage;
     import db-runtime;
     import signals;
+    import websocket;
     export data-source;
     export ui-component;
     export tab-host;

--- a/wit/thoth-plugin.wit
+++ b/wit/thoth-plugin.wit
@@ -747,7 +747,7 @@ interface websocket {
     /// messages via handle-event with widget-id = <connection-id> and:
     ///   kind = "ws-open"                                     (connected)
     ///   kind = "ws-message", value = JSON {"text":"..."}
-    ///                              or JSON {"binary":"<base64>"}
+    ///                              or JSON {"binary":"<hex>","len":<frame-bytes>}
     ///   kind = "ws-error",   value = message
     ///   kind = "ws-close",   value = JSON {"code":u16,"reason":"..."}
     connect: func(url: string, headers: list<tuple<string, string>>)


### PR DESCRIPTION
Adds WebSocket support to the URL Source plugin — the WebSocket item of the #68 epic.

## Host — new `websocket` WIT import
- `connect(url, headers) -> id`, `send-text`, `send-binary`, `close`.
- The host owns each connection via **tokio-tungstenite** on a dedicated runtime, enforces the **same network-policy / consent gate as HTTP**, answers server pings, and sends periodic keepalive pings.
- Incoming frames + lifecycle stream to the plugin over the existing async `handle-event` path (`ws-open` / `ws-message` / `ws-error` / `ws-close`), keyed by connection id — no polling.
- A published `egui::Context` lets the off-thread connection task request a repaint when a frame arrives. Loader drains WS events per pane/sidebar and dispatches them like HTTP.

## url-source — WebSocket mode
- A `ws://` or `wss://` URL switches the action button to **Connect / Disconnect** and the response column to a **WebSocket panel**: live message log (sent / received / system; text + binary frames), a send box, and connection status.
- Custom request headers + bearer auth are forwarded as connect headers.

## Scope
Per the agreed **MVP + niceties**: connect/disconnect, live log, send text, text **and** binary frame display, custom headers/auth, ping/pong keepalive.

## Validation
- Host `cargo build` + `cargo clippy` clean; `url-source` `cargo component build` + clippy clean; formatted.

Part of #68. Closes #126.