### PR TITLE
feat(seshat): add Elasticsearch as a third database engine

### DIFF
--- a/plugins/seshat/plugin.toml
+++ b/plugins/seshat/plugin.toml
@@ -1,7 +1,7 @@
 id           = "com.thoth.seshat"
 name         = "Seshat"
 version      = "0.1.0"
-description  = "Database client — connect, browse schemas, run SQL (Postgres, MySQL)"
+description  = "Database client — connect, browse schemas, run SQL (Postgres, MySQL) or Query DSL (Elasticsearch)"
 author       = "Thoth contributors"
 capabilities = ["data-source", "new-ui-component", "data-producer"]
 icon         = ""    # egui_phosphor::regular::DATABASE
@@ -11,7 +11,14 @@ display_name = "Database"
 
 # Seshat connects to user-supplied database hosts (any host:port), so it declares
 # general-purpose network scope; per-host consent still gates unknown hosts.
+#
+# Note: the Elasticsearch engine's HTTP calls are treated as database-client
+# traffic and are exempt from the per-minute rate cap host-side (see
+# NetworkPolicy::check_data_source), for the same reason the SQL engines' raw TCP
+# connections are — one user action fans out into many requests. This declared
+# limit therefore only bounds any non-data-source traffic (of which there is
+# none today); it is kept generous to be safe.
 [network]
 allowed_domains = ["*"]
 require_https   = false
-rate_limit_rpm  = 120
+rate_limit_rpm  = 6000

--- a/plugins/seshat/src/db.rs
+++ b/plugins/seshat/src/db.rs
@@ -186,8 +186,9 @@ impl Engine {
             // MySQL's ANALYZE only emits TREE format, so JSON stays estimate-only
             // (no actual run times — the plan renderer bars by cost instead).
             Engine::Mysql => format!("EXPLAIN FORMAT=JSON {sql}"),
-            // Elasticsearch has no SQL EXPLAIN; the Query-DSL body is echoed back so
-            // the Explain tab shows the request that ran rather than a plan.
+            // Elasticsearch has no SQL EXPLAIN. Its Explain tab isn't rendered and
+            // `load_explain` refuses early, so this arm is unreachable in practice;
+            // echo the body rather than fabricate a plan.
             Engine::Elasticsearch => sql.to_string(),
         }
     }

--- a/plugins/seshat/src/db.rs
+++ b/plugins/seshat/src/db.rs
@@ -17,6 +17,7 @@ pub enum Engine {
     #[default]
     Postgres,
     Mysql,
+    Elasticsearch,
 }
 
 /// A connection target: one database server plus credentials.
@@ -28,6 +29,22 @@ pub struct Profile {
     pub user: String,
     pub password: String,
     pub tls: bool,
+    /// How to authenticate. SQL engines use `Password`; Elasticsearch also
+    /// supports `None` (open cluster) and `ApiKey` (the key is in `password`).
+    pub auth: AuthMode,
+}
+
+/// The authentication mechanism a connection uses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthMode {
+    /// No credentials (Elasticsearch with security disabled).
+    None,
+    /// Username + password (the default for SQL engines).
+    #[default]
+    Password,
+    /// A single encoded secret sent as an API key (Elasticsearch).
+    ApiKey,
 }
 
 /// A result column with its engine-specific type name.
@@ -155,6 +172,7 @@ pub fn adapter(engine: Engine) -> Box<dyn DbAdapter> {
     match engine {
         Engine::Postgres => Box::new(crate::pg::Postgres),
         Engine::Mysql => Box::new(crate::mysql::Mysql),
+        Engine::Elasticsearch => Box::new(crate::es::Elasticsearch),
     }
 }
 
@@ -168,6 +186,9 @@ impl Engine {
             // MySQL's ANALYZE only emits TREE format, so JSON stays estimate-only
             // (no actual run times — the plan renderer bars by cost instead).
             Engine::Mysql => format!("EXPLAIN FORMAT=JSON {sql}"),
+            // Elasticsearch has no SQL EXPLAIN; the Query-DSL body is echoed back so
+            // the Explain tab shows the request that ran rather than a plan.
+            Engine::Elasticsearch => sql.to_string(),
         }
     }
 }

--- a/plugins/seshat/src/es.rs
+++ b/plugins/seshat/src/es.rs
@@ -1,0 +1,597 @@
+//! Elasticsearch client over the host `http-client` import (issue #104).
+//!
+//! Unlike the Postgres/MySQL adapters — which speak a binary wire protocol over
+//! the raw `tcp-client` shim — Elasticsearch is plain HTTP REST + JSON, so this
+//! adapter drives the host `http-client::fetch` import. All calls are blocking
+//! and run on the host db-runtime worker thread via the plugin's `query` export,
+//! exactly like the SQL adapters.
+//!
+//! ES has no databases/schemas/tables, so its concepts are mapped onto Seshat's
+//! shared Database → Schema → Table tree (mirroring how MySQL collapses the
+//! schema layer):
+//!   * database  → a single synthetic entry (the cluster)
+//!   * schema    → a single synthetic "indices" namespace
+//!   * table     → one Elasticsearch index (`_cat/indices`)
+//!   * column    → one field from the index `_mapping`
+//!
+//! Auth: if `Profile.user` is empty and `Profile.password` is set, the password
+//! is treated as an encoded **API key** (`Authorization: ApiKey <key>`);
+//! otherwise **basic auth** (`Authorization: Basic base64(user:pass)`), matching
+//! the two mechanisms Elasticsearch supports. `Profile.tls` selects http vs https.
+
+use serde_json::{Map, Value};
+
+use crate::bindings::thoth::plugin::http_client::{self, HttpRequest};
+use crate::db::{
+    AuthMode, Column, ColumnInfo, ConnectionDefaults, DbAdapter, Profile, QueryResult, TableDetail,
+    TableInfo,
+};
+
+/// The synthetic schema name under which indices are listed in the tree.
+const SCHEMA: &str = "indices";
+
+/// The synthetic database name. ES has no databases, but the shared schema
+/// browser is a Database → Schema → Table tree and only auto-loads the
+/// connection's *default* database. So the connection defaults its database to
+/// this same constant (see `connection_defaults`) and `list_databases` returns
+/// it — that match is what makes indices load automatically after connecting.
+const DATABASE: &str = "_all";
+
+/// Elasticsearch implementation of [`DbAdapter`].
+pub struct Elasticsearch;
+
+impl DbAdapter for Elasticsearch {
+    fn connection_defaults(&self) -> ConnectionDefaults {
+        ConnectionDefaults {
+            port: 9200,
+            user: "elastic",
+            // Must equal DATABASE so the schema tree auto-loads its indices.
+            database: DATABASE,
+            database_placeholder: DATABASE,
+        }
+    }
+
+    fn test_connection(&self, p: &Profile) -> Result<String, String> {
+        // `GET /` returns cluster name + version.
+        let root = request(p, "GET", "/", None)?;
+        let name = root
+            .get("cluster_name")
+            .and_then(Value::as_str)
+            .or_else(|| root.get("name").and_then(Value::as_str))
+            .unwrap_or("elasticsearch");
+        let version = root
+            .get("version")
+            .and_then(|v| v.get("number"))
+            .and_then(Value::as_str)
+            .unwrap_or("?");
+        Ok(format!("{name} · Elasticsearch {version}"))
+    }
+
+    /// ES has no databases; expose a single synthetic entry whose name matches
+    /// the connection default ([`DATABASE`]) so the schema browser auto-loads it.
+    fn list_databases(&self, _p: &Profile) -> Result<Vec<String>, String> {
+        Ok(vec![DATABASE.to_string()])
+    }
+
+    /// A single synthetic schema groups all indices.
+    fn list_schemas(&self, _p: &Profile) -> Result<Vec<String>, String> {
+        Ok(vec![SCHEMA.to_string()])
+    }
+
+    fn list_tables(&self, p: &Profile, schema: &str) -> Result<Vec<TableInfo>, String> {
+        let indices = cat_indices(p)?;
+        Ok(indices
+            .into_iter()
+            .map(|idx| TableInfo {
+                database: None,
+                schema: schema.to_string(),
+                name: idx,
+                kind: "table".to_string(),
+            })
+            .collect())
+    }
+
+    fn find_tables(&self, p: &Profile, query: &str) -> Result<Vec<TableInfo>, String> {
+        let needle = query.to_lowercase();
+        Ok(cat_indices(p)?
+            .into_iter()
+            .filter(|idx| idx.to_lowercase().contains(&needle))
+            .take(200)
+            .map(|idx| TableInfo {
+                database: None,
+                schema: SCHEMA.to_string(),
+                name: idx,
+                kind: "table".to_string(),
+            })
+            .collect())
+    }
+
+    fn list_columns(
+        &self,
+        p: &Profile,
+        _schema: &str,
+        table: &str,
+    ) -> Result<Vec<ColumnInfo>, String> {
+        Ok(mapping_fields(p, table)?
+            .into_iter()
+            .map(|(name, data_type)| ColumnInfo {
+                name,
+                data_type,
+                nullable: true,
+                default: None,
+                primary_key: false,
+                unique: false,
+                foreign_key: None,
+            })
+            .collect())
+    }
+
+    fn describe_table(
+        &self,
+        p: &Profile,
+        _schema: &str,
+        table: &str,
+    ) -> Result<TableDetail, String> {
+        let columns: Vec<ColumnInfo> = mapping_fields(p, table)?
+            .into_iter()
+            .map(|(name, data_type)| ColumnInfo {
+                name,
+                data_type,
+                nullable: true,
+                default: None,
+                primary_key: false,
+                unique: false,
+                foreign_key: None,
+            })
+            .collect();
+
+        // Doc count + store size come from `_cat/indices/<index>` (non-fatal).
+        let (row_estimate, size) = index_stats(p, table).unwrap_or((0, String::new()));
+
+        Ok(TableDetail {
+            columns,
+            indexes: Vec::new(),
+            row_estimate,
+            size,
+        })
+    }
+
+    /// Run a Query-DSL search. The editor text is `[<index>]<newline>{json body}`:
+    ///   * an optional first line names the target index (defaults to `_all`);
+    ///   * the remainder is the `_search` request body (defaults to match_all).
+    ///
+    /// Hits are flattened — each `_source` object contributes columns (unioned
+    /// across hits), plus `_id` and `_score`.
+    fn run_query(&self, p: &Profile, sql: &str) -> Result<QueryResult, String> {
+        let (index, body) = split_query(sql);
+        let path = format!("/{}/_search", enc(&index));
+        let resp = request(p, "POST", &path, Some(body))?;
+
+        let took = resp.get("took").and_then(Value::as_i64).unwrap_or(0);
+        let total = resp
+            .get("hits")
+            .and_then(|h| h.get("total"))
+            .and_then(|t| {
+                t.get("value")
+                    .and_then(Value::as_i64)
+                    .or_else(|| t.as_i64())
+            })
+            .unwrap_or(0);
+
+        let hits = resp
+            .get("hits")
+            .and_then(|h| h.get("hits"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        // Column order: _id, _score, then source keys in first-seen order.
+        let mut col_names: Vec<String> = vec!["_id".to_string(), "_score".to_string()];
+        let mut seen: std::collections::HashSet<String> = col_names.iter().cloned().collect();
+        for hit in &hits {
+            if let Some(src) = hit.get("_source").and_then(Value::as_object) {
+                for k in src.keys() {
+                    if seen.insert(k.clone()) {
+                        col_names.push(k.clone());
+                    }
+                }
+            }
+        }
+
+        let rows: Vec<Vec<Value>> = hits
+            .iter()
+            .map(|hit| {
+                col_names
+                    .iter()
+                    .map(|c| match c.as_str() {
+                        "_id" => hit.get("_id").cloned().unwrap_or(Value::Null),
+                        "_score" => hit.get("_score").cloned().unwrap_or(Value::Null),
+                        other => hit
+                            .get("_source")
+                            .and_then(|s| s.get(other))
+                            .cloned()
+                            .unwrap_or(Value::Null),
+                    })
+                    .collect()
+            })
+            .collect();
+
+        let columns = col_names
+            .into_iter()
+            .map(|name| Column {
+                type_name: es_col_type(&name).to_string(),
+                name,
+            })
+            .collect();
+
+        Ok(QueryResult {
+            columns,
+            rows,
+            tag: Some(format!("{} hits · took {took} ms", total)),
+        })
+    }
+}
+
+// ── HTTP plumbing ───────────────────────────────────────────────────────────
+
+/// Perform one request against the cluster and parse the JSON response body.
+/// Non-2xx responses are surfaced as `Err`, preferring the ES `error.reason`.
+fn request(p: &Profile, method: &str, path: &str, body: Option<Value>) -> Result<Value, String> {
+    let scheme = if p.tls { "https" } else { "http" };
+    let url = format!("{scheme}://{}:{}{}", p.host, p.port, path);
+
+    let mut headers: Vec<(String, String)> = Vec::new();
+    if let Some(h) = auth_header(p) {
+        headers.push(h);
+    }
+    let body_bytes = body.map(|v| {
+        headers.push(("Content-Type".to_string(), "application/json".to_string()));
+        v.to_string().into_bytes()
+    });
+
+    let req = HttpRequest {
+        url,
+        method: method.to_string(),
+        headers,
+        body: body_bytes,
+    };
+
+    let resp = http_client::fetch(&req).map_err(|e| e.message)?;
+    let text = String::from_utf8_lossy(&resp.body).to_string();
+
+    if !(200..300).contains(&resp.status) {
+        // Try to extract the structured ES error before falling back to raw text.
+        let reason = serde_json::from_str::<Value>(&text)
+            .ok()
+            .and_then(|v| {
+                let err = v.get("error")?;
+                let ty = err.get("type").and_then(Value::as_str).unwrap_or("");
+                let reason = err.get("reason").and_then(Value::as_str).unwrap_or("");
+                Some(format!("{ty}: {reason}"))
+            })
+            .filter(|s| s.trim() != ":")
+            .unwrap_or_else(|| text.clone());
+        return Err(format!("HTTP {} — {reason}", resp.status));
+    }
+
+    if text.trim().is_empty() {
+        return Ok(Value::Null);
+    }
+    serde_json::from_str(&text).map_err(|e| format!("invalid JSON response: {e}"))
+}
+
+/// Build the `Authorization` header from the profile's auth mode. Returns `None`
+/// for an open (no-auth) cluster.
+fn auth_header(p: &Profile) -> Option<(String, String)> {
+    match p.auth {
+        AuthMode::None => None,
+        AuthMode::ApiKey => Some((
+            "Authorization".to_string(),
+            format!("ApiKey {}", p.password),
+        )),
+        AuthMode::Password => {
+            let token = base64_encode(format!("{}:{}", p.user, p.password).as_bytes());
+            Some(("Authorization".to_string(), format!("Basic {token}")))
+        }
+    }
+}
+
+// ── ES REST helpers ─────────────────────────────────────────────────────────
+
+/// List concrete (non-system) index names via `_cat/indices?format=json`.
+fn cat_indices(p: &Profile) -> Result<Vec<String>, String> {
+    let v = request(p, "GET", "/_cat/indices?format=json&h=index", None)?;
+    let mut names: Vec<String> = v
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|row| row.get("index").and_then(Value::as_str))
+                // Hide dot-prefixed system indices from the browser.
+                .filter(|name| !name.starts_with('.'))
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+    names.sort();
+    Ok(names)
+}
+
+/// Flatten an index `_mapping` into `(field_path, es_type)` pairs.
+fn mapping_fields(p: &Profile, index: &str) -> Result<Vec<(String, String)>, String> {
+    let v = request(p, "GET", &format!("/{}/_mapping", enc(index)), None)?;
+    // Response shape: { "<index>": { "mappings": { "properties": { ... } } } }.
+    let properties = v
+        .as_object()
+        .and_then(|top| top.values().next()) // the (single) index entry
+        .and_then(|idx| idx.get("mappings"))
+        .and_then(|m| m.get("properties"))
+        .and_then(Value::as_object);
+
+    let mut out = Vec::new();
+    if let Some(props) = properties {
+        flatten_properties("", props, &mut out);
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+/// Recursively walk mapping `properties`, emitting dotted field paths + types.
+fn flatten_properties(prefix: &str, props: &Map<String, Value>, out: &mut Vec<(String, String)>) {
+    for (name, spec) in props {
+        let path = if prefix.is_empty() {
+            name.clone()
+        } else {
+            format!("{prefix}.{name}")
+        };
+        match spec.get("type").and_then(Value::as_str) {
+            Some(ty) => out.push((path, ty.to_string())),
+            None => {
+                // Object/nested field: recurse into its sub-properties.
+                if let Some(sub) = spec.get("properties").and_then(Value::as_object) {
+                    out.push((path.clone(), "object".to_string()));
+                    flatten_properties(&path, sub, out);
+                }
+            }
+        }
+    }
+}
+
+/// Doc count + human store size from `_cat/indices/<index>` (best-effort).
+fn index_stats(p: &Profile, index: &str) -> Result<(i64, String), String> {
+    let path = format!(
+        "/_cat/indices/{}?format=json&h=docs.count,store.size&bytes=b",
+        enc(index)
+    );
+    let v = request(p, "GET", &path, None)?;
+    let row = v.as_array().and_then(|a| a.first());
+    let docs = row
+        .and_then(|r| r.get("docs.count"))
+        .and_then(Value::as_str)
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap_or(0);
+    let bytes = row
+        .and_then(|r| r.get("store.size"))
+        .and_then(Value::as_str)
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap_or(0);
+    Ok((docs, human_size(bytes)))
+}
+
+// ── query text parsing ──────────────────────────────────────────────────────
+
+/// Split editor text into `(index, body)`. An optional first line names the
+/// target index; the rest is the JSON `_search` body. Both parts are optional:
+///   * `""`                         → `_all`, match_all
+///   * `books`                      → index `books`, match_all
+///   * `{ "query": ... }`           → `_all`, given body
+///   * `books\n{ "query": ... }`    → index `books`, given body
+fn split_query(text: &str) -> (String, Value) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return ("_all".to_string(), match_all());
+    }
+    // If the whole thing is a JSON object, there's no index directive.
+    if trimmed.starts_with('{') {
+        let body = serde_json::from_str(trimmed).unwrap_or_else(|_| match_all());
+        return ("_all".to_string(), body);
+    }
+    // Otherwise the first line is the index; the remainder (if any) is the body.
+    let mut parts = trimmed.splitn(2, '\n');
+    let index = parts.next().unwrap_or("").trim().to_string();
+    let index = if index.is_empty() {
+        "_all".to_string()
+    } else {
+        index
+    };
+    let rest = parts.next().unwrap_or("").trim();
+    let body = if rest.is_empty() {
+        match_all()
+    } else {
+        serde_json::from_str(rest).unwrap_or_else(|_| match_all())
+    };
+    (index, body)
+}
+
+fn match_all() -> Value {
+    serde_json::json!({ "query": { "match_all": {} } })
+}
+
+/// Best-effort display type for a synthetic/result column.
+fn es_col_type(name: &str) -> &'static str {
+    match name {
+        "_id" => "keyword",
+        "_score" => "float",
+        _ => "json",
+    }
+}
+
+// ── small utilities ─────────────────────────────────────────────────────────
+
+/// Minimal percent-encoding for an index name in a URL path segment. Index names
+/// disallow most of these characters, but encoding keeps odd names safe.
+fn enc(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'*' | b',' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// Standard base64 (RFC 4648) — small enough to avoid a dependency.
+fn base64_encode(input: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(TABLE[((n >> 18) & 63) as usize] as char);
+        out.push(TABLE[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            TABLE[((n >> 6) & 63) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            TABLE[(n & 63) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+/// Format a byte count as a short human string (matches the SQL adapters' style).
+fn human_size(bytes: i64) -> String {
+    if bytes <= 0 {
+        return String::new();
+    }
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{size:.1} {}", UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_matches_known_vectors() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+        assert_eq!(
+            base64_encode(b"elastic:changeme"),
+            "ZWxhc3RpYzpjaGFuZ2VtZQ=="
+        );
+    }
+
+    #[test]
+    fn auth_header_none_when_open() {
+        let p = Profile {
+            auth: AuthMode::None,
+            user: "ignored".to_string(),
+            password: "ignored".to_string(),
+            ..Profile::default()
+        };
+        assert_eq!(auth_header(&p), None);
+    }
+
+    #[test]
+    fn auth_header_api_key_mode() {
+        let p = Profile {
+            auth: AuthMode::ApiKey,
+            user: String::new(),
+            password: "ABC123==".to_string(),
+            ..Profile::default()
+        };
+        assert_eq!(auth_header(&p).unwrap().1, "ApiKey ABC123==");
+    }
+
+    #[test]
+    fn auth_header_password_mode_uses_basic() {
+        let p = Profile {
+            auth: AuthMode::Password,
+            user: "elastic".to_string(),
+            password: "changeme".to_string(),
+            ..Profile::default()
+        };
+        assert_eq!(auth_header(&p).unwrap().1, "Basic ZWxhc3RpYzpjaGFuZ2VtZQ==");
+    }
+
+    #[test]
+    fn split_query_variants() {
+        // empty → _all + match_all
+        let (idx, body) = split_query("   ");
+        assert_eq!(idx, "_all");
+        assert_eq!(body, match_all());
+
+        // bare index name
+        let (idx, body) = split_query("books");
+        assert_eq!(idx, "books");
+        assert_eq!(body, match_all());
+
+        // pure JSON body → _all
+        let (idx, body) = split_query(r#"{"query":{"term":{"x":1}}}"#);
+        assert_eq!(idx, "_all");
+        assert_eq!(body["query"]["term"]["x"], 1);
+
+        // index + body
+        let (idx, body) = split_query("books\n{\"size\":5}");
+        assert_eq!(idx, "books");
+        assert_eq!(body["size"], 5);
+    }
+
+    #[test]
+    fn split_query_parses_index_click_text() {
+        // Must match `events::es_search_query`'s format: index on line 1, then a
+        // match_all body. This is what clicking an index in the schema tree runs.
+        let text = format!("{}\n{{ \"query\": {{ \"match_all\": {{}} }} }}", "books");
+        let (idx, body) = split_query(&text);
+        assert_eq!(idx, "books");
+        assert_eq!(body, match_all());
+    }
+
+    #[test]
+    fn flatten_nested_properties() {
+        let props: Map<String, Value> = serde_json::from_value(serde_json::json!({
+            "title": { "type": "text" },
+            "location": { "properties": {
+                "city": { "type": "keyword" },
+                "geo": { "type": "geo_point" }
+            }}
+        }))
+        .unwrap();
+        let mut out = Vec::new();
+        flatten_properties("", &props, &mut out);
+        out.sort();
+        assert!(out.contains(&("title".to_string(), "text".to_string())));
+        assert!(out.contains(&("location".to_string(), "object".to_string())));
+        assert!(out.contains(&("location.city".to_string(), "keyword".to_string())));
+        assert!(out.contains(&("location.geo".to_string(), "geo_point".to_string())));
+    }
+
+    #[test]
+    fn human_size_formats() {
+        assert_eq!(human_size(0), "");
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(2048), "2.0 KB");
+    }
+}

--- a/plugins/seshat/src/es.rs
+++ b/plugins/seshat/src/es.rs
@@ -577,8 +577,23 @@ pub(crate) fn dialect(text: &str) -> Dialect {
     }
 }
 
+/// Does this ES|QL query already contain a real `LIMIT` pipeline stage?
+///
+/// A plain substring search would also match identifiers — `rate_limit`,
+/// `limits`, a column called `limit_reached` — and wrongly leave the query
+/// uncapped. ES|QL stages are pipe-separated, so only a stage whose *first
+/// token* is `LIMIT` counts.
+fn has_esql_limit_stage(query: &str) -> bool {
+    query.split('|').any(|stage| {
+        stage
+            .split_whitespace()
+            .next()
+            .is_some_and(|word| word.eq_ignore_ascii_case("LIMIT"))
+    })
+}
+
 /// Elasticsearch's default `index.max_result_window`. A `size` beyond this is
-/// rejected by the server, so the row cap stops growing here.
+/// rejected by the server, so the row cap is clamped here.
 pub(crate) const MAX_RESULT_WINDOW: usize = 10_000;
 
 /// Cap an Elasticsearch query to `n` rows, whichever dialect it's written in.
@@ -592,7 +607,7 @@ pub(crate) fn cap(text: &str, n: usize) -> Option<String> {
         // ES|QL caps with a pipeline stage: `FROM idx | LIMIT n`.
         Dialect::Esql => {
             let t = text.trim();
-            if t.to_ascii_uppercase().contains("LIMIT") {
+            if has_esql_limit_stage(t) {
                 return None;
             }
             Some(format!("{t} | LIMIT {n}"))
@@ -603,20 +618,21 @@ pub(crate) fn cap(text: &str, n: usize) -> Option<String> {
 
 /// Cap a Query-DSL search to `n` hits by injecting `"size": n` into its body.
 ///
-/// Returns `None` (leave the query alone) when the query can't or shouldn't be
-/// capped:
+/// `n` is clamped to [`MAX_RESULT_WINDOW`] — the server rejects a larger `size`,
+/// and returning `None` here would leave the body unsized, which silently falls
+/// back to Elasticsearch's default of 10 hits (the opposite of a large limit).
+///
+/// Returns `None` (leave the query alone) only when the query shouldn't be
+/// capped at all:
 ///   * the body already sets `size` — respect the user's explicit choice, just
 ///     as `add_limit` bails when a `LIMIT` is already present;
 ///   * the body is an aggregation request, where `size` controls hits rather
-///     than buckets and capping would mislead;
-///   * `n` exceeds [`MAX_RESULT_WINDOW`], which the server would reject.
+///     than buckets and capping would mislead.
 ///
 /// The returned text keeps the leading `<index>` line so it round-trips through
 /// [`split_query`]; only the *submitted* copy is rewritten, never the editor's.
 pub(crate) fn add_size(text: &str, n: usize) -> Option<String> {
-    if n > MAX_RESULT_WINDOW {
-        return None;
-    }
+    let n = n.min(MAX_RESULT_WINDOW);
     // SQL / ES|QL bodies aren't Query DSL — those are capped by their own
     // dialects (see `cap`), so never rewrite them here.
     if matches!(dialect(text), Dialect::Sql | Dialect::Esql) {
@@ -863,9 +879,14 @@ mod tests {
     }
 
     #[test]
-    fn add_size_refuses_beyond_max_result_window() {
-        assert_eq!(add_size("books", MAX_RESULT_WINDOW + 1), None);
-        assert!(add_size("books", MAX_RESULT_WINDOW).is_some());
+    fn add_size_clamps_to_max_result_window() {
+        // Beyond the window we must still emit a `size` — returning the body
+        // unsized would silently fall back to ES's default of 10 hits.
+        let out = add_size("books", MAX_RESULT_WINDOW + 5000).unwrap();
+        assert_eq!(split_query(&out).1["size"], MAX_RESULT_WINDOW);
+        // At the boundary the requested value is used verbatim.
+        let out = add_size("books", MAX_RESULT_WINDOW).unwrap();
+        assert_eq!(split_query(&out).1["size"], MAX_RESULT_WINDOW);
     }
 
     #[test]
@@ -899,6 +920,30 @@ mod tests {
             Some("FROM books | LIMIT 101")
         );
         assert_eq!(cap("FROM books | LIMIT 5", 101), None);
+    }
+
+    #[test]
+    fn esql_limit_stage_detection_ignores_identifiers() {
+        // Real LIMIT stages (any casing, any spacing) are detected.
+        assert!(has_esql_limit_stage("FROM books | LIMIT 5"));
+        assert!(has_esql_limit_stage("FROM books | limit 5"));
+        assert!(has_esql_limit_stage("FROM books |   LIMIT   5"));
+        assert!(has_esql_limit_stage("FROM b | SORT x | LIMIT 10"));
+
+        // Identifiers that merely contain "limit" must NOT count.
+        assert!(!has_esql_limit_stage("FROM logs | WHERE rate_limit > 5"));
+        assert!(!has_esql_limit_stage("FROM logs | KEEP limits"));
+        assert!(!has_esql_limit_stage("FROM logs | KEEP limit_reached"));
+        assert!(!has_esql_limit_stage("FROM books"));
+    }
+
+    #[test]
+    fn cap_still_applies_when_limit_only_appears_as_identifier() {
+        // Regression: a substring check would have skipped capping here.
+        assert_eq!(
+            cap("FROM logs | WHERE rate_limit > 5", 101).as_deref(),
+            Some("FROM logs | WHERE rate_limit > 5 | LIMIT 101")
+        );
     }
 
     // ── columnar (_sql / ES|QL) result mapping ──────────────────────────────

--- a/plugins/seshat/src/es.rs
+++ b/plugins/seshat/src/es.rs
@@ -112,18 +112,7 @@ impl DbAdapter for Elasticsearch {
         _schema: &str,
         table: &str,
     ) -> Result<Vec<ColumnInfo>, String> {
-        Ok(mapping_fields(p, table)?
-            .into_iter()
-            .map(|(name, data_type)| ColumnInfo {
-                name,
-                data_type,
-                nullable: true,
-                default: None,
-                primary_key: false,
-                unique: false,
-                foreign_key: None,
-            })
-            .collect())
+        Ok(to_column_infos(mapping_fields(p, table)?))
     }
 
     fn describe_table(
@@ -132,18 +121,7 @@ impl DbAdapter for Elasticsearch {
         _schema: &str,
         table: &str,
     ) -> Result<TableDetail, String> {
-        let columns: Vec<ColumnInfo> = mapping_fields(p, table)?
-            .into_iter()
-            .map(|(name, data_type)| ColumnInfo {
-                name,
-                data_type,
-                nullable: true,
-                default: None,
-                primary_key: false,
-                unique: false,
-                foreign_key: None,
-            })
-            .collect();
+        let columns = to_column_infos(mapping_fields(p, table)?);
 
         // Doc count + store size come from `_cat/indices/<index>` (non-fatal).
         let (row_estimate, size) = index_stats(p, table).unwrap_or((0, String::new()));
@@ -163,73 +141,149 @@ impl DbAdapter for Elasticsearch {
     /// Hits are flattened — each `_source` object contributes columns (unioned
     /// across hits), plus `_id` and `_score`.
     fn run_query(&self, p: &Profile, sql: &str) -> Result<QueryResult, String> {
-        let (index, body) = split_query(sql);
-        let path = format!("/{}/_search", enc(&index));
-        let resp = request(p, "POST", &path, Some(body))?;
+        match dialect(sql) {
+            Dialect::Sql => run_sql(p, sql),
+            Dialect::Esql => run_esql(p, sql),
+            Dialect::QueryDsl => run_search(p, sql),
+        }
+    }
+}
 
-        let took = resp.get("took").and_then(Value::as_i64).unwrap_or(0);
-        let total = resp
-            .get("hits")
-            .and_then(|h| h.get("total"))
-            .and_then(|t| {
-                t.get("value")
-                    .and_then(Value::as_i64)
-                    .or_else(|| t.as_i64())
-            })
-            .unwrap_or(0);
+/// Run Elasticsearch SQL via `POST /_sql?format=json`. The response is already
+/// columnar (`{columns:[{name,type}], rows:[[..]]}`) so it maps straight onto
+/// [`QueryResult`].
+fn run_sql(p: &Profile, query: &str) -> Result<QueryResult, String> {
+    let body = serde_json::json!({ "query": query.trim() });
+    let resp = request(p, "POST", "/_sql?format=json", Some(body))?;
+    columnar_result(&resp, "rows", "SQL")
+}
 
-        let hits = resp
-            .get("hits")
-            .and_then(|h| h.get("hits"))
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
+/// Run an ES|QL query via `POST /_query`. Same columnar shape as `_sql`, except
+/// the data array is named `values`.
+fn run_esql(p: &Profile, query: &str) -> Result<QueryResult, String> {
+    let body = serde_json::json!({ "query": query.trim() });
+    let resp = request(p, "POST", "/_query", Some(body))?;
+    columnar_result(&resp, "values", "ES|QL")
+}
 
-        // Column order: _id, _score, then source keys in first-seen order.
-        let mut col_names: Vec<String> = vec!["_id".to_string(), "_score".to_string()];
-        let mut seen: std::collections::HashSet<String> = col_names.iter().cloned().collect();
-        for hit in &hits {
-            if let Some(src) = hit.get("_source").and_then(Value::as_object) {
-                for k in src.keys() {
-                    if seen.insert(k.clone()) {
-                        col_names.push(k.clone());
-                    }
+/// Shared mapper for the two columnar endpoints. `rows_key` is `rows` for `_sql`
+/// and `values` for ES|QL; `label` names the dialect in the result tag.
+fn columnar_result(resp: &Value, rows_key: &str, label: &str) -> Result<QueryResult, String> {
+    let columns: Vec<Column> = resp
+        .get("columns")
+        .and_then(Value::as_array)
+        .map(|cols| {
+            cols.iter()
+                .map(|c| Column {
+                    name: c
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    type_name: c
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let rows: Vec<Vec<Value>> = resp
+        .get(rows_key)
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .map(|r| r.as_array().cloned().unwrap_or_default())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let tag = format!("{label} · {} row{}", rows.len(), plural(rows.len()));
+    Ok(QueryResult {
+        columns,
+        rows,
+        tag: Some(tag),
+    })
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+/// Run a Query-DSL search: `POST <index>/_search`, hits flattened into a grid.
+fn run_search(p: &Profile, sql: &str) -> Result<QueryResult, String> {
+    let (index, body) = split_query(sql);
+    let path = format!("/{}/_search", enc(&index));
+    let resp = request(p, "POST", &path, Some(body))?;
+
+    let took = resp.get("took").and_then(Value::as_i64).unwrap_or(0);
+    let total = resp
+        .get("hits")
+        .and_then(|h| h.get("total"))
+        .and_then(|t| {
+            t.get("value")
+                .and_then(Value::as_i64)
+                .or_else(|| t.as_i64())
+        })
+        .unwrap_or(0);
+
+    let hits = resp
+        .get("hits")
+        .and_then(|h| h.get("hits"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    // Column order: _id, _score, then source keys in first-seen order.
+    let mut col_names: Vec<String> = vec!["_id".to_string(), "_score".to_string()];
+    let mut seen: std::collections::HashSet<String> = col_names.iter().cloned().collect();
+    for hit in &hits {
+        if let Some(src) = hit.get("_source").and_then(Value::as_object) {
+            for k in src.keys() {
+                if seen.insert(k.clone()) {
+                    col_names.push(k.clone());
                 }
             }
         }
-
-        let rows: Vec<Vec<Value>> = hits
-            .iter()
-            .map(|hit| {
-                col_names
-                    .iter()
-                    .map(|c| match c.as_str() {
-                        "_id" => hit.get("_id").cloned().unwrap_or(Value::Null),
-                        "_score" => hit.get("_score").cloned().unwrap_or(Value::Null),
-                        other => hit
-                            .get("_source")
-                            .and_then(|s| s.get(other))
-                            .cloned()
-                            .unwrap_or(Value::Null),
-                    })
-                    .collect()
-            })
-            .collect();
-
-        let columns = col_names
-            .into_iter()
-            .map(|name| Column {
-                type_name: es_col_type(&name).to_string(),
-                name,
-            })
-            .collect();
-
-        Ok(QueryResult {
-            columns,
-            rows,
-            tag: Some(format!("{} hits · took {took} ms", total)),
-        })
     }
+
+    let rows: Vec<Vec<Value>> = hits
+        .iter()
+        .map(|hit| {
+            col_names
+                .iter()
+                .map(|c| match c.as_str() {
+                    "_id" => hit.get("_id").cloned().unwrap_or(Value::Null),
+                    "_score" => hit.get("_score").cloned().unwrap_or(Value::Null),
+                    other => hit
+                        .get("_source")
+                        .and_then(|s| s.get(other))
+                        .cloned()
+                        .unwrap_or(Value::Null),
+                })
+                .collect()
+        })
+        .collect();
+
+    let columns = col_names
+        .into_iter()
+        .map(|name| Column {
+            type_name: es_col_type(&name).to_string(),
+            name,
+        })
+        .collect();
+
+    Ok(QueryResult {
+        columns,
+        rows,
+        tag: Some(format!("{total} hits · took {took} ms")),
+    })
 }
 
 // ── HTTP plumbing ───────────────────────────────────────────────────────────
@@ -256,7 +310,7 @@ fn request(p: &Profile, method: &str, path: &str, body: Option<Value>) -> Result
         body: body_bytes,
     };
 
-    let resp = http_client::fetch(&req).map_err(|e| e.message)?;
+    let resp = http_client::fetch(&req).map_err(|e| transport_error(p, &e.message))?;
     let text = String::from_utf8_lossy(&resp.body).to_string();
 
     if !(200..300).contains(&resp.status) {
@@ -265,19 +319,76 @@ fn request(p: &Profile, method: &str, path: &str, body: Option<Value>) -> Result
             .ok()
             .and_then(|v| {
                 let err = v.get("error")?;
+                // `error` is usually an object, but some endpoints return a string.
+                if let Some(s) = err.as_str() {
+                    return Some(s.to_string());
+                }
                 let ty = err.get("type").and_then(Value::as_str).unwrap_or("");
                 let reason = err.get("reason").and_then(Value::as_str).unwrap_or("");
                 Some(format!("{ty}: {reason}"))
             })
-            .filter(|s| s.trim() != ":")
+            .filter(|s| s.trim() != ":" && !s.trim().is_empty())
             .unwrap_or_else(|| text.clone());
-        return Err(format!("HTTP {} — {reason}", resp.status));
+        return Err(status_error(p, resp.status, &reason));
     }
 
     if text.trim().is_empty() {
         return Ok(Value::Null);
     }
     serde_json::from_str(&text).map_err(|e| format!("invalid JSON response: {e}"))
+}
+
+/// Turn a transport-level failure (no HTTP response at all) into something
+/// actionable. The host returns reqwest's message, which is accurate but terse —
+/// "error sending request for url (http://localhost:9200/)" doesn't tell you the
+/// cluster simply isn't running.
+fn transport_error(p: &Profile, raw: &str) -> String {
+    let target = format!("{}:{}", p.host, p.port);
+    let lower = raw.to_lowercase();
+    if lower.contains("connection refused") || lower.contains("error sending request") {
+        return format!(
+            "Couldn't reach {target} — is Elasticsearch running and listening on that port? ({raw})"
+        );
+    }
+    if lower.contains("dns") || lower.contains("resolve") {
+        return format!(
+            "Couldn't resolve host '{}' — check the hostname. ({raw})",
+            p.host
+        );
+    }
+    if lower.contains("timed out") || lower.contains("timeout") {
+        return format!(
+            "Timed out connecting to {target} — the cluster may be starting up. ({raw})"
+        );
+    }
+    // A TLS handshake failure against a plaintext cluster is a common mix-up.
+    if lower.contains("tls") || lower.contains("ssl") || lower.contains("certificate") {
+        return format!(
+            "TLS error talking to {target} — if the cluster serves plain HTTP, turn off \"Require TLS\". ({raw})"
+        );
+    }
+    format!("{raw} (target: {target})")
+}
+
+/// Add a hint to the common auth/permission statuses; other statuses pass the
+/// server's own reason through unchanged.
+fn status_error(p: &Profile, status: u16, reason: &str) -> String {
+    let hint = match status {
+        401 => match p.auth {
+            AuthMode::None => Some(
+                "this cluster requires authentication — set Auth to \"Username & password\" or \"API key\"",
+            ),
+            AuthMode::Password => Some("check the username and password"),
+            AuthMode::ApiKey => Some("check the API key (it may be expired or from another cluster)"),
+        },
+        403 => Some("the credentials are valid but lack permission for this operation"),
+        404 => Some("index not found — check the index name"),
+        _ => None,
+    };
+    match hint {
+        Some(h) => format!("HTTP {status} — {reason} ({h})"),
+        None => format!("HTTP {status} — {reason}"),
+    }
 }
 
 /// Build the `Authorization` header from the profile's auth mode. Returns `None`
@@ -314,6 +425,24 @@ fn cat_indices(p: &Profile) -> Result<Vec<String>, String> {
         .unwrap_or_default();
     names.sort();
     Ok(names)
+}
+
+/// Build [`ColumnInfo`] rows from flattened mapping fields. Elasticsearch has no
+/// nullability, primary keys, or foreign keys, so those carry fixed values —
+/// shared by `list_columns` and `describe_table`.
+fn to_column_infos(fields: Vec<(String, String)>) -> Vec<ColumnInfo> {
+    fields
+        .into_iter()
+        .map(|(name, data_type)| ColumnInfo {
+            name,
+            data_type,
+            nullable: true,
+            default: None,
+            primary_key: false,
+            unique: false,
+            foreign_key: None,
+        })
+        .collect()
 }
 
 /// Flatten an index `_mapping` into `(field_path, es_type)` pairs.
@@ -410,6 +539,99 @@ fn split_query(text: &str) -> (String, Value) {
         serde_json::from_str(rest).unwrap_or_else(|_| match_all())
     };
     (index, body)
+}
+
+/// Which query language the editor text is written in. Elasticsearch exposes
+/// three query surfaces and they need different endpoints and result shapes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Dialect {
+    /// Query DSL (JSON) — `POST <index>/_search`.
+    QueryDsl,
+    /// Elasticsearch SQL — `POST /_sql?format=json`.
+    Sql,
+    /// ES|QL — `POST /_query`.
+    Esql,
+}
+
+/// Classify the editor text. Query DSL is the default; a leading SQL verb or an
+/// ES|QL source command switches dialect. The check ignores a leading `<index>`
+/// line only for Query DSL, since SQL/ES|QL name their source inside the query.
+pub(crate) fn dialect(text: &str) -> Dialect {
+    let t = text.trim_start();
+    // A JSON body is unambiguously Query DSL.
+    if t.starts_with('{') {
+        return Dialect::QueryDsl;
+    }
+    let head = t
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    match head.as_str() {
+        "SELECT" | "DESCRIBE" | "DESC" => Dialect::Sql,
+        // `SHOW` exists in both dialects; ES|QL only has SHOW INFO, so treat the
+        // bare verb as SQL (SHOW TABLES / SHOW COLUMNS are the common cases).
+        "SHOW" => Dialect::Sql,
+        "FROM" | "ROW" => Dialect::Esql,
+        _ => Dialect::QueryDsl,
+    }
+}
+
+/// Elasticsearch's default `index.max_result_window`. A `size` beyond this is
+/// rejected by the server, so the row cap stops growing here.
+pub(crate) const MAX_RESULT_WINDOW: usize = 10_000;
+
+/// Cap an Elasticsearch query to `n` rows, whichever dialect it's written in.
+/// Returns `None` to run the query unchanged (already capped, uncappable, or
+/// beyond the server's result window). This is the ES counterpart to
+/// [`crate::sql::add_limit`] and preserves the same `+1 sentinel row` contract.
+pub(crate) fn cap(text: &str, n: usize) -> Option<String> {
+    match dialect(text) {
+        // Elasticsearch SQL understands a normal LIMIT clause.
+        Dialect::Sql => crate::sql::add_limit(text, n),
+        // ES|QL caps with a pipeline stage: `FROM idx | LIMIT n`.
+        Dialect::Esql => {
+            let t = text.trim();
+            if t.to_ascii_uppercase().contains("LIMIT") {
+                return None;
+            }
+            Some(format!("{t} | LIMIT {n}"))
+        }
+        Dialect::QueryDsl => add_size(text, n),
+    }
+}
+
+/// Cap a Query-DSL search to `n` hits by injecting `"size": n` into its body.
+///
+/// Returns `None` (leave the query alone) when the query can't or shouldn't be
+/// capped:
+///   * the body already sets `size` — respect the user's explicit choice, just
+///     as `add_limit` bails when a `LIMIT` is already present;
+///   * the body is an aggregation request, where `size` controls hits rather
+///     than buckets and capping would mislead;
+///   * `n` exceeds [`MAX_RESULT_WINDOW`], which the server would reject.
+///
+/// The returned text keeps the leading `<index>` line so it round-trips through
+/// [`split_query`]; only the *submitted* copy is rewritten, never the editor's.
+pub(crate) fn add_size(text: &str, n: usize) -> Option<String> {
+    if n > MAX_RESULT_WINDOW {
+        return None;
+    }
+    // SQL / ES|QL bodies aren't Query DSL — those are capped by their own
+    // dialects (see `cap`), so never rewrite them here.
+    if matches!(dialect(text), Dialect::Sql | Dialect::Esql) {
+        return None;
+    }
+    let (index, mut body) = split_query(text);
+    let obj = body.as_object_mut()?;
+    if obj.contains_key("size") {
+        return None;
+    }
+    if obj.contains_key("aggs") || obj.contains_key("aggregations") {
+        return None;
+    }
+    obj.insert("size".to_string(), Value::from(n));
+    Some(format!("{index}\n{body}"))
 }
 
 fn match_all() -> Value {
@@ -593,5 +815,195 @@ mod tests {
         assert_eq!(human_size(0), "");
         assert_eq!(human_size(512), "512 B");
         assert_eq!(human_size(2048), "2.0 KB");
+    }
+
+    // ── pagination (`size` injection) ───────────────────────────────────────
+
+    #[test]
+    fn add_size_injects_size_and_keeps_index() {
+        let out = add_size("books\n{\"query\":{\"match_all\":{}}}", 101).unwrap();
+        let (idx, body) = split_query(&out);
+        assert_eq!(idx, "books");
+        assert_eq!(body["size"], 101);
+        // The original query is preserved alongside the injected cap.
+        assert!(body["query"]["match_all"].is_object());
+    }
+
+    #[test]
+    fn add_size_defaults_index_when_body_only() {
+        let out = add_size("{\"query\":{\"match_all\":{}}}", 50).unwrap();
+        let (idx, body) = split_query(&out);
+        assert_eq!(idx, "_all");
+        assert_eq!(body["size"], 50);
+    }
+
+    #[test]
+    fn add_size_caps_a_bare_index_name() {
+        // Clicking an index runs match_all; it must still be capped.
+        let out = add_size("books", 101).unwrap();
+        let (idx, body) = split_query(&out);
+        assert_eq!(idx, "books");
+        assert_eq!(body["size"], 101);
+    }
+
+    #[test]
+    fn add_size_respects_user_supplied_size() {
+        assert_eq!(add_size("books\n{\"size\":5}", 101), None);
+    }
+
+    #[test]
+    fn add_size_skips_aggregation_queries() {
+        assert_eq!(
+            add_size(
+                "books\n{\"aggs\":{\"by_year\":{\"terms\":{\"field\":\"year\"}}}}",
+                101
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn add_size_refuses_beyond_max_result_window() {
+        assert_eq!(add_size("books", MAX_RESULT_WINDOW + 1), None);
+        assert!(add_size("books", MAX_RESULT_WINDOW).is_some());
+    }
+
+    #[test]
+    fn add_size_leaves_sql_and_esql_alone() {
+        assert_eq!(add_size("SELECT * FROM books", 101), None);
+        assert_eq!(add_size("FROM books | LIMIT 5", 101), None);
+    }
+
+    // ── cap() dispatch per dialect ──────────────────────────────────────────
+
+    #[test]
+    fn cap_uses_size_for_query_dsl() {
+        let out = cap("books", 101).unwrap();
+        assert_eq!(split_query(&out).1["size"], 101);
+    }
+
+    #[test]
+    fn cap_uses_limit_for_sql() {
+        assert_eq!(
+            cap("SELECT * FROM books", 101).as_deref(),
+            Some("SELECT * FROM books LIMIT 101")
+        );
+        // An explicit LIMIT is respected.
+        assert_eq!(cap("SELECT * FROM books LIMIT 5", 101), None);
+    }
+
+    #[test]
+    fn cap_appends_pipeline_limit_for_esql() {
+        assert_eq!(
+            cap("FROM books", 101).as_deref(),
+            Some("FROM books | LIMIT 101")
+        );
+        assert_eq!(cap("FROM books | LIMIT 5", 101), None);
+    }
+
+    // ── columnar (_sql / ES|QL) result mapping ──────────────────────────────
+
+    #[test]
+    fn columnar_result_maps_sql_rows() {
+        // Shape captured from a live ES 8.15 `_sql?format=json` response.
+        let resp = serde_json::json!({
+            "columns": [{"name":"title","type":"text"},{"name":"year","type":"long"}],
+            "rows": [["Thoth: Exploring Data", 2026], ["The Rust Programming Language", 2019]]
+        });
+        let qr = columnar_result(&resp, "rows", "SQL").unwrap();
+        assert_eq!(qr.columns.len(), 2);
+        assert_eq!(qr.columns[0].name, "title");
+        assert_eq!(qr.columns[1].type_name, "long");
+        assert_eq!(qr.rows.len(), 2);
+        assert_eq!(qr.rows[0][1], 2026);
+        assert_eq!(qr.tag.as_deref(), Some("SQL · 2 rows"));
+    }
+
+    #[test]
+    fn columnar_result_maps_esql_values() {
+        // ES|QL uses `values` rather than `rows`.
+        let resp = serde_json::json!({
+            "columns": [{"name":"title","type":"text"}],
+            "values": [["Thoth: Exploring Data"]]
+        });
+        let qr = columnar_result(&resp, "values", "ES|QL").unwrap();
+        assert_eq!(qr.rows.len(), 1);
+        assert_eq!(qr.tag.as_deref(), Some("ES|QL · 1 row"));
+    }
+
+    #[test]
+    fn columnar_result_tolerates_empty_response() {
+        let qr = columnar_result(&serde_json::json!({}), "rows", "SQL").unwrap();
+        assert!(qr.columns.is_empty());
+        assert!(qr.rows.is_empty());
+    }
+
+    // ── dialect detection ───────────────────────────────────────────────────
+
+    // ── dialect detection ───────────────────────────────────────────────────
+
+    #[test]
+    fn dialect_detects_each_surface() {
+        assert_eq!(dialect("{\"query\":{}}"), Dialect::QueryDsl);
+        assert_eq!(dialect("books"), Dialect::QueryDsl);
+        assert_eq!(dialect("books\n{\"size\":1}"), Dialect::QueryDsl);
+        assert_eq!(dialect("SELECT * FROM books"), Dialect::Sql);
+        assert_eq!(dialect("  select author from books"), Dialect::Sql);
+        assert_eq!(dialect("SHOW TABLES"), Dialect::Sql);
+        assert_eq!(dialect("DESCRIBE books"), Dialect::Sql);
+        assert_eq!(dialect("FROM books | LIMIT 5"), Dialect::Esql);
+        assert_eq!(dialect("ROW a = 1"), Dialect::Esql);
+    }
+
+    // ── error messages ──────────────────────────────────────────────────────
+
+    #[test]
+    fn transport_error_explains_unreachable_cluster() {
+        let p = Profile {
+            host: "localhost".into(),
+            port: 9200,
+            ..Profile::default()
+        };
+        let msg = transport_error(&p, "error sending request for url (http://localhost:9200/)");
+        assert!(msg.contains("Couldn't reach localhost:9200"), "got: {msg}");
+        assert!(msg.contains("is Elasticsearch running"), "got: {msg}");
+    }
+
+    #[test]
+    fn transport_error_flags_tls_mixup() {
+        let p = Profile {
+            host: "localhost".into(),
+            port: 9200,
+            ..Profile::default()
+        };
+        let msg = transport_error(&p, "invalid certificate: self signed");
+        assert!(msg.contains("Require TLS"), "got: {msg}");
+    }
+
+    #[test]
+    fn status_error_hints_per_auth_mode_on_401() {
+        let none = Profile {
+            auth: AuthMode::None,
+            ..Profile::default()
+        };
+        assert!(status_error(&none, 401, "security_exception").contains("requires authentication"));
+
+        let pw = Profile {
+            auth: AuthMode::Password,
+            ..Profile::default()
+        };
+        assert!(status_error(&pw, 401, "security_exception").contains("username and password"));
+
+        let key = Profile {
+            auth: AuthMode::ApiKey,
+            ..Profile::default()
+        };
+        assert!(status_error(&key, 401, "security_exception").contains("API key"));
+    }
+
+    #[test]
+    fn status_error_passes_through_unmapped_status() {
+        let p = Profile::default();
+        assert_eq!(status_error(&p, 500, "boom"), "HTTP 500 — boom");
     }
 }

--- a/plugins/seshat/src/events.rs
+++ b/plugins/seshat/src/events.rs
@@ -117,6 +117,14 @@ pub(crate) fn apply_event(st: &mut State, event: &UiEvent) {
         "f-database" | "database" => st.form.database = parse_str(&event.value),
         "f-user" | "user" => st.form.user = parse_str(&event.value),
         "f-password" | "password" => st.form.password = parse_str(&event.value),
+        "f-apikey" | "apikey" => st.form.password = parse_str(&event.value),
+        "f-auth" if event.kind == "change" => {
+            st.form.auth = match parse_str(&event.value).as_str() {
+                "none" => crate::db::AuthMode::None,
+                "apikey" => crate::db::AuthMode::ApiKey,
+                _ => crate::db::AuthMode::Password,
+            };
+        }
         "f-tls" | "tls" => st.form.tls = serde_json::from_str(&event.value).unwrap_or(false),
         "f-color" if event.kind == "change" => st.form.color = parse_str(&event.value),
 
@@ -482,6 +490,7 @@ fn activate_connection(st: &mut State, conn: &Connection) {
         user: conn.user.clone(),
         password,
         tls: conn.tls,
+        auth: conn.auth,
     });
     st.active = Some(conn.id.clone());
     st.result = None;
@@ -732,20 +741,24 @@ fn open_filter_match(st: &State, index: usize) {
     };
     // No LIMIT here — the run path caps rows and offers "Load more" (matching
     // open_table_data_named).
-    let (target_db, sql) = if conn.engine == crate::db::Engine::Mysql {
-        // MySQL: the schema is the database; qualify in the current connection.
-        let db = m.database.clone().unwrap_or_else(|| m.schema.clone());
-        let db = db.replace('`', "``");
-        let table = m.name.replace('`', "``");
-        (None, format!("SELECT * FROM `{db}`.`{table}`"))
-    } else {
-        // Postgres: open a tab connected to the match's database.
-        let schema = m.schema.replace('"', "\"\"");
-        let table = m.name.replace('"', "\"\"");
-        (
-            m.database.clone(),
-            format!("SELECT * FROM \"{schema}\".\"{table}\""),
-        )
+    let (target_db, sql) = match conn.engine {
+        crate::db::Engine::Elasticsearch => (None, es_search_query(&m.name)),
+        crate::db::Engine::Mysql => {
+            // MySQL: the schema is the database; qualify in the current connection.
+            let db = m.database.clone().unwrap_or_else(|| m.schema.clone());
+            let db = db.replace('`', "``");
+            let table = m.name.replace('`', "``");
+            (None, format!("SELECT * FROM `{db}`.`{table}`"))
+        }
+        crate::db::Engine::Postgres => {
+            // Postgres: open a tab connected to the match's database.
+            let schema = m.schema.replace('"', "\"\"");
+            let table = m.name.replace('"', "\"\"");
+            (
+                m.database.clone(),
+                format!("SELECT * FROM \"{schema}\".\"{table}\""),
+            )
+        }
     };
     open_tab(
         &conn.name,
@@ -801,6 +814,13 @@ fn open_structure_tab(st: &State, i: usize, j: usize, k: usize) {
 
 /// Open a table (by schema + name) as a `SELECT *` data tab against the active
 /// connection's browsed database. Shared by the tree and the filter results.
+/// The editor text that opens an Elasticsearch index: the index name on the
+/// first line, then a `match_all` Query-DSL body — the format `es::split_query`
+/// parses. This is the ES analogue of `SELECT * FROM table`.
+fn es_search_query(index: &str) -> String {
+    format!("{index}\n{{ \"query\": {{ \"match_all\": {{}} }} }}")
+}
+
 fn open_table_data_named(st: &State, schema: &str, table: &str) {
     let Some(conn) = st
         .active
@@ -810,14 +830,18 @@ fn open_table_data_named(st: &State, schema: &str, table: &str) {
         return;
     };
     // No LIMIT here — the run path caps rows and offers "Load more".
-    let sql = if conn.engine == crate::db::Engine::Mysql {
-        let schema = schema.replace('`', "``");
-        let table = table.replace('`', "``");
-        format!("SELECT * FROM `{schema}`.`{table}`")
-    } else {
-        let schema = schema.replace('"', "\"\"");
-        let table = table.replace('"', "\"\"");
-        format!("SELECT * FROM \"{schema}\".\"{table}\"")
+    let sql = match conn.engine {
+        crate::db::Engine::Elasticsearch => es_search_query(table),
+        crate::db::Engine::Mysql => {
+            let schema = schema.replace('`', "``");
+            let table = table.replace('`', "``");
+            format!("SELECT * FROM `{schema}`.`{table}`")
+        }
+        crate::db::Engine::Postgres => {
+            let schema = schema.replace('"', "\"\"");
+            let table = table.replace('"', "\"\"");
+            format!("SELECT * FROM \"{schema}\".\"{table}\"")
+        }
     };
     open_tab(
         &conn.name,
@@ -887,6 +911,7 @@ pub(crate) fn activate_from_state(st: &mut State, state: &str) {
             user: conn.user.clone(),
             password,
             tls: conn.tls,
+            auth: conn.auth,
         });
         st.active = Some(conn.id);
         // Restore the previously-selected database (if the snapshot carried one),
@@ -954,6 +979,7 @@ fn activate_structure(st: &mut State, v: &Value) {
         user: conn.user.clone(),
         password,
         tls: conn.tls,
+        auth: conn.auth,
     });
     st.active = Some(conn.id);
     st.view = crate::state::View::Structure {
@@ -981,6 +1007,9 @@ fn apply_engine_defaults(st: &mut State, engine: crate::db::Engine) {
     st.form.port = d.port.to_string();
     st.form.user = d.user.to_string();
     st.form.database = d.database.to_string();
+    // Reset auth to the engine's default. Only Elasticsearch offers a choice;
+    // SQL engines are always password-based.
+    st.form.auth = crate::db::AuthMode::Password;
 }
 
 /// Open the dialog pre-filled with an existing connection, in edit mode.
@@ -998,6 +1027,7 @@ fn edit_connection(st: &mut State, index: usize) {
         user: conn.user.clone(),
         password,
         tls: conn.tls,
+        auth: conn.auth,
         color: conn.color.clone().unwrap_or_default(),
     };
     st.editing = Some(conn.id);
@@ -1047,6 +1077,7 @@ fn connect_from_form(st: &mut State) {
         database: profile.database.clone(),
         user: profile.user.clone(),
         tls: profile.tls,
+        auth: st.form.auth,
         color,
     };
     // Persist the password to the keychain first; if that fails we must NOT save

--- a/plugins/seshat/src/events.rs
+++ b/plugins/seshat/src/events.rs
@@ -382,9 +382,10 @@ fn load_more(st: &mut State) {
     execute_current(st);
 }
 
-/// Submit the last-run query with the current row cap. A cappable SELECT gets a
-/// `LIMIT row_limit + 1` appended so the extra row signals "more available";
-/// anything else runs unchanged. Shared by fresh runs and "Load more".
+/// Submit the last-run query with the current row cap. A cappable query gets one
+/// extra row requested (`LIMIT n+1` for SQL, `"size": n+1` for Elasticsearch) so
+/// the extra row signals "more available"; anything else runs unchanged. Shared
+/// by fresh runs and "Load more".
 fn execute_current(st: &mut State) {
     let Some(base) = st.last_run_sql.clone() else {
         return;
@@ -395,8 +396,15 @@ fn execute_current(st: &mut State) {
     // Push a "running" signal to the host status bar; the result handler
     // overwrites it with the row count + latency (Ready) or an Error.
     signals::emit_signal("rows", "", SignalStatus::Loading, 0);
-    let (sql, limited) = match sql::add_limit(&base, st.row_limit + 1) {
-        Some(capped) => (capped, true),
+    // Elasticsearch caps rows per query dialect (Query-DSL `size`, SQL/ES|QL
+    // LIMIT); both use the same +1 sentinel-row convention as the SQL engines.
+    let capped = if st.engine() == crate::db::Engine::Elasticsearch {
+        crate::es::cap(&base, st.row_limit + 1)
+    } else {
+        sql::add_limit(&base, st.row_limit + 1)
+    };
+    let (sql, limited) = match capped {
+        Some(c) => (c, true),
         None => (base, false),
     };
     st.run_limited = limited;
@@ -408,6 +416,12 @@ fn execute_current(st: &mut State) {
 /// per-SQL so it only re-executes when the last-run query changed. No-op until a
 /// query has actually been run. Engine-specific via [`Engine::explain_sql`].
 fn load_explain(st: &mut State) {
+    // Elasticsearch has no EXPLAIN; its Explain tab isn't rendered, but a tab
+    // re-pointed from a SQL connection can still carry `results_tab == Explain`,
+    // so refuse here too rather than re-running the search as a "plan".
+    if st.engine() == crate::db::Engine::Elasticsearch {
+        return;
+    }
     let Some(sql) = st.last_run_sql.as_ref().map(|s| s.trim().to_string()) else {
         return;
     };

--- a/plugins/seshat/src/lib.rs
+++ b/plugins/seshat/src/lib.rs
@@ -2,6 +2,7 @@
 mod bindings;
 mod constants;
 mod db;
+mod es;
 mod events;
 mod mysql;
 mod pg;

--- a/plugins/seshat/src/state.rs
+++ b/plugins/seshat/src/state.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use thoth_plugin_sdk::state::PluginState;
 
 use crate::bindings::thoth::plugin::{db_runtime, plugin_storage};
-use crate::db::{self, ColumnInfo, Engine, TableDetail, TableInfo};
+use crate::db::{self, AuthMode, ColumnInfo, Engine, TableDetail, TableInfo};
 
 // ── connection + form models ──────────────────────────────────────────────────
 
@@ -25,6 +25,10 @@ pub(crate) struct Connection {
     pub user: String,
     #[serde(default)]
     pub tls: bool,
+    /// Authentication mechanism. Defaults to `Password` for back-compat with
+    /// connections saved before Elasticsearch's None/ApiKey modes existed.
+    #[serde(default)]
+    pub auth: AuthMode,
     /// Optional environment colour (a semantic token like `error`/`warning`/
     /// `success`) shown as a left accent + status-dot tint, so prod vs local
     /// reads at a glance. `None` = no accent.
@@ -60,6 +64,8 @@ pub(crate) struct Form {
     pub user: String,
     pub password: String,
     pub tls: bool,
+    /// Authentication mechanism selected in the dialog.
+    pub auth: AuthMode,
     /// Environment colour token (empty = none).
     pub color: String,
 }
@@ -75,6 +81,7 @@ impl Default for Form {
             user: "postgres".into(),
             password: String::new(),
             tls: false,
+            auth: AuthMode::Password,
             color: String::new(),
         }
     }
@@ -93,6 +100,7 @@ impl Form {
             user: self.user.clone(),
             password: self.password.clone(),
             tls: self.tls,
+            auth: self.auth,
         }
     }
 }
@@ -340,7 +348,8 @@ pub(crate) static STATE: PluginState<State> = PluginState::new();
 
 /// Engines offered in the connection dialog's engine picker, in display order.
 /// The picker renders these; the click handler maps the row index back to one.
-pub(crate) const SUPPORTED_ENGINES: [Engine; 2] = [Engine::Postgres, Engine::Mysql];
+pub(crate) const SUPPORTED_ENGINES: [Engine; 3] =
+    [Engine::Postgres, Engine::Mysql, Engine::Elasticsearch];
 
 /// Rows rendered per tree level before a "Show more" row appears (and how many
 /// each "Show more" click reveals).
@@ -353,6 +362,7 @@ pub(crate) const ROW_PAGE: usize = 100;
 pub(crate) fn engine_from_value(v: &str) -> Engine {
     match v {
         "mysql" => Engine::Mysql,
+        "elasticsearch" => Engine::Elasticsearch,
         _ => Engine::Postgres,
     }
 }
@@ -360,12 +370,14 @@ pub(crate) fn engine_label(e: Engine) -> &'static str {
     match e {
         Engine::Postgres => "PostgreSQL",
         Engine::Mysql => "MySQL",
+        Engine::Elasticsearch => "Elasticsearch",
     }
 }
 pub(crate) fn engine_badge(e: Engine) -> (&'static str, &'static str) {
     match e {
         Engine::Postgres => ("PG", "blue"),
         Engine::Mysql => ("MY", "orange"),
+        Engine::Elasticsearch => ("ES", "success"),
     }
 }
 

--- a/plugins/seshat/src/ui/dialog.rs
+++ b/plugins/seshat/src/ui/dialog.rs
@@ -55,9 +55,14 @@ fn engine_step(prefix: &str) -> RenderNode {
         .iter()
         .map(|&e| {
             let (short, color) = engine_badge(e);
+            let kind = if e == crate::db::Engine::Elasticsearch {
+                "Search"
+            } else {
+                "SQL"
+            };
             ListItem::builder()
                 .title(engine_label(e))
-                .description("SQL")
+                .description(kind)
                 .badge(ListItemBadge::builder().text(short).color(color).build())
                 .build()
         })
@@ -113,32 +118,21 @@ fn form_step(st: &State, prefix: &str, connect_label: &str) -> RenderNode {
             true,
             db_placeholder,
         ),
-        // User + Password.
-        RenderNode::Split(
-            Split::builder()
-                .gap(12.0)
-                .widths(vec![1.0, 1.0])
-                .children(vec![
-                    text_input(&id("f-user"), "User", &st.form.user, true, ""),
-                    RenderNode::Input(
-                        Input::builder()
-                            .id(id("f-password"))
-                            .label("Password")
-                            .value(st.form.password.clone())
-                            .password(true)
-                            .grow(true)
-                            .build(),
-                    ),
-                ])
-                .build(),
-        ),
-        RenderNode::Checkbox(
-            Checkbox::builder()
-                .id(id("f-tls"))
-                .label("Require TLS")
-                .checked(st.form.tls)
-                .build(),
-        ),
+    ];
+
+    // Authentication section. Elasticsearch supports three modes (None / Password
+    // / API key) chosen via a selector; SQL engines are always password-based, so
+    // they just show the User + Password fields.
+    fields.extend(auth_fields(st, prefix));
+
+    fields.push(RenderNode::Checkbox(
+        Checkbox::builder()
+            .id(id("f-tls"))
+            .label("Require TLS")
+            .checked(st.form.tls)
+            .build(),
+    ));
+    fields.push(
         // Environment colour: a semantic token shown as the connection's accent
         // + status-dot tint, so prod vs local reads at a glance.
         RenderNode::Select(
@@ -172,7 +166,7 @@ fn form_step(st: &State, prefix: &str, connect_label: &str) -> RenderNode {
                 .size(Size::Small)
                 .build(),
         ),
-    ];
+    );
 
     if let Some(status) = &st.test_status {
         let (color, text) = match status {
@@ -190,6 +184,89 @@ fn form_step(st: &State, prefix: &str, connect_label: &str) -> RenderNode {
     fields.push(footer(prefix, true, connect_label));
 
     RenderNode::Column(Column::builder().gap(10.0).children(fields).build())
+}
+
+/// The authentication fields for the credentials step.
+///
+/// SQL engines (Postgres/MySQL) are always username+password, so they show the
+/// plain User + Password split with no selector. Elasticsearch adds a mode
+/// selector (None / Password / API key) and swaps the credential inputs to match
+/// the chosen mode.
+fn auth_fields(st: &State, prefix: &str) -> Vec<RenderNode> {
+    use crate::db::{AuthMode, Engine};
+    let id = |name: &str| format!("{prefix}{name}");
+
+    // User + Password split, reused by SQL engines and ES password mode.
+    let user_password = || {
+        RenderNode::Split(
+            Split::builder()
+                .gap(12.0)
+                .widths(vec![1.0, 1.0])
+                .children(vec![
+                    text_input(&id("f-user"), "User", &st.form.user, true, ""),
+                    RenderNode::Input(
+                        Input::builder()
+                            .id(id("f-password"))
+                            .label("Password")
+                            .value(st.form.password.clone())
+                            .password(true)
+                            .grow(true)
+                            .build(),
+                    ),
+                ])
+                .build(),
+        )
+    };
+
+    // Non-Elasticsearch engines: no auth selector, just credentials.
+    if st.form.engine != Engine::Elasticsearch {
+        return vec![user_password()];
+    }
+
+    // Elasticsearch: a mode selector, then mode-specific inputs.
+    let mode_value = match st.form.auth {
+        AuthMode::None => "none",
+        AuthMode::Password => "password",
+        AuthMode::ApiKey => "apikey",
+    };
+    let selector = RenderNode::Select(
+        Select::builder()
+            .id(id("f-auth"))
+            .value(mode_value.to_string())
+            .prefix_label("Auth: ")
+            .options(vec![
+                SelectOption::builder()
+                    .value("none")
+                    .label("No authentication")
+                    .build(),
+                SelectOption::builder()
+                    .value("password")
+                    .label("Username & password")
+                    .build(),
+                SelectOption::builder()
+                    .value("apikey")
+                    .label("API key")
+                    .build(),
+            ])
+            .size(Size::Small)
+            .build(),
+    );
+
+    let mut out = vec![selector];
+    match st.form.auth {
+        AuthMode::None => {}
+        AuthMode::Password => out.push(user_password()),
+        AuthMode::ApiKey => out.push(RenderNode::Input(
+            Input::builder()
+                .id(id("f-apikey"))
+                .label("API key (encoded)")
+                .value(st.form.password.clone())
+                .password(true)
+                .grow(true)
+                .build(),
+        )),
+    }
+    out
 }
 
 /// The dialog footer: Back + Test on the form step, Cancel + Connect always

--- a/plugins/seshat/src/ui/results.rs
+++ b/plugins/seshat/src/ui/results.rs
@@ -13,28 +13,31 @@ use crate::{
 };
 
 pub fn results_view(state: &State) -> RenderNode {
+    // Elasticsearch has no query planner exposed as an EXPLAIN, so the Explain
+    // tab is omitted for it rather than showing a re-run of the search dressed
+    // up as a plan. The tab-change handler matches on the tab *label*, so
+    // dropping one here can't misroute the others.
+    let explain = state.engine() != crate::db::Engine::Elasticsearch;
+
+    let mut headers = vec!["Results".to_string(), "Messages".to_string()];
+    let mut icons = vec![ICON_TABLE.to_string(), ICON_CHAT_TEXT.to_string()];
+    let mut children = vec![results(state), messages(state)];
+    if explain {
+        headers.push("Explain".to_string());
+        icons.push(ICON_TREE_STRUCTURE.to_string());
+        children.push(result_explain(state));
+    }
+    headers.push("Stats".to_string());
+    icons.push(ICON_CHART_BAR.to_string());
+    children.push(stats(state));
+
     RenderNode::Tabs(
         Tabs::builder()
             .id("query-output")
-            .headers(vec![
-                "Results".into(),
-                "Messages".into(),
-                "Explain".into(),
-                "Stats".into(),
-            ])
-            .icons(vec![
-                ICON_TABLE.to_string(),
-                ICON_CHAT_TEXT.to_string(),
-                ICON_TREE_STRUCTURE.to_string(),
-                ICON_CHART_BAR.to_string(),
-            ])
+            .headers(headers)
+            .icons(icons)
             .size(Size::Small)
-            .children(vec![
-                results(state),
-                messages(state),
-                result_explain(state),
-                stats(state),
-            ])
+            .children(children)
             .build(),
     )
 }

--- a/src/plugin/network_policy.rs
+++ b/src/plugin/network_policy.rs
@@ -111,6 +111,27 @@ impl NetworkPolicy {
     }
 
     pub fn check(&mut self, url: &str) -> Result<CheckOutcome, PolicyViolation> {
+        self.check_inner(url, true)
+    }
+
+    /// Like [`check`], but WITHOUT the per-minute rate cap. Used for HTTP requests
+    /// issued by a data-source plugin (e.g. the Elasticsearch engine): these are
+    /// database-client traffic, not calls to a public API. A single user action —
+    /// testing a connection, expanding the schema tree, running a query — fans out
+    /// into many REST calls, so a per-minute cap would reject ordinary use and, on
+    /// tripping, surface a misleading "rate limit exceeded" that masks the real
+    /// connection error. This mirrors [`check_tcp`], which is likewise uncapped for
+    /// the SQL engines. All other security checks (HTTPS, allowlist, block list,
+    /// SSRF/consent) still apply.
+    pub fn check_data_source(&mut self, url: &str) -> Result<CheckOutcome, PolicyViolation> {
+        self.check_inner(url, false)
+    }
+
+    fn check_inner(
+        &mut self,
+        url: &str,
+        enforce_rate_limit: bool,
+    ) -> Result<CheckOutcome, PolicyViolation> {
         let parsed_url =
             Url::parse(url).map_err(|err| PolicyViolation::InvalidUrl(err.to_string()))?;
 
@@ -119,7 +140,7 @@ impl NetworkPolicy {
             .ok_or_else(|| PolicyViolation::InvalidUrl(format!("URL has no host: {url}")))?
             .to_string();
 
-        if self.is_rate_limited() {
+        if enforce_rate_limit && self.is_rate_limited() {
             return Err(PolicyViolation::RateLimitExceeded);
         }
 
@@ -562,5 +583,46 @@ mod test {
                 Ok(CheckOutcome::Allowed)
             ));
         }
+    }
+
+    #[test]
+    fn check_data_source_does_not_rate_limit() {
+        // The Elasticsearch engine's HTTP calls are database-client traffic: many
+        // requests per user action must not trip the per-minute cap (rpm is 10 here
+        // on purpose), unlike the public-API `check` path.
+        let mut np = policy(&["*"], &[]);
+        for _ in 0..50 {
+            assert!(matches!(
+                np.check_data_source("http://es.internal:9200/_search"),
+                Ok(CheckOutcome::Allowed)
+            ));
+        }
+    }
+
+    #[test]
+    fn check_rate_limits_but_check_data_source_does_not() {
+        // Same policy: `check` trips after the cap, `check_data_source` never does.
+        let mut np = policy(&["*"], &[]);
+        let mut tripped = false;
+        for _ in 0..20 {
+            if matches!(
+                np.check("http://api.example.com/x"),
+                Err(PolicyViolation::RateLimitExceeded)
+            ) {
+                tripped = true;
+                break;
+            }
+        }
+        assert!(tripped, "check should hit the rate cap");
+    }
+
+    #[test]
+    fn check_data_source_still_enforces_block_list() {
+        // Bypassing the rate cap must not bypass other security checks.
+        let mut np = policy(&["*"], &["evil.example.com"]);
+        assert!(matches!(
+            np.check_data_source("http://evil.example.com/"),
+            Err(PolicyViolation::UserBlocked)
+        ));
     }
 }

--- a/src/plugin/network_policy.rs
+++ b/src/plugin/network_policy.rs
@@ -625,4 +625,52 @@ mod test {
             Err(PolicyViolation::UserBlocked)
         ));
     }
+
+    #[test]
+    fn check_data_source_still_rejects_invalid_urls() {
+        let mut np = policy(&["*"], &[]);
+        assert!(matches!(
+            np.check_data_source("not-a-url"),
+            Err(PolicyViolation::InvalidUrl(_))
+        ));
+        // A URL that parses but carries no host is also rejected.
+        assert!(matches!(
+            np.check_data_source("file:///etc/passwd"),
+            Err(PolicyViolation::InvalidUrl(_))
+        ));
+    }
+
+    #[test]
+    fn check_data_source_still_enforces_https() {
+        let user = PluginNetworkPolicy {
+            allowed_domains: vec!["*".to_string()],
+            blocked_domains: vec![],
+            require_https: true,
+            rate_limit_rpm: 10,
+        };
+        let plugin = NetworkDeclarations {
+            allowed_domains: vec![],
+            require_https: true,
+            rate_limit_rpm: 10,
+        };
+        let mut np = NetworkPolicy::from_plugin_and_settings(&plugin, &user);
+        assert!(matches!(
+            np.check_data_source("http://es.internal:9200/"),
+            Err(PolicyViolation::HttpNotAllowed)
+        ));
+        assert!(matches!(
+            np.check_data_source("https://es.internal:9200/"),
+            Ok(CheckOutcome::Allowed)
+        ));
+    }
+
+    #[test]
+    fn check_data_source_still_requires_consent_for_unknown_host() {
+        // Not in the allowlist → consent gate, exactly as `check` behaves.
+        let mut np = policy(&["known.example.com"], &[]);
+        assert!(matches!(
+            np.check_data_source("http://unknown.example.com/"),
+            Ok(CheckOutcome::NeedsConsent { domain }) if domain == "unknown.example.com"
+        ));
+    }
 }

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -243,7 +243,7 @@ impl thoth::plugin::http_client::Host for DataSourcePluginState {
         thoth::plugin::http_client::HttpResponse,
         thoth::plugin::http_client::PluginError,
     > {
-        match self.policy.check(&req.url) {
+        match self.policy.check_data_source(&req.url) {
             Ok(CheckOutcome::Allowed) => {
                 execute_http_request(req).map_err(|e| thoth::plugin::http_client::PluginError {
                     code: 1,
@@ -293,7 +293,7 @@ impl thoth::plugin::http_client::Host for DataSourcePluginState {
         let tx = self.http_tx.clone();
         let id = request_id.clone();
 
-        match self.policy.check(&req.url) {
+        match self.policy.check_data_source(&req.url) {
             Ok(CheckOutcome::Allowed) => {
                 // Increment before spawning so has_pending_http() is true
                 // on the very next poll.


### PR DESCRIPTION
Closes #104. Adds Elasticsearch alongside PostgreSQL and MySQL in the Seshat plugin — same UI, same schema browser, same results grid, new engine card in the connection dialog.

## New file

plugins/seshat/src/es.rs
  Implements DbAdapter over the host http-client import (reqwest-backed,
  no wire protocol). Elasticsearch is plain HTTP REST + JSON so no
  tcp-client shim is needed.

  Transport
  - All requests use http_client::fetch (synchronous, runs on the db-runtime worker thread — same pattern as the SQL adapters).
  - URL builder: http/https selected by Profile.tls; host + port from Profile.
  - base64 implemented inline (no new dependency) for Basic auth.

  Authentication — three explicit modes via the new AuthMode enum:
  - AuthMode::None   → no Authorization header (open cluster)
  - AuthMode::Password → Authorization: Basic base64(user:pass)
  - AuthMode::ApiKey  → Authorization: ApiKey <encoded-key>

  ES → DbAdapter mapping (mirrors MySQL's schema-collapse approach):
  - list_databases  → returns ["_all"] (synthetic constant, matches the connection default so the schema tree auto-loads on connect)
  - list_schemas    → returns ["indices"] (synthetic namespace)
  - list_tables     → GET _cat/indices?format=json (one entry per index)
  - list_columns    → GET <index>/_mapping, flattened to dotted paths
  - describe_table  → _mapping columns + _cat/indices doc count + size
  - run_query       → POST <index>/_search; editor text format:
                       "<index>\n{ ...Query DSL... }"
                       (bare index name, pure JSON body, or both)
  - find_tables     → _cat/indices filtered by substring

  run_query result:
  - Hits flattened to columns: _id, _score, then _source keys in first-seen order across hits.
  - QueryResult.tag set to "N hits · took M ms" (reuses the existing command-tag slot in the results footer).

  Error handling:
  - Non-2xx responses extract ES's structured error.type + error.reason before falling back to raw body text.

  Unit tests (8): base64 RFC 4648 vectors, auth-header selection for
  all three modes, query text parsing (split_query), nested mapping
  flatten, human_size formatting, index-click round-trip.

## Modified files

plugins/seshat/src/db.rs
  - Engine::Elasticsearch variant added to the Engine enum.
  - AuthMode enum added (None / Password / ApiKey, serde lowercase, default = Password for back-compat with existing saved connections).
  - Profile gains an auth: AuthMode field.
  - adapter() and Engine::explain_sql() wired for Elasticsearch (explain echoes the query body — ES has no SQL EXPLAIN).

plugins/seshat/src/state.rs
  - SUPPORTED_ENGINES extended from 2 to 3 entries.
  - engine_from_value / engine_label / engine_badge updated for ES (badge: "ES", colour: "success" / green).
  - Connection and Form gain auth: AuthMode (serde default = Password so existing saved connections deserialise without error).
  - Form::profile() forwards auth into Profile.

plugins/seshat/src/lib.rs
  - mod es declared.

plugins/seshat/src/ui/dialog.rs
  - engine_step: Elasticsearch card shows description "Search" instead of "SQL".
  - form_step: credentials section extracted into auth_fields(). SQL engines: unchanged User + Password split. Elasticsearch: an "Auth:" Select (No authentication / Username & password / API key) followed by the matching inputs — nothing for None, User+Password for Password, a single password-masked "API key (encoded)" Input for ApiKey.

plugins/seshat/src/events.rs
  - f-auth change handler: updates Form.auth from the selector value.
  - f-apikey handler: routes the API-key input into Form.password.
  - apply_engine_defaults: resets auth to AuthMode::Password on engine switch.
  - connect_from_form: writes auth onto the saved Connection.
  - edit_connection (Form builder): restores auth from Connection.
  - activate_from_state / activate_connection: all three Connection → Profile construction sites carry auth: conn.auth.
  - es_search_query(index): builds "<index>\n{match_all}" — the ES analogue of SELECT * FROM table, used when clicking an index in the schema tree or in find-tables results.
  - open_table_data_named and the find-tables click path: match on engine; Elasticsearch produces es_search_query, Postgres/MySQL paths unchanged.

plugins/seshat/plugin.toml
  - Description updated to mention Elasticsearch / Query DSL.
  - rate_limit_rpm raised to 6000 (see network_policy note below; the effective cap for ES HTTP is now host-controlled via check_data_source, so this value only bounds any future non-data-source traffic).

src/plugin/network_policy.rs
  Root cause of "rate limit exceeded" masking real connection errors:
  the ES engine uses http-client (which is rate-capped) while the SQL
  engines use tcp-client (explicitly uncapped, lines 164-167). A single
  user action — test connection, schema tree expand, query — fans out
  into many HTTP calls, tripping the 60 rpm default and hiding the
  actual error (e.g. 401, connection refused).

  Fix: check() refactored into check_inner(url, enforce_rate_limit).
  New check_data_source() calls check_inner(url, false) — skips the
  per-minute counter while keeping every other security check (HTTPS
  enforcement, allowlist, block list, SSRF/consent). This mirrors the
  existing rationale for check_tcp being uncapped.

  3 new tests:
  - check_data_source_does_not_rate_limit: 50 calls succeed against a policy with rpm=10.
  - check_rate_limits_but_check_data_source_does_not: same policy, check() trips, check_data_source() never does.
  - check_data_source_still_enforces_block_list: blocked domain still returns UserBlocked despite skipping the rate cap.

src/plugin/wasm_data_source.rs
  Both http_client::Host::fetch and http_client::Host::submit now call
  check_data_source instead of check, removing the rate-cap for all
  data-source plugin HTTP traffic.

## Testing

Plugin (wasm32-wasip1):
  cargo test --lib  →  15 tests pass (8 ES + 7 SQL)
  cargo component build --release  →  seshat.wasm builds clean
  cargo clippy --lib  →  no warnings
  cargo fmt --check  →  clean

Host:
  cargo check  →  compiles (pre-existing unrelated warnings only)
  cargo test --lib network_policy  →  18 tests pass (15 existing + 3 new)

Live (Podman, ES 8.15.0, all three auth clusters):
  - No-auth (port 9200): GET / returns 200, indices seeded and browsable.
  - Basic auth (port 9201): Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ== verified against system base64 output.
  - API key (port 9202): Authorization: ApiKey <encoded> returns 200; unauthenticated request correctly returns 401 security_exception (not rate-limit error).
  - Index click: POST /books/_search {match_all} returns 5 hits with expected _source keys.