### PR TITLE
feat(datasets): streaming append to the dataset bus (#117)

### DIFF
--- a/plugins/seshat/src/bindings.rs
+++ b/plugins/seshat/src/bindings.rs
@@ -2504,6 +2504,98 @@ pub mod thoth {
                 }
             }
             #[allow(unused_unsafe, clippy::all)]
+            /// Append rows to an existing handle, keeping its columns — for streaming
+            /// producers (e.g. a Kafka/Redis tail) that push batches over time. The host
+            /// keeps only the most recent rows (older ones are dropped past a cap) so an
+            /// unbounded stream stays bounded, and refreshes any bound `data-view`.
+            /// No-op unless the handle is known and owned by the calling instance.
+            pub fn append(handle: &str, rows: &[_rt::Vec<_rt::String>]) -> () {
+                unsafe {
+                    let mut cleanup_list = _rt::Vec::new();
+                    let vec0 = handle;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec3 = rows;
+                    let len3 = vec3.len();
+                    let layout3 = _rt::alloc::Layout::from_size_align_unchecked(
+                        vec3.len() * (2 * ::core::mem::size_of::<*const u8>()),
+                        ::core::mem::size_of::<*const u8>(),
+                    );
+                    let result3 = if layout3.size() != 0 {
+                        let ptr = _rt::alloc::alloc(layout3).cast::<u8>();
+                        if ptr.is_null() {
+                            _rt::alloc::handle_alloc_error(layout3);
+                        }
+                        ptr
+                    } else {
+                        ::core::ptr::null_mut()
+                    };
+                    for (i, e) in vec3.into_iter().enumerate() {
+                        let base = result3
+                            .add(i * (2 * ::core::mem::size_of::<*const u8>()));
+                        {
+                            let vec2 = e;
+                            let len2 = vec2.len();
+                            let layout2 = _rt::alloc::Layout::from_size_align_unchecked(
+                                vec2.len() * (2 * ::core::mem::size_of::<*const u8>()),
+                                ::core::mem::size_of::<*const u8>(),
+                            );
+                            let result2 = if layout2.size() != 0 {
+                                let ptr = _rt::alloc::alloc(layout2).cast::<u8>();
+                                if ptr.is_null() {
+                                    _rt::alloc::handle_alloc_error(layout2);
+                                }
+                                ptr
+                            } else {
+                                ::core::ptr::null_mut()
+                            };
+                            for (i, e) in vec2.into_iter().enumerate() {
+                                let base = result2
+                                    .add(i * (2 * ::core::mem::size_of::<*const u8>()));
+                                {
+                                    let vec1 = e;
+                                    let ptr1 = vec1.as_ptr().cast::<u8>();
+                                    let len1 = vec1.len();
+                                    *base
+                                        .add(::core::mem::size_of::<*const u8>())
+                                        .cast::<usize>() = len1;
+                                    *base.add(0).cast::<*mut u8>() = ptr1.cast_mut();
+                                }
+                            }
+                            *base
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len2;
+                            *base.add(0).cast::<*mut u8>() = result2;
+                            cleanup_list.extend_from_slice(&[(result2, layout2)]);
+                        }
+                    }
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/dataset-bus@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "append"]
+                        fn wit_import4(_: *mut u8, _: usize, _: *mut u8, _: usize);
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import4(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe { wit_import4(ptr0.cast_mut(), len0, result3, len3) };
+                    if layout3.size() != 0 {
+                        _rt::alloc::dealloc(result3.cast(), layout3);
+                    }
+                    for (ptr, layout) in cleanup_list {
+                        if layout.size() != 0 {
+                            _rt::alloc::dealloc(ptr.cast(), layout);
+                        }
+                    }
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
             /// Drop a published dataset early (otherwise it's dropped when the tab closes).
             pub fn release(handle: &str) -> () {
                 unsafe {
@@ -5445,8 +5537,8 @@ pub(crate) use __export_data_source_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3641] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb0\x1b\x01A\x02\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3671] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xce\x1b\x01A\x02\x01\
 A)\x01B\x0a\x01m\x07\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
 search-provider\x10new-ui-component\x0ddata-producer\x04\0\x0acapability\x03\0\0\
 \x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescriptions\x0ccapabili\
@@ -5485,50 +5577,51 @@ ebsocket@0.1.0\x05\x09\x01B\x0c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\
 s\x01p\x05\x01r\x04\x04names\x04kinds\x07columns\x04\x04rows\x06\x04\0\x07datase\
 t\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\x09\x04\0\x0fprovide-dataset\x01\x0a\x03\
 \0\x20thoth:plugin/data-producer@0.1.0\x05\x0a\x02\x03\0\x09\x0edataset-column\x01\
-B\x0b\x02\x03\x02\x01\x0b\x04\0\x0edataset-column\x03\0\0\x01p\x01\x01ps\x01p\x03\
+B\x0d\x02\x03\x02\x01\x0b\x04\0\x0edataset-column\x03\0\0\x01p\x01\x01ps\x01p\x03\
 \x01@\x03\x04names\x07columns\x02\x04rows\x04\0s\x04\0\x07publish\x01\x05\x01@\x03\
-\x06handles\x07columns\x02\x04rows\x04\x01\0\x04\0\x06update\x01\x06\x01@\x01\x06\
-handles\x01\0\x04\0\x07release\x01\x07\x03\0\x1ethoth:plugin/dataset-bus@0.1.0\x05\
-\x0c\x01B\x0d\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04path\
-s\x08contentss\x04\0\x0bopened-file\x03\0\x02\x01ps\x01k\x03\x01j\x01\x05\x01\x01\
-\x01@\x02\x05titles\x0aextensions\x04\0\x06\x04\0\x09open-file\x01\x07\x01ks\x01\
-j\x01\x08\x01\x01\x01@\x04\x05titles\x0cdefault-names\x0aextensions\x04\x08conte\
-ntss\0\x09\x04\0\x09save-file\x01\x0a\x03\0\x1ethoth:plugin/file-dialog@0.1.0\x05\
-\x0d\x01B\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04name\
-s\x0bdescriptions\x08required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\
-\x03\x04names\x09type-hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\
-\x05\x01r\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09\
-node-jsons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\
-\0\x0frequired-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\
-\0\x07connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\
-\0\x06schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\
-\x01\x06handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06ha\
-ndles\0\x14\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\
-\x05\x0e\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09\
-widget-ids\x04kinds\x05values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\
-\x0bheight-hinty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\
-\0\x09render-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\
-\x01k\x05\x01j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\
-\x1fthoth:plugin/ui-component@0.1.0\x05\x0f\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\
-\0\x08tab-icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\
-\x01j\0\x01\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\
-\x01\0\x04\0\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0d\
-on-tab-closed\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.0\x05\x10\x01B\x0c\x02\x03\
-\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04names\x09type-hints\x04\0\
-\x0edataset-column\x03\0\x02\x01p\x03\x01ps\x01p\x05\x01r\x04\x04names\x04kinds\x07\
-columns\x04\x04rows\x06\x04\0\x07dataset\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\
-\x09\x04\0\x0fprovide-dataset\x01\x0a\x04\0\x20thoth:plugin/data-producer@0.1.0\x05\
-\x11\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x12\x04\0\x0bplugin-inf\
-o\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-me\
-ta@0.1.0\x05\x13\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\
-\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:\
-plugin/plugin-lifecycle@0.1.0\x05\x14\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplug\
-in-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\
-\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\
-\0\"thoth:plugin/plugin-settings@0.1.0\x05\x15\x04\0%thoth:plugin/data-source-pl\
-ugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\x01\
-\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
+\x06handles\x07columns\x02\x04rows\x04\x01\0\x04\0\x06update\x01\x06\x01@\x02\x06\
+handles\x04rows\x04\x01\0\x04\0\x06append\x01\x07\x01@\x01\x06handles\x01\0\x04\0\
+\x07release\x01\x08\x03\0\x1ethoth:plugin/dataset-bus@0.1.0\x05\x0c\x01B\x0d\x02\
+\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04paths\x08contentss\x04\
+\0\x0bopened-file\x03\0\x02\x01ps\x01k\x03\x01j\x01\x05\x01\x01\x01@\x02\x05titl\
+es\x0aextensions\x04\0\x06\x04\0\x09open-file\x01\x07\x01ks\x01j\x01\x08\x01\x01\
+\x01@\x04\x05titles\x0cdefault-names\x0aextensions\x04\x08contentss\0\x09\x04\0\x09\
+save-file\x01\x0a\x03\0\x1ethoth:plugin/file-dialog@0.1.0\x05\x0d\x01B\x1c\x02\x03\
+\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04names\x0bdescriptions\x08\
+required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\x03\x04names\x09type\
+-hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\x05\x01r\x02\x04name\
+s\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09node-jsons\x0bheigh\
+t-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\0\x0frequired-c\
+onfig\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\0\x07connect\x01\
+\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\0\x06schema\x01\
+\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\x01\x06handles\x01\
+\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06handles\0\x14\x04\0\x0b\
+render-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\x05\x0e\x01B\x0f\x02\
+\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09widget-ids\x04kinds\x05\
+values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x09\
+ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\0\x09render-ui\x01\x07\
+\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\x01k\x05\x01j\x01\x09\
+\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\x1fthoth:plugin/ui-c\
+omponent@0.1.0\x05\x0f\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\
+\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\0\x08tab-icon\x01\x04\
+\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\x01j\0\x01\x01\x01@\x01\
+\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\x01\0\x04\0\x0eon-tab-f\
+ocused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0don-tab-closed\x01\x09\x04\
+\0\x1bthoth:plugin/tab-host@0.1.0\x05\x10\x01B\x0c\x02\x03\x02\x01\x01\x04\0\x0c\
+plugin-error\x03\0\0\x01r\x02\x04names\x09type-hints\x04\0\x0edataset-column\x03\
+\0\x02\x01p\x03\x01ps\x01p\x05\x01r\x04\x04names\x04kinds\x07columns\x04\x04rows\
+\x06\x04\0\x07dataset\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\x09\x04\0\x0fprovi\
+de-dataset\x01\x0a\x04\0\x20thoth:plugin/data-producer@0.1.0\x05\x11\x02\x03\0\0\
+\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x12\x04\0\x0bplugin-info\x03\0\0\x01@\0\
+\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x13\
+\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08\
+on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:plugin/plugin-life\
+cycle@0.1.0\x05\x14\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01\
+r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\
+\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugi\
+n-settings@0.1.0\x05\x15\x04\0%thoth:plugin/data-source-plugin@0.1.0\x04\0\x0b\x18\
+\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0d\
+wit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/seshat/src/bindings.rs
+++ b/plugins/seshat/src/bindings.rs
@@ -2506,9 +2506,10 @@ pub mod thoth {
             #[allow(unused_unsafe, clippy::all)]
             /// Append rows to an existing handle, keeping its columns — for streaming
             /// producers (e.g. a Kafka/Redis tail) that push batches over time. The host
-            /// keeps only the most recent rows (older ones are dropped past a cap) so an
-            /// unbounded stream stays bounded, and refreshes any bound `data-view`.
-            /// No-op unless the handle is known and owned by the calling instance.
+            /// retains at most the 50,000 most recent rows, dropping older rows beyond
+            /// that limit, so an unbounded stream stays bounded, and refreshes any bound
+            /// `data-view`. No-op unless the handle is known and owned by the calling
+            /// instance.
             pub fn append(handle: &str, rows: &[_rt::Vec<_rt::String>]) -> () {
                 unsafe {
                     let mut cleanup_list = _rt::Vec::new();

--- a/plugins/url-source/src/bindings.rs
+++ b/plugins/url-source/src/bindings.rs
@@ -2504,6 +2504,98 @@ pub mod thoth {
                 }
             }
             #[allow(unused_unsafe, clippy::all)]
+            /// Append rows to an existing handle, keeping its columns — for streaming
+            /// producers (e.g. a Kafka/Redis tail) that push batches over time. The host
+            /// keeps only the most recent rows (older ones are dropped past a cap) so an
+            /// unbounded stream stays bounded, and refreshes any bound `data-view`.
+            /// No-op unless the handle is known and owned by the calling instance.
+            pub fn append(handle: &str, rows: &[_rt::Vec<_rt::String>]) -> () {
+                unsafe {
+                    let mut cleanup_list = _rt::Vec::new();
+                    let vec0 = handle;
+                    let ptr0 = vec0.as_ptr().cast::<u8>();
+                    let len0 = vec0.len();
+                    let vec3 = rows;
+                    let len3 = vec3.len();
+                    let layout3 = _rt::alloc::Layout::from_size_align_unchecked(
+                        vec3.len() * (2 * ::core::mem::size_of::<*const u8>()),
+                        ::core::mem::size_of::<*const u8>(),
+                    );
+                    let result3 = if layout3.size() != 0 {
+                        let ptr = _rt::alloc::alloc(layout3).cast::<u8>();
+                        if ptr.is_null() {
+                            _rt::alloc::handle_alloc_error(layout3);
+                        }
+                        ptr
+                    } else {
+                        ::core::ptr::null_mut()
+                    };
+                    for (i, e) in vec3.into_iter().enumerate() {
+                        let base = result3
+                            .add(i * (2 * ::core::mem::size_of::<*const u8>()));
+                        {
+                            let vec2 = e;
+                            let len2 = vec2.len();
+                            let layout2 = _rt::alloc::Layout::from_size_align_unchecked(
+                                vec2.len() * (2 * ::core::mem::size_of::<*const u8>()),
+                                ::core::mem::size_of::<*const u8>(),
+                            );
+                            let result2 = if layout2.size() != 0 {
+                                let ptr = _rt::alloc::alloc(layout2).cast::<u8>();
+                                if ptr.is_null() {
+                                    _rt::alloc::handle_alloc_error(layout2);
+                                }
+                                ptr
+                            } else {
+                                ::core::ptr::null_mut()
+                            };
+                            for (i, e) in vec2.into_iter().enumerate() {
+                                let base = result2
+                                    .add(i * (2 * ::core::mem::size_of::<*const u8>()));
+                                {
+                                    let vec1 = e;
+                                    let ptr1 = vec1.as_ptr().cast::<u8>();
+                                    let len1 = vec1.len();
+                                    *base
+                                        .add(::core::mem::size_of::<*const u8>())
+                                        .cast::<usize>() = len1;
+                                    *base.add(0).cast::<*mut u8>() = ptr1.cast_mut();
+                                }
+                            }
+                            *base
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len2;
+                            *base.add(0).cast::<*mut u8>() = result2;
+                            cleanup_list.extend_from_slice(&[(result2, layout2)]);
+                        }
+                    }
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "thoth:plugin/dataset-bus@0.1.0")]
+                    unsafe extern "C" {
+                        #[link_name = "append"]
+                        fn wit_import4(_: *mut u8, _: usize, _: *mut u8, _: usize);
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unsafe extern "C" fn wit_import4(
+                        _: *mut u8,
+                        _: usize,
+                        _: *mut u8,
+                        _: usize,
+                    ) {
+                        unreachable!()
+                    }
+                    unsafe { wit_import4(ptr0.cast_mut(), len0, result3, len3) };
+                    if layout3.size() != 0 {
+                        _rt::alloc::dealloc(result3.cast(), layout3);
+                    }
+                    for (ptr, layout) in cleanup_list {
+                        if layout.size() != 0 {
+                            _rt::alloc::dealloc(ptr.cast(), layout);
+                        }
+                    }
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
             /// Drop a published dataset early (otherwise it's dropped when the tab closes).
             pub fn release(handle: &str) -> () {
                 unsafe {
@@ -5445,8 +5537,8 @@ pub(crate) use __export_data_source_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3641] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb0\x1b\x01A\x02\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3671] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xce\x1b\x01A\x02\x01\
 A)\x01B\x0a\x01m\x07\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
 search-provider\x10new-ui-component\x0ddata-producer\x04\0\x0acapability\x03\0\0\
 \x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescriptions\x0ccapabili\
@@ -5485,50 +5577,51 @@ ebsocket@0.1.0\x05\x09\x01B\x0c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\
 s\x01p\x05\x01r\x04\x04names\x04kinds\x07columns\x04\x04rows\x06\x04\0\x07datase\
 t\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\x09\x04\0\x0fprovide-dataset\x01\x0a\x03\
 \0\x20thoth:plugin/data-producer@0.1.0\x05\x0a\x02\x03\0\x09\x0edataset-column\x01\
-B\x0b\x02\x03\x02\x01\x0b\x04\0\x0edataset-column\x03\0\0\x01p\x01\x01ps\x01p\x03\
+B\x0d\x02\x03\x02\x01\x0b\x04\0\x0edataset-column\x03\0\0\x01p\x01\x01ps\x01p\x03\
 \x01@\x03\x04names\x07columns\x02\x04rows\x04\0s\x04\0\x07publish\x01\x05\x01@\x03\
-\x06handles\x07columns\x02\x04rows\x04\x01\0\x04\0\x06update\x01\x06\x01@\x01\x06\
-handles\x01\0\x04\0\x07release\x01\x07\x03\0\x1ethoth:plugin/dataset-bus@0.1.0\x05\
-\x0c\x01B\x0d\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04path\
-s\x08contentss\x04\0\x0bopened-file\x03\0\x02\x01ps\x01k\x03\x01j\x01\x05\x01\x01\
-\x01@\x02\x05titles\x0aextensions\x04\0\x06\x04\0\x09open-file\x01\x07\x01ks\x01\
-j\x01\x08\x01\x01\x01@\x04\x05titles\x0cdefault-names\x0aextensions\x04\x08conte\
-ntss\0\x09\x04\0\x09save-file\x01\x0a\x03\0\x1ethoth:plugin/file-dialog@0.1.0\x05\
-\x0d\x01B\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04name\
-s\x0bdescriptions\x08required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\
-\x03\x04names\x09type-hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\
-\x05\x01r\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09\
-node-jsons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\
-\0\x0frequired-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\
-\0\x07connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\
-\0\x06schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\
-\x01\x06handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06ha\
-ndles\0\x14\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\
-\x05\x0e\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09\
-widget-ids\x04kinds\x05values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\
-\x0bheight-hinty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\
-\0\x09render-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\
-\x01k\x05\x01j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\
-\x1fthoth:plugin/ui-component@0.1.0\x05\x0f\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\
-\0\x08tab-icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\
-\x01j\0\x01\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\
-\x01\0\x04\0\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0d\
-on-tab-closed\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.0\x05\x10\x01B\x0c\x02\x03\
-\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04names\x09type-hints\x04\0\
-\x0edataset-column\x03\0\x02\x01p\x03\x01ps\x01p\x05\x01r\x04\x04names\x04kinds\x07\
-columns\x04\x04rows\x06\x04\0\x07dataset\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\
-\x09\x04\0\x0fprovide-dataset\x01\x0a\x04\0\x20thoth:plugin/data-producer@0.1.0\x05\
-\x11\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x12\x04\0\x0bplugin-inf\
-o\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-me\
-ta@0.1.0\x05\x13\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\
-\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:\
-plugin/plugin-lifecycle@0.1.0\x05\x14\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplug\
-in-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\
-\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\
-\0\"thoth:plugin/plugin-settings@0.1.0\x05\x15\x04\0%thoth:plugin/data-source-pl\
-ugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\x01\
-\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
+\x06handles\x07columns\x02\x04rows\x04\x01\0\x04\0\x06update\x01\x06\x01@\x02\x06\
+handles\x04rows\x04\x01\0\x04\0\x06append\x01\x07\x01@\x01\x06handles\x01\0\x04\0\
+\x07release\x01\x08\x03\0\x1ethoth:plugin/dataset-bus@0.1.0\x05\x0c\x01B\x0d\x02\
+\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04paths\x08contentss\x04\
+\0\x0bopened-file\x03\0\x02\x01ps\x01k\x03\x01j\x01\x05\x01\x01\x01@\x02\x05titl\
+es\x0aextensions\x04\0\x06\x04\0\x09open-file\x01\x07\x01ks\x01j\x01\x08\x01\x01\
+\x01@\x04\x05titles\x0cdefault-names\x0aextensions\x04\x08contentss\0\x09\x04\0\x09\
+save-file\x01\x0a\x03\0\x1ethoth:plugin/file-dialog@0.1.0\x05\x0d\x01B\x1c\x02\x03\
+\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04names\x0bdescriptions\x08\
+required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\x03\x04names\x09type\
+-hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\x05\x01r\x02\x04name\
+s\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09node-jsons\x0bheigh\
+t-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\0\x0frequired-c\
+onfig\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\0\x07connect\x01\
+\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\0\x06schema\x01\
+\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\x01\x06handles\x01\
+\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06handles\0\x14\x04\0\x0b\
+render-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\x05\x0e\x01B\x0f\x02\
+\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09widget-ids\x04kinds\x05\
+values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x09\
+ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\0\x09render-ui\x01\x07\
+\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\x01k\x05\x01j\x01\x09\
+\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\x1fthoth:plugin/ui-c\
+omponent@0.1.0\x05\x0f\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\
+\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\0\x08tab-icon\x01\x04\
+\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\x01j\0\x01\x01\x01@\x01\
+\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\x01\0\x04\0\x0eon-tab-f\
+ocused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0don-tab-closed\x01\x09\x04\
+\0\x1bthoth:plugin/tab-host@0.1.0\x05\x10\x01B\x0c\x02\x03\x02\x01\x01\x04\0\x0c\
+plugin-error\x03\0\0\x01r\x02\x04names\x09type-hints\x04\0\x0edataset-column\x03\
+\0\x02\x01p\x03\x01ps\x01p\x05\x01r\x04\x04names\x04kinds\x07columns\x04\x04rows\
+\x06\x04\0\x07dataset\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\x09\x04\0\x0fprovi\
+de-dataset\x01\x0a\x04\0\x20thoth:plugin/data-producer@0.1.0\x05\x11\x02\x03\0\0\
+\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x12\x04\0\x0bplugin-info\x03\0\0\x01@\0\
+\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x13\
+\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08\
+on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:plugin/plugin-life\
+cycle@0.1.0\x05\x14\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01\
+r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\
+\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugi\
+n-settings@0.1.0\x05\x15\x04\0%thoth:plugin/data-source-plugin@0.1.0\x04\0\x0b\x18\
+\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0d\
+wit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/url-source/src/bindings.rs
+++ b/plugins/url-source/src/bindings.rs
@@ -2506,9 +2506,10 @@ pub mod thoth {
             #[allow(unused_unsafe, clippy::all)]
             /// Append rows to an existing handle, keeping its columns — for streaming
             /// producers (e.g. a Kafka/Redis tail) that push batches over time. The host
-            /// keeps only the most recent rows (older ones are dropped past a cap) so an
-            /// unbounded stream stays bounded, and refreshes any bound `data-view`.
-            /// No-op unless the handle is known and owned by the calling instance.
+            /// retains at most the 50,000 most recent rows, dropping older rows beyond
+            /// that limit, so an unbounded stream stays bounded, and refreshes any bound
+            /// `data-view`. No-op unless the handle is known and owned by the calling
+            /// instance.
             pub fn append(handle: &str, rows: &[_rt::Vec<_rt::String>]) -> () {
                 unsafe {
                     let mut cleanup_list = _rt::Vec::new();

--- a/src/plugin/datasets.rs
+++ b/src/plugin/datasets.rs
@@ -26,6 +26,9 @@ const MAX_BYTES: usize = 128 * 1024 * 1024;
 /// Hard cap on rows returned by a single `read`, so a huge dataset never
 /// crosses the boundary at once.
 pub const MAX_READ_LIMIT: u32 = 1000;
+/// Rows retained by a streaming dataset (`append`). Past this the oldest rows
+/// are dropped (ring buffer) so an unbounded stream can't grow without limit.
+const MAX_STREAM_ROWS: usize = 50_000;
 
 #[derive(Clone, Debug)]
 pub struct DatasetColumn {
@@ -249,6 +252,38 @@ pub fn update(instance: &str, id: &str, columns: Vec<DatasetColumn>, rows: Vec<V
     }
 }
 
+/// Append rows to an existing handle, keeping its columns — for streaming
+/// producers that push batches over time. Retains only the most recent
+/// [`MAX_STREAM_ROWS`] (a ring buffer, so an unbounded stream stays bounded),
+/// keeps the byte total and budget current. No-op unless the handle is known
+/// and owned by `instance`.
+pub fn append(instance: &str, id: &str, rows: Vec<Vec<String>>) {
+    if rows.is_empty() {
+        return;
+    }
+    if let Ok(mut reg) = REGISTRY.lock() {
+        let Some(stored) = reg.map.get_mut(id) else {
+            return;
+        };
+        if stored.meta.source_instance != instance {
+            return;
+        }
+        stored.rows.extend(rows);
+        // Ring-buffer: drop the oldest rows past the cap.
+        let overflow = stored.rows.len().saturating_sub(MAX_STREAM_ROWS);
+        if overflow > 0 {
+            stored.rows.drain(0..overflow);
+        }
+        stored.meta.row_count = stored.rows.len() as u64;
+        let new_size = dataset_bytes(&stored.meta, &stored.rows);
+        let old_size = stored.size;
+        stored.size = new_size;
+        stored.last_access = Instant::now();
+        reg.bytes = reg.bytes.saturating_add(new_size).saturating_sub(old_size);
+        reg.enforce_budget();
+    }
+}
+
 /// Remove a dataset (idempotent). No-op unless the handle is owned by
 /// `instance`, so a producer can only release its own datasets.
 pub fn release(instance: &str, id: &str) {
@@ -356,6 +391,37 @@ mod tests {
         // A different instance can't mutate this dataset.
         update("other#1", &id, vec![col("x")], vec![]);
         assert_eq!(read(&id, 0, 10).unwrap().total, 3);
+    }
+
+    #[test]
+    fn append_adds_rows_scoped_to_instance() {
+        let _g = reset();
+        let id = publish(
+            "p",
+            "p#1",
+            "a".into(),
+            "k".into(),
+            vec![],
+            vec![col("x")],
+            vec![vec!["1".into()]],
+        );
+        append("p#1", &id, vec![vec!["2".into()], vec!["3".into()]]);
+        assert_eq!(read(&id, 0, 10).unwrap().total, 3);
+        // A different instance can't append.
+        append("other#1", &id, vec![vec!["9".into()]]);
+        assert_eq!(read(&id, 0, 10).unwrap().total, 3);
+    }
+
+    #[test]
+    fn append_ring_buffers_past_cap() {
+        let _g = reset();
+        let id = publish_small("p#1", "a"); // seeds one row "1"
+        let batch: Vec<Vec<String>> = (0..MAX_STREAM_ROWS).map(|i| vec![i.to_string()]).collect();
+        append("p#1", &id, batch);
+        let page = read(&id, 0, MAX_READ_LIMIT).unwrap();
+        // Capped to MAX_STREAM_ROWS; the seed row was the oldest and got dropped.
+        assert_eq!(page.total, MAX_STREAM_ROWS as u64);
+        assert_eq!(page.rows[0][0], "0");
     }
 
     #[test]

--- a/src/plugin/datasets.rs
+++ b/src/plugin/datasets.rs
@@ -105,17 +105,19 @@ impl Registry {
     }
 }
 
+/// Estimated heap footprint of a single row (used so `append` can track bytes
+/// incrementally instead of re-summing every retained row each call).
+fn row_bytes(row: &[String]) -> usize {
+    std::mem::size_of::<Vec<String>>()
+        + row
+            .iter()
+            .map(|c| std::mem::size_of::<String>() + c.len())
+            .sum::<usize>()
+}
+
 /// Estimated heap footprint of a dataset's rows + metadata strings.
 fn dataset_bytes(meta: &DatasetMeta, rows: &[Vec<String>]) -> usize {
-    let cells: usize = rows
-        .iter()
-        .map(|r| {
-            std::mem::size_of::<Vec<String>>()
-                + r.iter()
-                    .map(|c| std::mem::size_of::<String>() + c.len())
-                    .sum::<usize>()
-        })
-        .sum();
+    let cells: usize = rows.iter().map(|r| row_bytes(r)).sum();
     let cols: usize = meta
         .columns
         .iter()
@@ -268,16 +270,24 @@ pub fn append(instance: &str, id: &str, rows: Vec<Vec<String>>) {
         if stored.meta.source_instance != instance {
             return;
         }
+        // Track bytes incrementally (add appended, subtract evicted) rather than
+        // re-summing every retained row — an append-heavy stream would otherwise
+        // be O(rows) per call.
+        let added: usize = rows.iter().map(|r| row_bytes(r)).sum();
         stored.rows.extend(rows);
         // Ring-buffer: drop the oldest rows past the cap.
         let overflow = stored.rows.len().saturating_sub(MAX_STREAM_ROWS);
-        if overflow > 0 {
-            stored.rows.drain(0..overflow);
-        }
+        let evicted: usize = if overflow > 0 {
+            let e = stored.rows[..overflow].iter().map(|r| row_bytes(r)).sum();
+            stored.rows.drain(..overflow);
+            e
+        } else {
+            0
+        };
         stored.meta.row_count = stored.rows.len() as u64;
-        let new_size = dataset_bytes(&stored.meta, &stored.rows);
         let old_size = stored.size;
-        stored.size = new_size;
+        stored.size = old_size.saturating_add(added).saturating_sub(evicted);
+        let new_size = stored.size;
         stored.last_access = Instant::now();
         reg.bytes = reg.bytes.saturating_add(new_size).saturating_sub(old_size);
         reg.enforce_budget();

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -791,6 +791,15 @@ impl thoth::plugin::dataset_bus::Host for DataSourcePluginState {
         );
     }
 
+    fn append(&mut self, handle: String, rows: Vec<Vec<String>>) {
+        crate::plugin::datasets::append(&self.instance_id, &handle, rows);
+        // The app is reactive; a background stream must nudge egui or the newly
+        // appended rows won't show until the next user interaction.
+        if let Some(ctx) = crate::EGUI_CTX.get() {
+            ctx.request_repaint();
+        }
+    }
+
     fn release(&mut self, handle: String) {
         crate::plugin::datasets::release(&self.instance_id, &handle);
     }

--- a/wit/thoth-plugin.wit
+++ b/wit/thoth-plugin.wit
@@ -841,9 +841,10 @@ interface dataset-bus {
 
     /// Append rows to an existing handle, keeping its columns — for streaming
     /// producers (e.g. a Kafka/Redis tail) that push batches over time. The host
-    /// keeps only the most recent rows (older ones are dropped past a cap) so an
-    /// unbounded stream stays bounded, and refreshes any bound `data-view`.
-    /// No-op unless the handle is known and owned by the calling instance.
+    /// retains at most the 50,000 most recent rows, dropping older rows beyond
+    /// that limit, so an unbounded stream stays bounded, and refreshes any bound
+    /// `data-view`. No-op unless the handle is known and owned by the calling
+    /// instance.
     append: func(handle: string, rows: list<list<string>>);
 
     /// Drop a published dataset early (otherwise it's dropped when the tab closes).

--- a/wit/thoth-plugin.wit
+++ b/wit/thoth-plugin.wit
@@ -839,6 +839,13 @@ interface dataset-bus {
     /// the handle a `data-view` node references stays stable across updates.
     update: func(handle: string, columns: list<dataset-column>, rows: list<list<string>>);
 
+    /// Append rows to an existing handle, keeping its columns — for streaming
+    /// producers (e.g. a Kafka/Redis tail) that push batches over time. The host
+    /// keeps only the most recent rows (older ones are dropped past a cap) so an
+    /// unbounded stream stays bounded, and refreshes any bound `data-view`.
+    /// No-op unless the handle is known and owned by the calling instance.
+    append: func(handle: string, rows: list<list<string>>);
+
     /// Drop a published dataset early (otherwise it's dropped when the tab closes).
     release: func(handle: string);
 }


### PR DESCRIPTION
## What

Adds an incremental **`append`** to the `dataset-bus`, alongside the existing `publish`/`update`, so a producer can stream rows onto an existing handle over time (a Kafka/Redis tail, a long-running query) without re-publishing the whole dataset.

Part of epic #118 (plugin data ecosystem); the minimal, additive slice of #117 — the reusable streaming primitive, not a full backpressure framework.

## Changes

- **wit** — `dataset-bus.append(handle, rows)`; reuses the handle's existing columns (append doesn't restate the schema).
- **registry** (`datasets.rs`) — `append(instance, id, rows)`: instance-scoped like `update`, pushes rows, and ring-buffers to `MAX_STREAM_ROWS` (50k — drops the oldest) so an unbounded stream stays bounded, keeping the byte total + budget current.
- **host bus impl** (`wasm_data_source.rs`) — `append` requests an egui repaint via the shared `EGUI_CTX` (the app is reactive), so a background stream refreshes any bound `DataView` live.
- Bindings regenerated for both plugins.

## How it'll be used

A streaming producer publishes once to get a handle, then calls `append(handle, batch)` per incoming batch. The host trims to the cap and repaints; the `DataView` (Table/JSON/Raw + Charts) shows rows arriving live.

## Not included (deliberately)

No streaming producer yet, so nothing calls `append` today — it's the capability, ready for a monitoring producer. Also left out the seshat "Load more → append" rewire.

## Validation

- clippy + fmt clean
- 231 lib tests pass (2 new: instance-scoped append, ring-buffer cap)
- both plugins rebuilt to wasm