### PR TITLE
feat(ui): squircle redesign — shell, SDK components, overlays, plugins, screens

### DIFF
--- a/plugins/card-view/src/lib.rs
+++ b/plugins/card-view/src/lib.rs
@@ -10,7 +10,9 @@ mod bindings;
 
 use serde::Deserialize;
 
-use thoth_plugin_sdk::components::{Card, Column, Split, Typography, TypographyVariant};
+use thoth_plugin_sdk::components::{
+    Card, Column, Row, Spacer, Split, Typography, TypographyVariant,
+};
 use thoth_plugin_sdk::render_node::RenderNode;
 use thoth_plugin_sdk::PluginMeta;
 
@@ -24,6 +26,17 @@ use bindings::exports::thoth::plugin::{
 const COLUMNS: usize = 2;
 /// Max cards rendered (matches the host DataView row cap); extra rows are noted.
 const MAX_CARDS: usize = 1000;
+
+/// Gap between grid cells — design `.cardgrid{gap:8px}`, the 8px panel gutter.
+const GRID_GAP: f32 = 8.0;
+/// Inset of the grid from the view edges — design `.cardgrid{padding:12px}`. The
+/// host draws a renderer's node flush (`.dvbody{padding:0}`), so the grid owns it.
+const GRID_PAD: f32 = 12.0;
+/// Space between a card's key/value lines — design `.kvl{line-height:1.75}`, i.e.
+/// ~21px lines for 12px mono text.
+const LINE_GAP: f32 = 6.0;
+/// Space after a key's colon — design `.kvl b` is followed by `": "`.
+const KEY_GAP: f32 = 4.0;
 
 #[derive(PluginMeta)]
 #[plugin(
@@ -55,21 +68,44 @@ fn muted(text: impl Into<String>) -> RenderNode {
     )
 }
 
+/// A mono run, optionally muted — the card body is monospaced throughout
+/// (design `.kvl{font-family:var(--mono);font-size:12px}`), with the key label
+/// carried a step brighter than its value.
+fn mono(text: impl Into<String>, muted: bool) -> RenderNode {
+    let run = Typography::builder()
+        .text(text.into())
+        .variant(TypographyVariant::Mono);
+    // Design `.kvl` sits at `--subtext0` with the value a further step down, so the
+    // brighter run is `fg-subtle` rather than full `fg`.
+    RenderNode::Text(if muted {
+        run.color("muted").build()
+    } else {
+        run.color("fg-subtle").build()
+    })
+}
+
 /// One row → a card: first column is the title, the rest are `name: value` lines.
 fn card_node(columns: &[String], row: &[String]) -> RenderNode {
     let title = row.first().cloned().unwrap_or_default();
+    // `.kvl b` (the key) reads brighter than the value it labels, so each line is
+    // a two-tone pair rather than one muted string.
     let lines: Vec<RenderNode> = columns
         .iter()
         .enumerate()
         .skip(1)
         .map(|(i, col)| {
-            muted(format!(
-                "{col}: {}",
-                row.get(i).cloned().unwrap_or_default()
-            ))
+            RenderNode::Row(
+                Row::builder()
+                    .gap(KEY_GAP)
+                    .children(vec![
+                        mono(format!("{col}:"), false),
+                        mono(row.get(i).cloned().unwrap_or_default(), true),
+                    ])
+                    .build(),
+            )
         })
         .collect();
-    let body = RenderNode::Column(Column::builder().gap(2.0).children(lines).build());
+    let body = RenderNode::Column(Column::builder().gap(LINE_GAP).children(lines).build());
     RenderNode::Card(Box::new(Card::builder().title(title).body(body).build()))
 }
 
@@ -85,7 +121,13 @@ impl RendererGuest for CardViewPlugin {
         })?;
 
         if recs.rows.is_empty() {
-            let empty = muted("No records to show.");
+            // Padded like the grid, so the hint isn't flush against the edge.
+            let empty = RenderNode::Row(
+                Row::builder()
+                    .padding(GRID_PAD)
+                    .children(vec![muted("No records to show.")])
+                    .build(),
+            );
             return serde_json::to_string(&empty).map_err(|e| PluginError {
                 code: 2,
                 message: e.to_string(),
@@ -100,29 +142,49 @@ impl RendererGuest for CardViewPlugin {
             .map(|row| card_node(&recs.columns, row))
             .collect();
 
-        // Lay the cards out COLUMNS-per-row via equal-width splits.
+        // Lay the cards out COLUMNS-per-row via equal-width splits. The splits are
+        // grid cells, not resizable regions, so they stay unframed (flush) — the
+        // cards themselves carry the panel fill, edge and corners. A short last
+        // chunk is padded with empty cells so its card keeps the grid's column
+        // width instead of stretching across the row.
         let mut grid: Vec<RenderNode> = cards
             .chunks(COLUMNS)
             .map(|chunk| {
-                if chunk.len() == 1 {
-                    chunk[0].clone()
-                } else {
-                    RenderNode::Split(
-                        Split::builder()
-                            .gap(8.0)
-                            .widths(vec![1.0; chunk.len()])
-                            .children(chunk.to_vec())
-                            .build(),
-                    )
+                let mut cells = chunk.to_vec();
+                while cells.len() < COLUMNS {
+                    cells.push(RenderNode::Spacer(Spacer::builder().size(0.0).build()));
                 }
+                RenderNode::Split(
+                    Split::builder()
+                        .gap(GRID_GAP)
+                        .widths(vec![1.0; cells.len()])
+                        .children(cells)
+                        .build(),
+                )
             })
             .collect();
 
         if total > shown {
-            grid.push(muted(format!("… {} more row(s) not shown.", total - shown)));
+            // Design: the overflow note is an italic caption under the grid.
+            grid.push(RenderNode::Text(
+                Typography::builder()
+                    .text(format!("… {} more row(s) not shown.", total - shown))
+                    .variant(TypographyVariant::Caption)
+                    .italic(true)
+                    .build(),
+            ));
         }
 
-        let root = RenderNode::Column(Column::builder().gap(8.0).children(grid).build());
+        // The grid supplies its own inset from the DataView body, which is flush.
+        let root = RenderNode::Row(
+            Row::builder()
+                .padding(GRID_PAD)
+                .max_width(true)
+                .children(vec![RenderNode::Column(
+                    Column::builder().gap(GRID_GAP).children(grid).build(),
+                )])
+                .build(),
+        );
         serde_json::to_string(&root).map_err(|e| PluginError {
             code: 2,
             message: e.to_string(),
@@ -160,7 +222,9 @@ mod tests {
         .to_string();
         let out = CardViewPlugin::render(recs).unwrap();
         assert!(out.contains("Alice"));
-        assert!(out.contains("dept: Eng"));
+        // Key and value are separate mono runs (two-tone `key: value` line).
+        assert!(out.contains("dept:"));
+        assert!(out.contains("Eng"));
         assert!(out.contains("Bob"));
     }
 

--- a/plugins/seshat/src/ui/dialog.rs
+++ b/plugins/seshat/src/ui/dialog.rs
@@ -2,14 +2,20 @@
 //! enter credentials (matching the design handoff's `NewConnectionDialog`).
 
 use thoth_plugin_sdk::components::{
-    Align, Checkbox, Colored, Column, Input, List, ListItem, ListItemPrefix, Modal, Row, Select,
-    SelectOption, Separator, Size, Spacer, Split, Typography, TypographyVariant,
+    Align, Checkbox, Column, Icon, Input, List, ListItem, ListItemPrefix, Modal, Row, Select,
+    SelectOption, Separator, Spacer, Split, Typography, TypographyVariant,
 };
 use thoth_plugin_sdk::render_node::RenderNode;
 
 use crate::state::{engine_label, State, ENGINE_GROUPS};
 use crate::ui::widgets::{button, text_input};
 use crate::ICON_PLUG;
+
+/// Glyphs used only by the dialog: the Back affordance and the test-connection
+/// verdict (design's `.m-foot` caret and the `.m-body` status line).
+const ICON_CARET_LEFT: &str = "\u{E138}";
+const ICON_CHECK_CIRCLE: &str = "\u{E184}";
+const ICON_X_CIRCLE: &str = "\u{E4F8}";
 
 /// The new/edit-connection modal. Shared by the manager view and the sidebar.
 ///
@@ -107,14 +113,25 @@ fn form_step(st: &State, prefix: &str, connect_label: &str) -> RenderNode {
             true,
             "my-database",
         ),
-        // Host (2 parts) + Port (1 part).
+        // Host (2 parts) + Port (1 part) — design `.split2{grid:2fr 1fr;gap:10px}`.
         RenderNode::Split(
             Split::builder()
-                .gap(12.0)
+                .gap(10.0)
                 .widths(vec![2.0, 1.0])
                 .children(vec![
                     text_input(&id("f-host"), "Host", &st.form.host, true, "localhost"),
-                    text_input(&id("f-port"), "Port", &st.form.port, true, "5432"),
+                    // The port is numeric, so the design sets it in mono
+                    // (`.field.mono`).
+                    RenderNode::Input(
+                        Input::builder()
+                            .id(id("f-port"))
+                            .label("Port")
+                            .value(st.form.port.clone())
+                            .placeholder("5432")
+                            .mono(true)
+                            .grow(true)
+                            .build(),
+                    ),
                 ])
                 .build(),
         ),
@@ -139,7 +156,9 @@ fn form_step(st: &State, prefix: &str, connect_label: &str) -> RenderNode {
             .checked(st.form.tls)
             .build(),
     ));
-    fields.push(
+    // The design's last body row: the environment-colour selector and the last
+    // test verdict side by side (`display:flex;gap:9px`).
+    let mut colour_row: Vec<RenderNode> = vec![
         // Environment colour: a semantic token shown as the connection's accent
         // + status-dot tint, so prod vs local reads at a glance.
         RenderNode::Select(
@@ -170,23 +189,38 @@ fn form_step(st: &State, prefix: &str, connect_label: &str) -> RenderNode {
                         .label("Purple")
                         .build(),
                 ])
-                .size(Size::Small)
+                // Design `.selbox{min-width:150px}`; left at the default size so
+                // the trigger is the same 28px box as the fields above it.
+                .width(150.0)
                 .build(),
         ),
-    );
+    ];
 
     if let Some(status) = &st.test_status {
-        let (color, text) = match status {
-            Ok(msg) => ("success", msg.clone()),
-            Err(msg) => ("error", msg.clone()),
+        let (color, glyph, text) = match status {
+            Ok(msg) => ("success", ICON_CHECK_CIRCLE, msg.clone()),
+            Err(msg) => ("error", ICON_X_CIRCLE, msg.clone()),
         };
-        fields.push(RenderNode::Colored(
-            Colored::builder()
-                .color(color)
-                .child(RenderNode::Text(Typography::builder().text(text).build()))
+        // A glyph + caption in the verdict's colour, e.g. "✓ Connected in 42 ms".
+        colour_row.push(RenderNode::Row(
+            Row::builder()
+                .gap(6.0)
+                .children(vec![
+                    RenderNode::Icon(Icon::builder().glyph(glyph).color(color).build()),
+                    RenderNode::Text(
+                        Typography::builder()
+                            .text(text)
+                            .variant(TypographyVariant::Caption)
+                            .color(color)
+                            .build(),
+                    ),
+                ])
                 .build(),
         ));
     }
+    fields.push(RenderNode::Row(
+        Row::builder().gap(9.0).children(colour_row).build(),
+    ));
 
     fields.push(footer(prefix, true, connect_label));
 
@@ -204,10 +238,12 @@ fn auth_fields(st: &State, prefix: &str) -> Vec<RenderNode> {
     let id = |name: &str| format!("{prefix}{name}");
 
     // User + Password split, reused by SQL engines and ES password mode.
+    // Design `.split1{grid:1fr 1fr;gap:10px}`, with the masked value in mono
+    // (`.field.mono`).
     let user_password = || {
         RenderNode::Split(
             Split::builder()
-                .gap(12.0)
+                .gap(10.0)
                 .widths(vec![1.0, 1.0])
                 .children(vec![
                     text_input(&id("f-user"), "User", &st.form.user, true, ""),
@@ -217,6 +253,7 @@ fn auth_fields(st: &State, prefix: &str) -> Vec<RenderNode> {
                             .label("Password")
                             .value(st.form.password.clone())
                             .password(true)
+                            .mono(true)
                             .grow(true)
                             .build(),
                     ),
@@ -255,7 +292,6 @@ fn auth_fields(st: &State, prefix: &str) -> Vec<RenderNode> {
                     .label("API key")
                     .build(),
             ])
-            .size(Size::Small)
             .build(),
     );
 
@@ -269,6 +305,7 @@ fn auth_fields(st: &State, prefix: &str) -> Vec<RenderNode> {
                 .label("API key (encoded)")
                 .value(st.form.password.clone())
                 .password(true)
+                .mono(true)
                 .grow(true)
                 .build(),
         )),
@@ -287,7 +324,8 @@ fn footer(prefix: &str, form_step: bool, connect_label: &str) -> RenderNode {
             "Back",
             "Text",
             "Default",
-            None,
+            // Design `.m-foot` leads the Back action with a caret.
+            Some(ICON_CARET_LEFT),
             true,
             false,
         ));

--- a/plugins/seshat/src/ui/editor.rs
+++ b/plugins/seshat/src/ui/editor.rs
@@ -1,8 +1,8 @@
 //! The SQL editor tab: header, code editor, Run, and the typed results grid.
 
 use thoth_plugin_sdk::components::{
-    Button, ButtonColor, ButtonSize, ButtonType, CodeEditor, Column, CustomSyntax, IconButton, Row,
-    Scroll, Select, SelectOption, Separator, Size, VSplit,
+    Button, ButtonColor, ButtonType, CodeEditor, Column, CustomSyntax, IconButton, Row, Scroll,
+    Select, SelectOption, Spacer, VSplit,
 };
 use thoth_plugin_sdk::render_node::RenderNode;
 
@@ -68,7 +68,6 @@ pub(crate) fn editor_view(st: &State) -> RenderNode {
                                             })
                                             .collect::<Vec<_>>(),
                                     )
-                                    .size(Size::Small)
                                     .width(180.0)
                                     .searchable(true)
                                     .build(),
@@ -90,30 +89,28 @@ pub(crate) fn editor_view(st: &State) -> RenderNode {
                                             })
                                             .collect::<Vec<_>>(),
                                     )
-                                    .size(Size::Small)
                                     .width(180.0)
                                     .searchable(true)
                                     .build(),
                             ),
-                            RenderNode::Separator(Separator::plain()),
+                            // Design `.etoolbar .tbdiv`: the target group is set
+                            // off from the actions by a 20px void, not a rule.
+                            RenderNode::Spacer(Spacer::builder().size(20.0).build()),
                             RenderNode::Button(
                                 Button::builder()
                                     .id("run")
                                     .label("Run")
                                     .button_type(ButtonType::Elevated)
                                     .color(ButtonColor::Primary)
-                                    .button_size(ButtonSize::Small)
                                     .icon(ICON_PLAY)
                                     .enabled(!st.loading)
                                     .build(),
                             ),
-                            RenderNode::Separator(Separator::plain()),
                             RenderNode::IconButton(
                                 IconButton::builder()
                                     .id("save-query")
                                     .icon(ICON_FLOPPY_DISK)
                                     .frame(true)
-                                    .size(Size::Small)
                                     .tooltip("Save query as .sql")
                                     .build(),
                             ),
@@ -122,7 +119,6 @@ pub(crate) fn editor_view(st: &State) -> RenderNode {
                                     .id("open-query")
                                     .icon(ICON_FOLDER_OPEN)
                                     .frame(true)
-                                    .size(Size::Small)
                                     .tooltip("Open a .sql file")
                                     .build(),
                             ),
@@ -131,7 +127,6 @@ pub(crate) fn editor_view(st: &State) -> RenderNode {
                                     .id("format-editor")
                                     .icon(ICON_FORMAT)
                                     .frame(true)
-                                    .size(Size::Small)
                                     .tooltip(format!(
                                         "Format the SQL query ({})",
                                         format_button_tooltip_shortcut
@@ -141,7 +136,9 @@ pub(crate) fn editor_view(st: &State) -> RenderNode {
                         ])
                         .build(),
                 ),
-                RenderNode::Separator(Separator::plain()),
+                // No rule under the toolbar: the design keeps the editor panel one
+                // unbroken card, and the split below already insets its two panes
+                // on the crust gutter.
                 // Editor over results, with a draggable divider to re-apportion
                 // their heights. Each pane scrolls on its own: the code editor has
                 // its own vertical scroll, and the results grid is wrapped in a
@@ -154,7 +151,8 @@ pub(crate) fn editor_view(st: &State) -> RenderNode {
                             CodeEditor::builder()
                                 .id("sql")
                                 .value(st.sql.clone())
-                                .font_size(12.0)
+                                // Body size (the component's own default) — the
+                                // design sets the editor at 13px/21px.
                                 .custom_syntax(
                                     CustomSyntax::builder()
                                         .language("sql")

--- a/plugins/seshat/src/ui/schema.rs
+++ b/plugins/seshat/src/ui/schema.rs
@@ -2,8 +2,8 @@
 //! shared `data-row` component so it matches the file-viewer tree styling.
 
 use thoth_plugin_sdk::components::{
-    Colored, Column, DataRow, DataRowIcon, Input, Row, Scroll, Separator, Size, Spinner,
-    Typography, TypographyVariant,
+    Colored, Column, DataRow, DataRowIcon, Input, Row, Scroll, Separator, Spinner, Typography,
+    TypographyVariant,
 };
 use thoth_plugin_sdk::render_node::RenderNode;
 use thoth_plugin_sdk::tokens::TextToken;
@@ -26,6 +26,12 @@ fn loading_row() -> RenderNode {
 use crate::{
     ICON_CIRCLE, ICON_DATABASE, ICON_EYE, ICON_FOLDER, ICON_KEY, ICON_TABLE, ICON_TREE_STRUCTURE,
 };
+
+/// The filter field's leading glyph — design `.field > i.ph-magnifying-glass`.
+const ICON_MAGNIFYING_GLASS: &str = "\u{E30C}";
+/// A non-primary-key column's marker dot — design `.dr .lead{font-size:8px}`,
+/// well under the 13px row glyphs.
+const MARKER_GLYPH: f32 = 8.0;
 
 pub(crate) fn schema_panel(st: &State) -> RenderNode {
     let active = st
@@ -53,16 +59,18 @@ pub(crate) fn schema_panel(st: &State) -> RenderNode {
         Column::builder()
             .gap(0.0)
             .children(vec![
+                // Search strip — design `padding:8px 10px` around a full-width
+                // `.field` with a leading magnifier.
                 RenderNode::Row(
                     Row::builder()
-                        .padding(6.0)
+                        .padding(8.0)
                         .children(vec![RenderNode::Input(
                             Input::builder()
                                 .id("schema-filter")
                                 .value(st.schema_filter.clone())
                                 .placeholder("Filter tables…")
+                                .icon(ICON_MAGNIFYING_GLASS)
                                 .grow(true)
-                                .size(Size::Small)
                                 .build(),
                         )])
                         .build(),
@@ -117,7 +125,8 @@ fn filter_results(st: &State) -> RenderNode {
         Some(_) => nodes.push(muted("No tables match.")),
         None => nodes.push(loading_row()),
     }
-    RenderNode::Column(Column::builder().gap(2.0).children(nodes).build())
+    // Contiguous rows: the design stacks 22px `.dr`s with no gap between them.
+    RenderNode::Column(Column::builder().gap(0.0).children(nodes).build())
 }
 
 /// The lazy schema tree (database → schema → table/view → columns).
@@ -154,9 +163,9 @@ fn schema_tree(st: &State) -> RenderNode {
                 .as_ref()
                 .and_then(|s| s.first())
                 .and_then(|sc| sc.tables.as_ref())
-                .map(|t| t.len().to_string())
+                .map(|t| count_label(t.len(), "table"))
         } else {
-            db.schemas.as_ref().map(|s| s.len().to_string())
+            db.schemas.as_ref().map(|s| count_label(s.len(), "schema"))
         };
         nodes.push(data_row(
             &format!("db:{i}"),
@@ -181,7 +190,18 @@ fn schema_tree(st: &State) -> RenderNode {
         nodes.push(show_more_row(st.databases.len() - limit, 0));
     }
 
-    RenderNode::Column(Column::builder().gap(2.0).children(nodes).build())
+    // Contiguous rows: the design stacks 22px `.dr`s with no gap between them.
+    RenderNode::Column(Column::builder().gap(0.0).children(nodes).build())
+}
+
+/// A trailing child count with its unit — design `.dr .cnt` reads "2 schemas" /
+/// "14 tables" rather than a bare number.
+fn count_label(n: usize, unit: &str) -> String {
+    if n == 1 {
+        format!("{n} {unit}")
+    } else {
+        format!("{n} {unit}s")
+    }
 }
 
 /// A clickable "Show more" row that reveals the next page of a capped level.
@@ -193,6 +213,43 @@ fn show_more_row(hidden: usize, indent: usize) -> RenderNode {
         None,
         Some((ICON_CIRCLE, "muted")),
         None,
+    )
+}
+
+/// A column row: the design's `.dr` with a leading marker, the column name, and
+/// the column type as a `.tybadge` chip *beside* the name — not as the row's
+/// right-pinned `.cnt`, which is reserved for child counts.
+///
+/// The primary-key marker is a 13px key glyph; every other column takes the
+/// design's 8px dot (`.lead{font-size:8px}`), a marker rather than an icon.
+fn column_row(
+    id: &str,
+    name: &str,
+    indent: usize,
+    primary_key: bool,
+    data_type: &str,
+) -> RenderNode {
+    let (glyph, color, size) = if primary_key {
+        (ICON_KEY, "warning", None)
+    } else {
+        (ICON_CIRCLE, "muted", Some(MARKER_GLYPH))
+    };
+    RenderNode::DataRow(
+        DataRow::builder()
+            .row_id(id)
+            .display_text(name.to_string())
+            .key_token(TextToken::Key)
+            .indent(indent)
+            .leading_icon(
+                DataRowIcon::builder()
+                    .glyph(glyph)
+                    .color(color)
+                    .maybe_size(size)
+                    .build(),
+            )
+            .chip(data_type.to_string())
+            .truncate(true)
+            .build(),
     )
 }
 
@@ -230,7 +287,7 @@ fn push_schemas(nodes: &mut Vec<RenderNode>, i: usize, db: &DatabaseNode, limit:
         return;
     }
     for (j, sch) in schemas.iter().enumerate() {
-        let count = sch.tables.as_ref().map(|t| t.len().to_string());
+        let count = sch.tables.as_ref().map(|t| count_label(t.len(), "table"));
         nodes.push(data_row(
             &format!("sch:{i}:{j}"),
             &sch.name,
@@ -280,18 +337,12 @@ fn push_tables(
                 Some(cols) if cols.is_empty() => nodes.push(muted("(no columns)")),
                 Some(cols) => {
                     for (l, c) in cols.iter().enumerate() {
-                        let marker = if c.primary_key {
-                            (ICON_KEY, "warning")
-                        } else {
-                            (ICON_CIRCLE, "muted")
-                        };
-                        nodes.push(data_row(
+                        nodes.push(column_row(
                             &format!("col:{i}:{j}:{k}:{l}"),
                             &c.name,
                             indent + 1,
-                            None,
-                            Some(marker),
-                            Some(&c.data_type),
+                            c.primary_key,
+                            &c.data_type,
                         ));
                     }
                 }

--- a/plugins/seshat/src/ui/widgets.rs
+++ b/plugins/seshat/src/ui/widgets.rs
@@ -38,6 +38,8 @@ pub(crate) fn button(
 ) -> RenderNode {
     let button_type = match btype {
         "Text" => ButtonType::Text,
+        // `.btn.dsoft` — a tinted wash rather than a solid fill.
+        "Soft" => ButtonType::Soft,
         _ => ButtonType::Elevated,
     };
     let color = match color {
@@ -45,6 +47,9 @@ pub(crate) fn button(
         "Secondary" => ButtonColor::Secondary,
         "Danger" => ButtonColor::Danger,
         "Success" => ButtonColor::Success,
+        // Cautionary but reversible — without this arm it fell through to the
+        // neutral surface, silently dropping the hue the caller asked for.
+        "Warning" => ButtonColor::Warning,
         _ => ButtonColor::Default,
     };
     RenderNode::Button(

--- a/plugins/url-source/src/helper.rs
+++ b/plugins/url-source/src/helper.rs
@@ -85,15 +85,6 @@ pub fn status_text(code: u16) -> &'static str {
     }
 }
 
-pub fn status_color(code: u16) -> &'static str {
-    match code {
-        200..=299 => "#10b981",
-        300..=399 => "#f59e0b",
-        400..=499 => "#f97316",
-        _ => "#ef4444",
-    }
-}
-
 pub fn normalise_array(v: Value) -> Value {
     match v {
         Value::Array(_) => v,

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -57,6 +57,8 @@ fn method_badge_token(method: &str) -> &'static str {
 /// on `--green`, with the other classes stepping through the semantic ramp.
 fn status_token(code: u16) -> &'static str {
     match code {
+        // 1xx is informational, not a failure — it reads as a neutral note.
+        100..=199 => "info",
         200..=299 => "success",
         300..=399 => "info",
         400..=499 => "warning",

--- a/plugins/url-source/src/ui.rs
+++ b/plugins/url-source/src/ui.rs
@@ -7,18 +7,16 @@ use crate::{
             websocket,
         },
     },
-    helper::{
-        is_body_method, parse_kv_list, parse_str, parse_url_into_state, status_color, status_text,
-    },
+    helper::{is_body_method, parse_kv_list, parse_str, parse_url_into_state, status_text},
     http::build_request,
     KvPair, ResponseState, State, WsDir, WsLogEntry,
 };
 use serde_json::Value;
 use thoth_plugin_sdk::components::{
-    Align, Badge, BgColor, Button, ButtonColor, ButtonType, Code, CodeEditor, Column, DataRow,
-    DataRowIcon, IconButton, Input, JsonTree, KeyValueList, KvEntry, List, ListItem,
+    Align, Badge, BgColor, Button, ButtonColor, ButtonSize, ButtonType, Code, CodeEditor, Column,
+    DataRow, DataRowIcon, IconButton, Input, JsonTree, KeyValueList, KvEntry, List, ListItem,
     ListItemAction, ListItemBadge, Modal, Radio, Row, Scroll, Select, SelectOption, Separator,
-    Spacer, Spinner, Split, TabAction, TableView, Tabs, Typography, TypographyVariant,
+    Size, Spacer, Spinner, Split, TabAction, TableView, Tabs, Typography, TypographyVariant,
 };
 use thoth_plugin_sdk::render_node::RenderNode;
 
@@ -27,18 +25,42 @@ const ICON_PLUS: &str = "\u{E3D4}"; // PLUS
 const ICON_CODE: &str = "\u{E1BC}"; // CODE (export cURL)
 const ICON_DOWNLOAD: &str = "\u{E20C}"; // DOWNLOAD_SIMPLE (import cURL)
 const ICON_CHART_LINE: &str = "\u{E154}"; // CHART_LINE (open in Charts)
+const ICON_LIGHTNING: &str = "\u{E2DE}"; // LIGHTNING (send request)
+
+// ── Layout constants ───────────────────────────────────────────────────────
+
+/// Gap between floating panes and toolbar controls — the design's 8px panel
+/// gutter (`GUTTER_GAP`), which is also `.urlbar{gap:8px}`.
+const GUTTER_GAP: f32 = 8.0;
+/// Toolbar / status-strip inner padding — design `.urlbar{padding:10px}` and
+/// `.respstat{padding:9px 12px}`.
+const STRIP_PAD: f32 = 10.0;
 
 // ── Small helpers ──────────────────────────────────────────────────────────
 
-/// `#rrggbb` badge colour for an HTTP method.
-fn method_badge_hex(method: &str) -> &'static str {
+/// Theme-token badge colour for an HTTP method. The design tints the method
+/// chip per verb (GET blue, POST green, PUT/PATCH peach, DELETE red,
+/// HEAD/OPTIONS mauve); those hues map onto palette tokens so both themes
+/// resolve them, never a baked hex.
+fn method_badge_token(method: &str) -> &'static str {
     match method {
-        "GET" => "#89b4fa",
-        "POST" => "#a6e3a1",
-        "PUT" | "PATCH" => "#fab387",
-        "DELETE" => "#f38ba8",
-        "HEAD" | "OPTIONS" => "#cba6f7",
-        _ => "#9399b2",
+        "GET" => "info",
+        "POST" => "success",
+        "PUT" | "PATCH" => "warning",
+        "DELETE" => "error",
+        "HEAD" | "OPTIONS" => "accent",
+        _ => "muted",
+    }
+}
+
+/// Theme token for the response status chip — the design's soft `200 OK` pill
+/// on `--green`, with the other classes stepping through the semantic ramp.
+fn status_token(code: u16) -> &'static str {
+    match code {
+        200..=299 => "success",
+        300..=399 => "info",
+        400..=499 => "warning",
+        _ => "error",
     }
 }
 
@@ -86,22 +108,31 @@ fn btn(id: &str, label: &str, enabled: bool, color: ButtonColor) -> RenderNode {
 // ── Main request/response view ──────────────────────────────────────────────
 
 pub fn build_ui(st: &State) -> RenderNode {
+    // Request | response are two floating panes on a crust gutter (design
+    // `.splith{background:bg-sunken;padding:8px}` + `.pane`). `framed` supplies
+    // the whole posture — the sunken canvas, the gutter inset and the pane cards —
+    // so no wrapper row is needed. The old 1px region borders (the separator under
+    // the url bar and the split's own divider) go away with them: a floating pane
+    // carries its own hairline edge and must not double up.
+    // `resizable` supersedes `gap` for the one divider: the grabber (design
+    // `.hhandle`, 11px) *is* the gutter between the two cards, so the request and
+    // response panes drag against each other like seshat's editor↔results do.
+    // `gap` stays declared as the fallback for a non-resizable rendering.
+    let panes = RenderNode::Split(
+        Split::builder()
+            .gap(GUTTER_GAP)
+            .framed(true)
+            .fill_height(true)
+            .resizable(true)
+            .id("url-source-panes")
+            .children(vec![build_request_column(st), build_response_column(st)])
+            .build(),
+    );
+
     RenderNode::Column(
         Column::builder()
             .gap(0.0)
-            .children(vec![
-                build_url_bar(st),
-                RenderNode::Separator(Separator::plain()),
-                RenderNode::Split(
-                    Split::builder()
-                        .gap(0.0)
-                        .separator(true)
-                        .fill_height(true)
-                        .children(vec![build_request_column(st), build_response_column(st)])
-                        .build(),
-                ),
-                curl_export_modal(st),
-            ])
+            .children(vec![build_url_bar(st), panes, curl_export_modal(st)])
             .build(),
     )
 }
@@ -118,7 +149,7 @@ pub fn build_sidebar(st: &State) -> RenderNode {
                 .badge(
                     ListItemBadge::builder()
                         .text(req.method.clone())
-                        .color(method_badge_hex(&req.method))
+                        .color(method_badge_token(&req.method))
                         .build(),
                 )
                 .actions(vec![ListItemAction::builder()
@@ -292,12 +323,14 @@ fn build_response_column(st: &State) -> RenderNode {
         } else {
             "Sending request…"
         };
+        // Reads as the pane's status strip while in flight — same `bg-panel`
+        // band as `.respstat`, which it is replaced by on arrival.
         return RenderNode::Row(
             Row::builder()
                 .bg_color(BgColor::BgPanel)
                 .max_width(true)
-                .padding(10.0)
-                .gap(8.0)
+                .padding(STRIP_PAD)
+                .gap(GUTTER_GAP)
                 .children(vec![
                     RenderNode::Spinner(Spinner::builder().size(14.0).build()),
                     muted(label),
@@ -314,13 +347,13 @@ fn build_response_column(st: &State) -> RenderNode {
                 .build(),
         )
     } else {
+        // An empty pane: a quiet hint padded onto the pane's own fill, not a
+        // filled band — the floating pane already reads as a region.
         RenderNode::Row(
             Row::builder()
-                .bg_color(BgColor::BgPanel)
                 .max_width(true)
-                .height(20.0)
-                .padding(10.0)
-                .children(vec![text("Send a request to see the response here.")])
+                .padding(STRIP_PAD)
+                .children(vec![muted("Send a request to see the response here.")])
                 .build(),
         )
     }
@@ -351,18 +384,22 @@ fn build_ws_panel(st: &State) -> RenderNode {
         Column::builder()
             .gap(0.0)
             .children(vec![
+                // Connection status reads as this pane's `.respstat` band.
                 RenderNode::Row(
                     Row::builder()
                         .bg_color(BgColor::BgPanel)
                         .max_width(true)
-                        .padding(8.0)
+                        .padding(STRIP_PAD)
                         .children(vec![muted(status)])
                         .build(),
                 ),
+                // Send box: a `.urlbar`-shaped control strip (field grows, button
+                // trails), so the row's own padding — not a trailing spacer —
+                // insets it from the pane edge.
                 RenderNode::Row(
                     Row::builder()
-                        .gap(4.0)
-                        .padding(4.0)
+                        .gap(GUTTER_GAP)
+                        .padding(STRIP_PAD)
                         .max_width(true)
                         .align(Align::Fill)
                         .children(vec![
@@ -381,7 +418,6 @@ fn build_ws_panel(st: &State) -> RenderNode {
                                 st.ws_connected && !st.ws_send_text.is_empty(),
                                 ButtonColor::Primary,
                             ),
-                            RenderNode::Spacer(Spacer::builder().size(8.0).build()),
                         ])
                         .build(),
                 ),
@@ -408,8 +444,8 @@ const ICON_DOT: &str = "\u{E18A}"; // CIRCLE — system
 /// sent (↑, blue), received (↓, green), system (•, muted).
 fn ws_log_row(idx: usize, entry: &WsLogEntry) -> RenderNode {
     let (glyph, color) = match entry.dir {
-        WsDir::Sent => (ICON_ARROW_UP, Some("#89b4fa".to_string())),
-        WsDir::Recv => (ICON_ARROW_DOWN, Some("#a6e3a1".to_string())),
+        WsDir::Sent => (ICON_ARROW_UP, Some("info".to_string())),
+        WsDir::Recv => (ICON_ARROW_DOWN, Some("success".to_string())),
         WsDir::System => (ICON_DOT, None),
     };
     RenderNode::DataRow(
@@ -432,10 +468,12 @@ fn build_url_bar(st: &State) -> RenderNode {
         .map(|m| SelectOption::builder().value(*m).label(*m).build())
         .collect();
 
+    // Design `.urlbar{gap:8px;padding:10px}`: method select (min-width 96) ·
+    // URL field (flex 1) · Clear · Send.
     RenderNode::Row(
         Row::builder()
-            .gap(4.0)
-            .padding(4.0)
+            .gap(GUTTER_GAP)
+            .padding(STRIP_PAD)
             .max_width(true)
             .align(Align::Fill)
             .children(vec![
@@ -505,7 +543,17 @@ fn ws_or_send_button(st: &State) -> RenderNode {
             )
         }
     } else {
-        btn("send", "⚡ Send", !st.url.is_empty(), ButtonColor::Primary)
+        // Design `.btn.primary` with a leading `ph-lightning` — a real Phosphor
+        // glyph plus the button's 6px icon gap, not an emoji baked into the label.
+        RenderNode::Button(
+            Button::builder()
+                .id("send")
+                .label("Send")
+                .icon(ICON_LIGHTNING)
+                .color(ButtonColor::Primary)
+                .enabled(!st.url.is_empty())
+                .build(),
+        )
     }
 }
 
@@ -655,16 +703,24 @@ fn response_is_chartable(resp: &ResponseState) -> bool {
 
 fn build_response_panel(resp: &ResponseState) -> RenderNode {
     let (color, status_label) = if resp.error.is_some() {
-        ("#ef4444".to_string(), "Error".to_string())
+        ("error".to_string(), "Error".to_string())
     } else {
         (
-            status_color(resp.status).to_string(),
+            status_token(resp.status).to_string(),
             format!("{} {}", resp.status, status_text(resp.status)),
         )
     };
 
+    // Design `.respstat .badge`: a *soft* chip — a faint tint of the status hue
+    // behind coloured mono text — at `.badge{font-size:10px;padding:2px 7px}`
+    // (the medium pill), not a solid fill.
     let mut status_children: Vec<RenderNode> = vec![RenderNode::Badge(
-        Badge::builder().label(status_label).color(color).build(),
+        Badge::builder()
+            .label(status_label)
+            .color(color)
+            .soft(true)
+            .size(Size::Medium)
+            .build(),
     )];
     if let Some(ms) = resp.duration_ms {
         let t = if ms < 1000 {
@@ -688,24 +744,29 @@ fn build_response_panel(resp: &ResponseState) -> RenderNode {
     // id is a host-interpreted action (see `actions::OPEN_IN_CHARTS`): clicking
     // opens the studio bound to this tab, which is a producer via `provide-dataset`.
     if resp.error.is_none() && response_is_chartable(resp) {
-        status_children.push(RenderNode::Spacer(Spacer::builder().size(8.0).build()));
+        // The design's `.respstat` ends with a `flex:1` spacer and a lavender
+        // `.btn.text.sm`, so the shortcut sits hard right of the status metrics.
+        status_children.push(RenderNode::Spacer(Spacer::builder().size(0.0).build()));
         status_children.push(RenderNode::Button(
             Button::builder()
                 .id(thoth_plugin_sdk::actions::OPEN_IN_CHARTS)
                 .label("Charts")
                 .icon(ICON_CHART_LINE)
                 .button_type(ButtonType::Text)
-                .color(ButtonColor::Secondary)
+                .color(ButtonColor::Primary)
+                .button_size(ButtonSize::Small)
                 .build(),
         ));
     }
+    // Design `.respstat{padding:9px 12px;gap:12px;background:bg-panel}` — a
+    // status strip across the top of the response pane.
     let status_row = RenderNode::Row(
         Row::builder()
             .bg_color(BgColor::BgPanel)
             .max_width(true)
-            .height(20.0)
-            .padding(10.0)
-            .gap(8.0)
+            .padding(STRIP_PAD)
+            .gap(12.0)
+            .align(Align::Fill)
             .children(status_children)
             .build(),
     );
@@ -716,11 +777,12 @@ fn build_response_panel(resp: &ResponseState) -> RenderNode {
                 .gap(0.0)
                 .children(vec![
                     status_row,
+                    // The pane owns the fill now, so the error body is just
+                    // padded text on it (design `.pane-pad{padding:10px 12px}`).
                     RenderNode::Row(
                         Row::builder()
-                            .bg_color(BgColor::Bg)
                             .max_width(true)
-                            .padding(10.0)
+                            .padding(STRIP_PAD)
                             .children(vec![text(err)])
                             .build(),
                     ),
@@ -729,8 +791,13 @@ fn build_response_panel(resp: &ResponseState) -> RenderNode {
         );
     }
 
+    // The tree and the header grid sit inside the floating response pane, which
+    // already owns the panel corners and hairline edge — so they draw flush
+    // (design `.tree.pane-scroll`), never a second container inside the first.
     let pretty = match &resp.parsed_body {
-        Some(val) => RenderNode::JsonTree(JsonTree::builder().value(val.clone()).build()),
+        Some(val) => {
+            RenderNode::JsonTree(JsonTree::builder().value(val.clone()).framed(false).build())
+        }
         None => RenderNode::Code(
             Code::builder()
                 .value(resp.body.clone())
@@ -765,6 +832,7 @@ fn build_response_panel(resp: &ResponseState) -> RenderNode {
                     TableView::builder()
                         .headers(vec!["Header".to_string(), "Value".to_string()])
                         .rows(header_rows)
+                        .framed(false)
                         .build(),
                 ),
             ])

--- a/src/app/persistent_state.rs
+++ b/src/app/persistent_state.rs
@@ -109,7 +109,10 @@ impl PersistentState {
     /// The persisted state from disk, or a [`blank`](PersistentState::blank) one if
     /// it can't be read. This is what the running app wants at startup.
     pub fn load_or_default() -> Self {
-        Self::load().unwrap_or_else(|_| Self::blank())
+        Self::load().unwrap_or_else(|err| {
+            eprintln!("Failed to load persistent state: {}", err);
+            Self::blank()
+        })
     }
 
     /// Get the path to the app state storage
@@ -173,11 +176,7 @@ impl PersistentState {
                 eprintln!("Migrating from old recent_files.json format...");
                 let new_state = PersistentState {
                     recent_files: old_data.files,
-                    sidebar_width: DEFAULT_SIDEBAR_WIDTH,
-                    sidebar_expanded: false,
-                    bookmarks: Vec::new(),
-                    open_tabs: Vec::new(),
-                    active_tab_index: 0,
+                    ..Self::blank()
                 };
 
                 // Save in new format
@@ -192,14 +191,7 @@ impl PersistentState {
         }
 
         // No migration needed or failed, return default
-        Ok(Self {
-            recent_files: Vec::new(),
-            sidebar_width: DEFAULT_SIDEBAR_WIDTH,
-            sidebar_expanded: false,
-            bookmarks: Vec::new(),
-            open_tabs: Vec::new(),
-            active_tab_index: 0,
-        })
+        Ok(Self::blank())
     }
 
     /// Save app state to disk

--- a/src/app/persistent_state.rs
+++ b/src/app/persistent_state.rs
@@ -80,20 +80,38 @@ fn default_sidebar_width() -> f32 {
 }
 
 impl Default for PersistentState {
+    /// A blank state — **no disk access**.
+    ///
+    /// `Default` used to call [`load`](PersistentState::load), which made
+    /// constructing one implicitly read the user's real saved session. That is
+    /// surprising for a `Default`, and it leaked the developer's own open tabs and
+    /// recent files into tests. Call [`load_or_default`](PersistentState::load_or_default)
+    /// when you actually want the persisted state.
     fn default() -> Self {
-        // Try to load from disk, fallback to empty state on error
-        Self::load().unwrap_or(Self {
+        Self::blank()
+    }
+}
+
+impl PersistentState {
+    /// An empty in-memory state, touching no files. Use this in tests so they
+    /// don't inherit whatever session the developer happens to have open.
+    pub fn blank() -> Self {
+        Self {
             recent_files: Vec::new(),
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_expanded: false,
             bookmarks: Vec::new(),
             open_tabs: Vec::new(),
             active_tab_index: 0,
-        })
+        }
     }
-}
 
-impl PersistentState {
+    /// The persisted state from disk, or a [`blank`](PersistentState::blank) one if
+    /// it can't be read. This is what the running app wants at startup.
+    pub fn load_or_default() -> Self {
+        Self::load().unwrap_or_else(|_| Self::blank())
+    }
+
     /// Get the path to the app state storage
     /// Returns: ~/.config/thoth/persistent_state.json on Linux/macOS
     ///          %APPDATA%/thoth/persistent_state.json on Windows

--- a/src/app/tab_manager.rs
+++ b/src/app/tab_manager.rs
@@ -117,6 +117,12 @@ pub enum TabEvent {
     TabClosed(TabId),
     OpenFilePicker,
     OpenRecentFile(std::path::PathBuf),
+    /// The Welcome screen's "New window" action.
+    NewWindow,
+    /// The Welcome screen's "Browse plugins…" action.
+    BrowsePlugins,
+    /// The Welcome screen's Recent → "Clear" action.
+    ClearRecentFiles,
     /// A toolbar action from a chart tab (Edit / Refresh).
     ChartAction {
         tab_id: TabId,
@@ -176,9 +182,9 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
         // Chart Studio tabs paint a chart directly — no file/plugin central panel.
         if let Some(chart) = tab.chart.as_mut() {
             let colors = self.colors.unwrap_or_default();
-            // Fill the whole leaf with the app background (egui_dock doesn't
-            // clear it, and there's no central panel here to provide a fill).
-            ui.painter().rect_filled(ui.max_rect(), 0.0, colors.bg);
+            // No leaf fill here: the enclosing floating dock panel paints the
+            // background as a rounded rect, and a square fill would clip its
+            // rounded bottom corners.
             let action = egui::Frame::new()
                 .inner_margin(egui::Margin::symmetric(16, 8))
                 .show(ui, |ui| chart.render(ui, &colors))
@@ -276,6 +282,15 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
                 CentralPanelEvent::OpenRecentFile(path) => {
                     self.events.push(TabEvent::OpenRecentFile(path));
                 }
+                CentralPanelEvent::NewWindow => {
+                    self.events.push(TabEvent::NewWindow);
+                }
+                CentralPanelEvent::BrowsePlugins => {
+                    self.events.push(TabEvent::BrowsePlugins);
+                }
+                CentralPanelEvent::ClearRecentFiles => {
+                    self.events.push(TabEvent::ClearRecentFiles);
+                }
             }
         }
     }
@@ -310,19 +325,21 @@ impl egui_dock::TabViewer for ThothTabViewer<'_> {
             .tabs
             .get(tab_id)
             .is_some_and(|t| t.active_plugin_pane.is_some());
-        let accent = if is_plugin {
-            c.accent_secondary
-        } else {
-            c.accent
-        };
 
         let mut style = global_style.clone();
-        // Active/focused: colored top accent strip via outline_color.
-        style.active.outline_color = accent;
-        style.focused.outline_color = accent;
-        // Inactive: suppress the outline so only active tabs show the accent.
-        style.inactive.outline_color = eframe::egui::Color32::TRANSPARENT;
-        style.hovered.outline_color = accent.gamma_multiply(0.5);
+        // The shared `dock_style()` already paints the design's pill: `surface`
+        // fill with a hairline edge (`.tab.active{background:surface0;box-shadow:
+        // var(--edge)}`). Only the *label* is tinted here, to mark a plugin pane
+        // apart from a file tab.
+        //
+        // Do NOT set `outline_color` — this override runs per tab, after
+        // `dock_style()`, so an accent here becomes a ring around the pill. It
+        // used to draw one deliberately, back when tabs were square and the accent
+        // read as a top strip; against a pill it reads as an outline instead.
+        if is_plugin {
+            style.active.text_color = c.accent_secondary;
+            style.focused.text_color = c.accent_secondary;
+        }
         Some(style)
     }
 }

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -518,8 +518,9 @@ impl App for ThothApp {
             let dock_colors = ui
                 .ctx()
                 .memory(|m| {
-                    m.data
-                        .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
+                    m.data.get_temp::<crate::theme::ThemeColors>(egui::Id::new(
+                        thoth_plugin_sdk::theme::THEME_MEMORY_ID,
+                    ))
                 })
                 .unwrap_or_else(|| {
                     let dark_mode = ui.ctx().global_style().visuals.dark_mode;
@@ -1694,8 +1695,9 @@ impl ThothApp {
         let focused_id = self.window_state.tab_manager.active_tab_id();
 
         let colors = ui.ctx().memory(|m| {
-            m.data
-                .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
+            m.data.get_temp::<crate::theme::ThemeColors>(egui::Id::new(
+                thoth_plugin_sdk::theme::THEME_MEMORY_ID,
+            ))
         });
 
         let mut dock_style = colors

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -52,6 +52,11 @@ pub struct ThothApp {
     /// Pending chart PNG export: `(chart rect in points, screenshot requested?)`
     /// — drives the two-frame screenshot → crop → save flow.
     chart_export: Option<(egui::Rect, bool)>,
+    /// Crust colour for the window canvas, refreshed each frame from the *applied*
+    /// palette. `clear_color` runs outside the frame and so can't read egui memory
+    /// itself; caching it here is what lets an unsaved theme **preview** repaint
+    /// the canvas instead of waiting for the settings to be saved.
+    canvas_color: egui::Color32,
 }
 
 /// Build the synthetic `http-response` UiEvent delivered to a plugin when an
@@ -150,9 +155,22 @@ struct SidebarPluginRuntime {
 }
 
 impl ThothApp {
+    /// The real app: restores the session persisted on disk.
     pub fn new(settings: settings::Settings, file_to_open: Option<PathBuf>) -> Self {
-        let persistent_state = PersistentState::default();
+        Self::with_persistent_state(settings, file_to_open, PersistentState::load_or_default())
+    }
 
+    /// Construct with an explicit [`PersistentState`], bypassing the on-disk one.
+    ///
+    /// Tests pass [`PersistentState::blank`] so they start from no open tabs and no
+    /// recent files. Without this they restore whatever session the developer has
+    /// open, and any assertion about the active tab reads their real file instead
+    /// of the test's fixture.
+    pub fn with_persistent_state(
+        settings: settings::Settings,
+        file_to_open: Option<PathBuf>,
+        persistent_state: PersistentState,
+    ) -> Self {
         let mut window_state = state::WindowState::default();
         if settings.ui.remember_sidebar_state {
             window_state.sidebar_expanded = persistent_state.get_sidebar_expanded();
@@ -192,6 +210,7 @@ impl ThothApp {
             };
 
         Self {
+            canvas_color: settings.theme.colors().bg_sunken,
             settings,
             persistent_state,
             window_state,
@@ -296,6 +315,14 @@ impl ThothApp {
 }
 
 impl App for ThothApp {
+    fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
+        // Crust is the root canvas the floating panels sit on, with GUTTER_GAP
+        // showing through between them. Not `visuals.panel_fill` — that is the
+        // *content* background, and making it crust would tint every
+        // `Frame::central_panel` too.
+        self.canvas_color.to_normalized_gamma_f32()
+    }
+
     fn update(&mut self, ctx: &egui::Context, _frame: &mut Frame) {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
@@ -303,6 +330,17 @@ impl App for ThothApp {
         // Publish the context once so off-thread workers (WebSocket tasks) can
         // request a repaint when data arrives.
         let _ = crate::EGUI_CTX.set(ctx.clone());
+
+        // Track the *applied* crust for `clear_color`, so previewing a theme in
+        // settings repaints the canvas immediately. Only overwrite once a palette
+        // has actually been published — `from_ctx` falls back to a zeroed one.
+        if let Some(applied) = ctx.memory(|m| {
+            m.data.get_temp::<crate::theme::ThemeColors>(egui::Id::new(
+                thoth_plugin_sdk::theme::THEME_MEMORY_ID,
+            ))
+        }) {
+            self.canvas_color = applied.bg_sunken;
+        }
 
         if UpdateHandler::should_check_updates(&self.update_state, &self.settings) {
             UpdateHandler::check_for_updates(&mut self.update_state);
@@ -357,6 +395,11 @@ impl App for ThothApp {
         if self.settings.ui.show_status_bar {
             self.render_status_bar(ui);
         }
+
+        // Panel::show_inside shrinks the available_rect but not the painter's
+        // clip_rect, so the outer painter still covers the status-bar area.
+        // Restrict it now so panel shadows can't bleed into the transparent strip.
+        ui.set_clip_rect(ui.available_rect_before_wrap().intersect(ui.clip_rect()));
 
         if let Some(text) = self.clipboard_text.take() {
             ctx.copy_text(text);
@@ -468,14 +511,44 @@ impl App for ThothApp {
             }
         }
 
-        if self.window_state.sidebar_selected_section
-            == Some(components::sidebar::SidebarSection::MarketPlace)
+        // Dock — the main content panel floats in the body area as a squircle panel.
+        // 10px right margin matches the body side-padding; left gap is provided by
+        // the sidebar container's transparent RIGHT_GAP area, so no left margin here.
         {
-            use crate::components::marketplace::{MarketplaceDetail, MarketplaceDetailProps};
-            use crate::components::traits::StatelessComponent;
-            MarketplaceDetail::render(ui, MarketplaceDetailProps);
-        } else {
-            self.render_central_panel(ui, msg_to_central);
+            let dock_colors = ui
+                .ctx()
+                .memory(|m| {
+                    m.data
+                        .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
+                })
+                .unwrap_or_else(|| {
+                    let dark_mode = ui.ctx().global_style().visuals.dark_mode;
+                    crate::theme::Theme::for_dark_mode(dark_mode).colors()
+                });
+            egui::Frame::NONE
+                .fill(dock_colors.bg)
+                .outer_margin(egui::Margin {
+                    left: 0,
+                    right: crate::theme::GUTTER_GAP as i8 + 2, // 10px right body padding
+                    top: 0,
+                    bottom: crate::theme::GUTTER_GAP as i8,
+                })
+                .corner_radius(egui::CornerRadius::same(crate::theme::RADIUS_PANEL as u8))
+                .shadow(crate::theme::panel_shadow(ui.visuals().dark_mode))
+                .stroke(crate::theme::edge_stroke(&dock_colors))
+                .show(ui, |ui| {
+                    if self.window_state.sidebar_selected_section
+                        == Some(components::sidebar::SidebarSection::MarketPlace)
+                    {
+                        use crate::components::marketplace::{
+                            MarketplaceDetail, MarketplaceDetailProps,
+                        };
+                        use crate::components::traits::StatelessComponent;
+                        MarketplaceDetail::render(ui, MarketplaceDetailProps);
+                    } else {
+                        self.render_central_panel(ui, msg_to_central);
+                    }
+                });
         }
 
         self.render_error_modal(&ctx);
@@ -1737,6 +1810,25 @@ impl ThothApp {
             }
             TabEvent::OpenRecentFile(path) => {
                 self.window_state.tab_manager.open_file(path, nav_capacity);
+            }
+            TabEvent::NewWindow => {
+                // Same target as `ShortcutAction::NewWindow` (⌘N).
+                self.create_new_window();
+            }
+            TabEvent::BrowsePlugins => {
+                self.window_state.previous_sidebar_section =
+                    self.window_state.sidebar_selected_section.clone();
+                self.window_state.sidebar_expanded = true;
+                self.window_state.sidebar_selected_section =
+                    Some(components::sidebar::SidebarSection::MarketPlace);
+            }
+            TabEvent::ClearRecentFiles => {
+                // `PersistentState` exposes no `clear_recent_files`, so the list is
+                // emptied through the existing per-path removal and saved once.
+                for path in self.persistent_state.get_recent_files().to_vec() {
+                    self.persistent_state.remove_recent_file(&path);
+                }
+                let _ = self.persistent_state.save();
             }
             TabEvent::ChartAction { tab_id, action } => {
                 use crate::components::chart_studio::ChartTabAction;

--- a/src/components/bookmarks.rs
+++ b/src/components/bookmarks.rs
@@ -74,19 +74,14 @@ impl StatefulComponent for Bookmarks {
 
         ui.add(Separator::with_margins(GUTTER_GAP, GUTTER_GAP / 2.0));
 
-        let show_filename: Vec<bool> = props
-            .bookmarks
-            .iter()
-            .map(|b| props.current_file_path != Some(&b.file_path))
-            .collect();
-
         let items: Vec<ListItem> = props
             .bookmarks
             .iter()
-            .enumerate()
-            .map(|(i, b)| {
+            .map(|b| {
                 let title = b.label.as_deref().unwrap_or(b.path.as_str());
-                let description = if show_filename[i] {
+                // A bookmark in another file gets its file name as the second
+                // line; one in the open file doesn't need it.
+                let description = if props.current_file_path != Some(&b.file_path) {
                     Some(
                         std::path::Path::new(&b.file_path)
                             .file_name()

--- a/src/components/bookmarks.rs
+++ b/src/components/bookmarks.rs
@@ -1,5 +1,6 @@
 use crate::app::persistent_state::Bookmark;
 use crate::components::traits::StatefulComponent;
+use crate::theme::GUTTER_GAP;
 use eframe::egui;
 use thoth_plugin_sdk::components::{
     Input, List, ListEvent, ListItem, ListItemPrefix, Separator, SidebarHeader,
@@ -41,85 +42,87 @@ impl StatefulComponent for Bookmarks {
 
         // Header
         ui.add(SidebarHeader::builder().title("BOOKMARKS").build());
-        ui.add_space(8.0);
+        ui.add_space(GUTTER_GAP);
 
-        // Jump-to-path input
-        {
-            let mut input = Input::builder()
-                .id("jump_input")
-                .value(self.jump_input.clone())
-                .placeholder("Jump to path (e.g., 0.user.name)")
-                .icon(egui_phosphor::regular::CROSSHAIR)
-                .build();
-            let r = input.show(ui);
-            if r.inner {
-                self.jump_input = input.value.clone();
-            }
-            let response = r.response;
-            if response.lost_focus()
-                && ui.input(|i| i.key_pressed(egui::Key::Enter))
-                && !self.jump_input.is_empty()
-            {
-                events.push(BookmarksEvent::JumpToPath(self.jump_input.clone()));
-                self.jump_input.clear();
-            }
-            if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
-                self.jump_input.clear();
-            }
-        }
-
-        ui.add(Separator::with_margins(8.0, 4.0));
-
-        egui::ScrollArea::vertical()
-            .auto_shrink([false, false])
+        // Jump-to-path input — inset to the panel's content gutter so it lines up
+        // with the rows below (design `.cscroll{padding:0 12px}`).
+        egui::Frame::new()
+            .inner_margin(egui::Margin::symmetric(GUTTER_GAP as i8, 0))
             .show(ui, |ui| {
-                let show_filename: Vec<bool> = props
-                    .bookmarks
-                    .iter()
-                    .map(|b| props.current_file_path != Some(&b.file_path))
-                    .collect();
-
-                let items: Vec<ListItem> = props
-                    .bookmarks
-                    .iter()
-                    .enumerate()
-                    .map(|(i, b)| {
-                        let title = b.label.as_deref().unwrap_or(b.path.as_str());
-                        let description = if show_filename[i] {
-                            Some(
-                                std::path::Path::new(&b.file_path)
-                                    .file_name()
-                                    .and_then(|n| n.to_str())
-                                    .unwrap_or(b.file_path.as_str())
-                                    .to_string(),
-                            )
-                        } else {
-                            None
-                        };
-                        ListItem::builder()
-                            .title(title.to_string())
-                            .maybe_description(description)
-                            .prefix(ListItemPrefix::Icon {
-                                glyph: egui_phosphor::regular::BOOKMARK_SIMPLE.to_string(),
-                                color: None,
-                            })
-                            .build()
-                    })
-                    .collect();
-
-                if let Some(ListEvent::ItemClicked(item_idx)) = List::builder()
-                    .items(items)
-                    .empty_label("No bookmarks — press Cmd+D to add one")
-                    .build()
-                    .show(ui)
-                    && let Some(b) = props.bookmarks.get(item_idx)
+                let mut input = Input::builder()
+                    .id("jump_input")
+                    .value(self.jump_input.clone())
+                    .placeholder("Jump to path (e.g., 0.user.name)")
+                    .icon(egui_phosphor::regular::CROSSHAIR)
+                    .build();
+                let r = input.show(ui);
+                if r.inner {
+                    self.jump_input = input.value.clone();
+                }
+                let response = r.response;
+                if response.lost_focus()
+                    && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                    && !self.jump_input.is_empty()
                 {
-                    events.push(BookmarksEvent::NavigateToBookmark {
-                        file_path: b.file_path.clone(),
-                        path: b.path.clone(),
-                    });
+                    events.push(BookmarksEvent::JumpToPath(self.jump_input.clone()));
+                    self.jump_input.clear();
+                }
+                if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
+                    self.jump_input.clear();
                 }
             });
+
+        ui.add(Separator::with_margins(GUTTER_GAP, GUTTER_GAP / 2.0));
+
+        let show_filename: Vec<bool> = props
+            .bookmarks
+            .iter()
+            .map(|b| props.current_file_path != Some(&b.file_path))
+            .collect();
+
+        let items: Vec<ListItem> = props
+            .bookmarks
+            .iter()
+            .enumerate()
+            .map(|(i, b)| {
+                let title = b.label.as_deref().unwrap_or(b.path.as_str());
+                let description = if show_filename[i] {
+                    Some(
+                        std::path::Path::new(&b.file_path)
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .unwrap_or(b.file_path.as_str())
+                            .to_string(),
+                    )
+                } else {
+                    None
+                };
+                ListItem::builder()
+                    .title(title.to_string())
+                    .maybe_description(description)
+                    .prefix(ListItemPrefix::Icon {
+                        glyph: egui_phosphor::regular::BOOKMARK_SIMPLE.to_string(),
+                        color: None,
+                    })
+                    .build()
+            })
+            .collect();
+
+        // `List` owns its own scroll area — no outer one. `shrink_to_fit` sizes
+        // it to its rows and lets the sidebar's scroll area do the scrolling.
+        if let Some(ListEvent::ItemClicked(item_idx)) = List::builder()
+            .items(items)
+            .empty_label("No bookmarks — press Cmd+D to add one")
+            .shrink_to_fit(true)
+            .build()
+            .show(ui)
+            && let Some(b) = props.bookmarks.get(item_idx)
+        {
+            events.push(BookmarksEvent::NavigateToBookmark {
+                file_path: b.file_path.clone(),
+                path: b.path.clone(),
+            });
+        }
 
         BookmarksOutput { events }
     }

--- a/src/components/central_panel.rs
+++ b/src/components/central_panel.rs
@@ -41,6 +41,12 @@ pub enum CentralPanelEvent {
     OpenFilePicker,
     /// User clicked a recent file on the Welcome screen.
     OpenRecentFile(PathBuf),
+    /// User clicked "New window" on the Welcome screen.
+    NewWindow,
+    /// User clicked "Browse plugins…" on the Welcome screen.
+    BrowsePlugins,
+    /// User clicked "Clear" over the Welcome screen's Recent list.
+    ClearRecentFiles,
 }
 
 pub struct CentralPanelOutput {
@@ -154,13 +160,21 @@ impl CentralPanel {
             }
         }
 
-        // Plugin panes manage their own padding, so drop the central-panel inner
-        // margin for them — but keep the panel *fill* (the dock tab viewer's
-        // clear_background is false, so this frame provides the background).
-        let panel_frame = if props.plugin_ui.is_some() {
-            egui::Frame::central_panel(ui.style()).inner_margin(0)
+        // No fill: the enclosing floating dock panel already paints the content
+        // background as a *rounded* rect. Filling here would span the full leaf
+        // rect with square corners and clip the panel's rounded bottom corners.
+        // Plugin panes manage their own padding, so they get no inner margin —
+        // and so does the Welcome screen, whose `.wrap` carries the design's own
+        // 40/44 padding and would otherwise be inset by a further 8px.
+        let welcome_screen = props.plugin_ui.is_none()
+            && self.loaded_path.is_none()
+            && props.error.is_none()
+            && self.last_open_err.is_none()
+            && !self.searching;
+        let panel_frame = if props.plugin_ui.is_some() || welcome_screen {
+            egui::Frame::NONE
         } else {
-            egui::Frame::central_panel(ui.style())
+            egui::Frame::NONE.inner_margin(8) // matches Frame::central_panel
         };
         egui::CentralPanel::default()
             .frame(panel_frame)
@@ -211,6 +225,13 @@ impl CentralPanel {
                             }
                             WelcomeEvent::OpenRecentFile(path) => {
                                 events.push(CentralPanelEvent::OpenRecentFile(path))
+                            }
+                            WelcomeEvent::NewWindow => events.push(CentralPanelEvent::NewWindow),
+                            WelcomeEvent::BrowsePlugins => {
+                                events.push(CentralPanelEvent::BrowsePlugins)
+                            }
+                            WelcomeEvent::ClearRecentFiles => {
+                                events.push(CentralPanelEvent::ClearRecentFiles)
                             }
                         }
                     }

--- a/src/components/central_panel.rs
+++ b/src/components/central_panel.rs
@@ -53,6 +53,16 @@ pub struct CentralPanelOutput {
     pub events: Vec<CentralPanelEvent>,
 }
 
+/// What the panel body shows this frame. Decided once so the frame's margin and
+/// the rendered content can never disagree.
+#[derive(Clone, Copy)]
+enum PanelContent {
+    Searching,
+    Plugin,
+    Welcome,
+    Viewer,
+}
+
 #[derive(Default)]
 pub struct CentralPanel {
     file_viewer: FileViewer,
@@ -160,21 +170,27 @@ impl CentralPanel {
             }
         }
 
+        // The body's dispatch order, resolved once: the spinner wins, then a
+        // plugin pane, then the Welcome screen on an empty tab, then the viewer.
+        let content = if self.searching {
+            PanelContent::Searching
+        } else if props.plugin_ui.is_some() {
+            PanelContent::Plugin
+        } else if self.loaded_path.is_none() {
+            PanelContent::Welcome
+        } else {
+            PanelContent::Viewer
+        };
+
         // No fill: the enclosing floating dock panel already paints the content
         // background as a *rounded* rect. Filling here would span the full leaf
         // rect with square corners and clip the panel's rounded bottom corners.
         // Plugin panes manage their own padding, so they get no inner margin —
         // and so does the Welcome screen, whose `.wrap` carries the design's own
         // 40/44 padding and would otherwise be inset by a further 8px.
-        let welcome_screen = props.plugin_ui.is_none()
-            && self.loaded_path.is_none()
-            && props.error.is_none()
-            && self.last_open_err.is_none()
-            && !self.searching;
-        let panel_frame = if props.plugin_ui.is_some() || welcome_screen {
-            egui::Frame::NONE
-        } else {
-            egui::Frame::NONE.inner_margin(8) // matches Frame::central_panel
+        let panel_frame = match content {
+            PanelContent::Plugin | PanelContent::Welcome => egui::Frame::NONE,
+            PanelContent::Searching | PanelContent::Viewer => egui::Frame::NONE.inner_margin(8), // matches Frame::central_panel
         };
         egui::CentralPanel::default()
             .frame(panel_frame)
@@ -186,64 +202,70 @@ impl CentralPanel {
                     ui.add(Separator::plain());
                 }
 
-                if self.searching {
-                    ui.horizontal(|ui| {
-                        ui.add(egui::Spinner::new().size(16.0));
-                        ui.label("Searching…");
-                    });
-                    ui.add_space(6.0);
-                    return;
-                }
-
-                // Plugin pane takes priority over the file viewer.
-                if let Some(output) = props.plugin_ui {
-                    match serde_json::from_str::<UiNode>(&output.node_json) {
-                        Ok(mut node) => {
-                            let mut ui_events = Vec::new();
-                            render_ui_node(ui, &mut node, &mut ui_events);
-                            for evt in ui_events {
-                                events.push(CentralPanelEvent::PluginUiEvent(evt));
-                            }
-                        }
-                        Err(e) => {
-                            ui.colored_label(
-                                egui::Color32::RED,
-                                format!("Plugin UI parse error: {e}"),
-                            );
-                        }
+                match content {
+                    PanelContent::Searching => {
+                        ui.horizontal(|ui| {
+                            ui.add(egui::Spinner::new().size(16.0));
+                            ui.label("Searching…");
+                        });
+                        ui.add_space(6.0);
                     }
-                    return;
-                }
 
-                if self.loaded_path.is_none() {
-                    use crate::components::welcome::{WelcomeEvent, WelcomePanel};
-                    let welcome_events = WelcomePanel::render(ui, props.recent_files, props.colors);
-                    for evt in welcome_events {
-                        match evt {
-                            WelcomeEvent::OpenFilePicker => {
-                                events.push(CentralPanelEvent::OpenFilePicker)
-                            }
-                            WelcomeEvent::OpenRecentFile(path) => {
-                                events.push(CentralPanelEvent::OpenRecentFile(path))
-                            }
-                            WelcomeEvent::NewWindow => events.push(CentralPanelEvent::NewWindow),
-                            WelcomeEvent::BrowsePlugins => {
-                                events.push(CentralPanelEvent::BrowsePlugins)
-                            }
-                            WelcomeEvent::ClearRecentFiles => {
-                                events.push(CentralPanelEvent::ClearRecentFiles)
+                    // Plugin pane takes priority over the file viewer.
+                    PanelContent::Plugin => {
+                        if let Some(output) = props.plugin_ui {
+                            match serde_json::from_str::<UiNode>(&output.node_json) {
+                                Ok(mut node) => {
+                                    let mut ui_events = Vec::new();
+                                    render_ui_node(ui, &mut node, &mut ui_events);
+                                    for evt in ui_events {
+                                        events.push(CentralPanelEvent::PluginUiEvent(evt));
+                                    }
+                                }
+                                Err(e) => {
+                                    ui.colored_label(
+                                        egui::Color32::RED,
+                                        format!("Plugin UI parse error: {e}"),
+                                    );
+                                }
                             }
                         }
                     }
-                    return;
+
+                    PanelContent::Welcome => {
+                        use crate::components::welcome::{WelcomeEvent, WelcomePanel};
+                        let welcome_events =
+                            WelcomePanel::render(ui, props.recent_files, props.colors);
+                        for evt in welcome_events {
+                            match evt {
+                                WelcomeEvent::OpenFilePicker => {
+                                    events.push(CentralPanelEvent::OpenFilePicker)
+                                }
+                                WelcomeEvent::OpenRecentFile(path) => {
+                                    events.push(CentralPanelEvent::OpenRecentFile(path))
+                                }
+                                WelcomeEvent::NewWindow => {
+                                    events.push(CentralPanelEvent::NewWindow)
+                                }
+                                WelcomeEvent::BrowsePlugins => {
+                                    events.push(CentralPanelEvent::BrowsePlugins)
+                                }
+                                WelcomeEvent::ClearRecentFiles => {
+                                    events.push(CentralPanelEvent::ClearRecentFiles)
+                                }
+                            }
+                        }
+                    }
+
+                    PanelContent::Viewer => {
+                        // Update viewer settings right before rendering (so changes apply immediately)
+                        self.file_viewer
+                            .set_syntax_highlighting(props.syntax_highlighting);
+
+                        // Render the viewer (no filtering UI needed - search results shown in sidebar)
+                        self.file_viewer.ui(ui);
+                    }
                 }
-
-                // Update viewer settings right before rendering (so changes apply immediately)
-                self.file_viewer
-                    .set_syntax_highlighting(props.syntax_highlighting);
-
-                // Render the viewer (no filtering UI needed - search results shown in sidebar)
-                self.file_viewer.ui(ui);
             });
     }
 

--- a/src/components/chart_studio/chart_tab.rs
+++ b/src/components/chart_studio/chart_tab.rs
@@ -7,9 +7,11 @@
 
 use std::f32::consts::TAU;
 
-use eframe::egui::{self, Color32, FontId, Pos2, Rect, Stroke, Vec2};
+use eframe::egui::{self, Color32, CornerRadius, FontId, Pos2, Rect, Stroke, Vec2};
 use egui_plot::{Bar, BarChart, Legend, Line, Plot, PlotPoint, PlotPoints, Points, Text};
 use serde::{Deserialize, Serialize};
+use thoth_plugin_sdk::components::Separator;
+use thoth_plugin_sdk::theme::{FONT_CAPTION, GUTTER_GAP, RADIUS_PANEL, color_to_hex, edge_stroke};
 
 use super::{
     Aggregation, ChartOptions, ChartSpec, ChartTabAction, ChartType, SortMode, series_palette,
@@ -22,6 +24,36 @@ use crate::theme::ThemeColors;
 const ROW_CAP: usize = 5000;
 /// Numeric columns shown in a heatmap.
 const HEATMAP_COL_CAP: usize = 8;
+
+// ── canvas chrome (design `.cs-canvas` / `.cs-chead` / `.cs-plot`) ────────────
+
+/// Vertical padding of the header row — design `.cs-chead{padding:12px 16px}`.
+const HEAD_PAD: f32 = 12.0;
+/// Vertical padding the dock tab frame already applies around this content.
+const TAB_PAD_Y: f32 = GUTTER_GAP;
+/// Minimum gap between the header text block and the tool buttons — design
+/// `.cs-chead{gap:12px}`.
+const HEAD_GAP: f32 = 12.0;
+/// Gap between the title and its subtitle — design `.sub{margin-top:1px}`.
+const TITLE_GAP: f32 = 1.0;
+/// Gap between the header's tool buttons — design `.cs-chead .tb{gap:6px}`.
+const TOOL_GAP: f32 = 6.0;
+/// Framed `.ib` square, matching `Size::Medium`.
+const TOOL_SIZE: f32 = 26.0;
+/// How many tool buttons the header carries (edit / refresh / copy / export).
+const TOOL_COUNT: f32 = 4.0;
+/// Inset of the chart card from the panel edge — design `.cs-plot{margin:16px}`.
+/// Only applied vertically: the tab frame already insets 16px horizontally.
+const PLOT_MARGIN: f32 = 16.0;
+/// Chart card padding — design `.cs-plot{padding:16px 18px}`.
+const PLOT_PAD_X: f32 = 18.0;
+/// …and its vertical half.
+const PLOT_PAD_Y: f32 = 16.0;
+/// Bar cap radius — design `.bar{border-radius:5px 5px 0 0}` (only the value end
+/// is rounded; the baseline end stays square).
+const BAR_RADIUS: f32 = 5.0;
+/// Legend / heat-cell chip radius — design `.legend i{border-radius:3px}`.
+const CHIP_RADIUS: f32 = 3.0;
 
 pub struct ChartTab {
     tab_title: String,
@@ -259,88 +291,125 @@ impl ChartTab {
         use thoth_plugin_sdk::components::{IconButton, Typography, TypographyVariant};
         let mut action = None;
 
-        // Header: title/subtitle on the left, tools on the right.
-        ui.add_space(6.0);
+        // Header — design `.cs-chead{padding:12px 16px}`; the tab frame already
+        // supplies 8px of that above, so top up to 12.
+        ui.add_space(HEAD_PAD - TAB_PAD_Y);
         let mut want_export = false;
         ui.horizontal(|ui| {
-            ui.vertical(|ui| {
-                ui.add(
-                    Typography::builder()
-                        .text(self.header_title())
-                        .variant(TypographyVariant::BodyLarge)
-                        .build(),
-                );
-                ui.add(
-                    Typography::builder()
-                        .text(&self.subtitle)
-                        .variant(TypographyVariant::BodyMuted)
-                        .build(),
-                );
-            });
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                if ui
-                    .add(
+            // Every gap in the row is explicit — design `.cs-chead{gap:12px}`
+            // and `.tb{gap:6px}`.
+            ui.spacing_mut().item_spacing.x = 0.0;
+            // The tools keep their width; the text block gets what's left, so a
+            // long title can never push them out of the pane.
+            let tools_w = TOOL_COUNT * TOOL_SIZE + (TOOL_COUNT - 1.0) * TOOL_GAP;
+            let text_w = (ui.available_width() - tools_w - HEAD_GAP).max(0.0);
+            let text_h = ui
+                .allocate_ui_with_layout(
+                    Vec2::new(text_w, 0.0),
+                    egui::Layout::top_down(egui::Align::Min),
+                    |ui| {
+                        ui.set_max_width(text_w);
+                        // `.ttl` 14px semibold over `.sub` 11.5px muted, 1px apart.
+                        ui.spacing_mut().item_spacing.y = TITLE_GAP;
+                        ui.add(
+                            Typography::builder()
+                                .text(self.header_title())
+                                .variant(TypographyVariant::Title)
+                                .build(),
+                        );
+                        ui.add(
+                            Typography::builder()
+                                .text(&self.subtitle)
+                                .variant(TypographyVariant::Caption)
+                                .build(),
+                        );
+                    },
+                )
+                .response
+                .rect
+                .height();
+            // `.tb{margin-left:auto;gap:6px}` — four framed `.ib`s flushed right
+            // by an explicit spacer, in a row bounded to the text block's height
+            // so `Align::Center` centres them (`.cs-chead{align-items:center}`)
+            // without claiming the whole pane height.
+            ui.add_space(HEAD_GAP);
+            ui.allocate_ui_with_layout(
+                Vec2::new(tools_w, text_h),
+                egui::Layout::left_to_right(egui::Align::Center),
+                |ui| {
+                    let tool = |glyph: &str, tip: &str| {
                         IconButton::builder()
-                            .icon(egui_phosphor::regular::DOWNLOAD_SIMPLE)
+                            .icon(glyph)
                             .frame(true)
-                            .tooltip("Export chart as PNG")
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    want_export = true;
-                }
-                if ui
-                    .add(
-                        IconButton::builder()
-                            .icon(egui_phosphor::regular::COPY)
-                            .frame(true)
-                            .tooltip("Copy chart config")
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    ui.ctx().copy_text(self.config_json());
-                }
-                if ui
-                    .add(
-                        IconButton::builder()
-                            .icon(egui_phosphor::regular::ARROWS_CLOCKWISE)
-                            .frame(true)
-                            .tooltip("Refresh data from source")
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    action = Some(ChartTabAction::Refresh);
-                }
-                if ui
-                    .add(
-                        IconButton::builder()
-                            .icon(egui_phosphor::regular::PENCIL_SIMPLE)
-                            .frame(true)
-                            .tooltip("Edit chart in Chart Studio")
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    action = Some(ChartTabAction::Edit);
-                }
-            });
+                            .tooltip(tip)
+                            .build()
+                    };
+                    if ui
+                        .add(tool(
+                            egui_phosphor::regular::PENCIL_SIMPLE,
+                            "Edit chart in Chart Studio",
+                        ))
+                        .clicked()
+                    {
+                        action = Some(ChartTabAction::Edit);
+                    }
+                    ui.add_space(TOOL_GAP);
+                    if ui
+                        .add(tool(
+                            egui_phosphor::regular::ARROWS_CLOCKWISE,
+                            "Refresh data from source",
+                        ))
+                        .clicked()
+                    {
+                        action = Some(ChartTabAction::Refresh);
+                    }
+                    ui.add_space(TOOL_GAP);
+                    if ui
+                        .add(tool(egui_phosphor::regular::COPY, "Copy chart config"))
+                        .clicked()
+                    {
+                        ui.ctx().copy_text(self.config_json());
+                    }
+                    ui.add_space(TOOL_GAP);
+                    if ui
+                        .add(tool(
+                            egui_phosphor::regular::DOWNLOAD_SIMPLE,
+                            "Export chart as PNG",
+                        ))
+                        .clicked()
+                    {
+                        want_export = true;
+                    }
+                },
+            );
         });
-        ui.add_space(8.0);
+
+        // The head's bottom edge — design `.cs-chead{box-shadow:inset 0 -1px 0
+        // var(--surface)}`: a flush 1px rule in the band colour, which is what
+        // `Separator::rule` draws (the bare separator would use the brighter
+        // border colour and add its own spacing).
+        ui.add_space(HEAD_PAD);
+        ui.add(Separator::rule(color_to_hex(colors.surface)));
 
         if self.rows.is_empty() {
+            ui.add_space(PLOT_MARGIN);
             self.empty_note(ui, "This dataset has no rows to plot.");
             return action;
         }
 
-        // Chart surface
+        // Chart surface — design `.cs-plot{margin:16px;background:var(--surface);
+        // box-shadow:var(--edge);border-radius:10px;padding:16px 18px}`.
+        ui.add_space(PLOT_MARGIN);
         let frame_rect = egui::Frame::new()
             .fill(colors.surface)
-            .stroke(Stroke::new(1.0, colors.surface_raised))
-            .corner_radius(8.0)
-            .inner_margin(14.0)
+            .stroke(edge_stroke(colors))
+            .corner_radius(RADIUS_PANEL)
+            .inner_margin(egui::Margin {
+                left: PLOT_PAD_X as i8,
+                right: PLOT_PAD_X as i8,
+                top: PLOT_PAD_Y as i8,
+                bottom: PLOT_PAD_Y as i8,
+            })
             .show(ui, |ui| {
                 let size = ui.available_size();
                 match self.chart_type {
@@ -417,7 +486,13 @@ impl ChartTab {
                     plot = plot.auto_bounds(egui::Vec2b::TRUE);
                 }
                 if self.options.legend {
-                    plot = plot.legend(Legend::default());
+                    // Design `.legend` is a bare row of 11px muted entries — no
+                    // boxed background behind them.
+                    plot = plot.legend(
+                        Legend::default()
+                            .background_alpha(0.0)
+                            .text_style(egui::TextStyle::Small),
+                    );
                 }
                 // Axis titles from the chosen columns (swapped for H-Bar).
                 let x_name = self.columns.get(self.x_col).cloned().unwrap_or_default();
@@ -479,8 +554,7 @@ impl ChartTab {
                     .transform
                     .position_from_point(&PlotPoint::new(b.hi[0], b.lo[1]));
                 let rect = Rect::from_two_pos(tl, br);
-                let radius = (rect.width().min(rect.height()) * 0.3).min(4.0);
-                painter.rect_filled(rect, radius, b.color);
+                painter.rect_filled(rect, bar_corners(rect, horizontal, b.value), b.color);
             }
             if labels {
                 for b in &bars {
@@ -826,12 +900,14 @@ impl ChartTab {
                     Pos2::new(rect.right() - legend_w + 4.0, y + 2.0),
                     Vec2::splat(10.0),
                 );
-                painter.rect_filled(sw, 2.0, *color);
+                // Design `.legend i{width:10px;height:10px;border-radius:3px}`
+                // + `.legend span{font-size:11px;color:overlay1;gap:6px}`.
+                painter.rect_filled(sw, CHIP_RADIUS, *color);
                 painter.text(
                     Pos2::new(sw.right() + 6.0, y + 7.0),
                     egui::Align2::LEFT_CENTER,
                     label,
-                    FontId::proportional(11.0),
+                    FontId::proportional(FONT_CAPTION),
                     colors.fg_muted,
                 );
                 y += 18.0;
@@ -1103,11 +1179,11 @@ impl ChartTab {
                 let x = grid.left() + cw * ci as f32;
                 let cell =
                     Rect::from_min_size(Pos2::new(x + 1.0, y + 1.0), Vec2::new(cw - 2.0, rh - 2.0));
-                painter.rect_filled(cell, 2.0, heat_color(t, colors));
+                painter.rect_filled(cell, CHIP_RADIUS, heat_color(t, colors));
                 if hover_r == Some(r) {
                     painter.rect_stroke(
                         cell,
-                        2.0,
+                        CHIP_RADIUS,
                         Stroke::new(1.5, colors.fg),
                         egui::StrokeKind::Inside,
                     );
@@ -1144,6 +1220,42 @@ impl ChartTab {
 }
 
 // ── free helpers ──────────────────────────────────────────────────────────────
+
+/// Corner radii for a bar: only the *value* end is rounded — design
+/// `.bar{border-radius:5px 5px 0 0}` — and never more than half the bar's short
+/// side, so thin bars don't turn into lozenges.
+fn bar_corners(rect: Rect, horizontal: bool, value: f64) -> CornerRadius {
+    let r = BAR_RADIUS
+        .min(rect.width().min(rect.height()) / 2.0)
+        .max(0.0) as u8;
+    match (horizontal, value >= 0.0) {
+        // Grows right / up: round the far / top edge.
+        (true, true) => CornerRadius {
+            ne: r,
+            se: r,
+            nw: 0,
+            sw: 0,
+        },
+        (true, false) => CornerRadius {
+            nw: r,
+            sw: r,
+            ne: 0,
+            se: 0,
+        },
+        (false, true) => CornerRadius {
+            nw: r,
+            ne: r,
+            sw: 0,
+            se: 0,
+        },
+        (false, false) => CornerRadius {
+            sw: r,
+            se: r,
+            nw: 0,
+            ne: 0,
+        },
+    }
+}
 
 /// Label for a categorical axis tick — only integer marks map to a row.
 fn tick_label(labels: &[String], value: f64) -> String {

--- a/src/components/chart_studio/studio.rs
+++ b/src/components/chart_studio/studio.rs
@@ -411,6 +411,9 @@ impl ChartStudio {
                             IconButton::builder()
                                 .icon(egui_phosphor::regular::X)
                                 .tooltip("Remove series")
+                                // Design's 26px `.ib`, matching the width
+                                // `remove_w` reserves for it above.
+                                .size(Size::Medium)
                                 .build(),
                         )
                         .clicked()

--- a/src/components/chart_studio/studio.rs
+++ b/src/components/chart_studio/studio.rs
@@ -5,27 +5,63 @@
 //! Emits [`ChartStudioEvent`]s up to the app, which does the data fetching and
 //! tab creation.
 //!
-//! Built entirely from `thoth-plugin-sdk` components (Select, ToggleSwitch,
-//! Button, IconButton, Icon, List, Typography, SidebarHeader) so it matches the
-//! rest of the app's styling.
+//! Built entirely from `thoth-plugin-sdk` components (Select, NumberInput,
+//! ToggleSwitch, Button, IconButton, List, Typography, SidebarHeader) so it
+//! matches the rest of the app's styling. The section rhythm and control
+//! metrics follow the design sheet's `.cs-side` block (`ChartStudio` in
+//! `screens.html`).
 
 use eframe::egui;
 use thoth_plugin_sdk::components::{
-    Button, ButtonColor, ButtonType, Icon, IconButton, List, ListEvent, ListItem, ListItemPrefix,
+    Button, ButtonColor, ButtonType, IconButton, List, ListEvent, ListItem, ListItemPrefix,
     NumberInput, Select, SelectOption, SidebarHeader, Size, ToggleSwitch, Typography,
     TypographyVariant,
 };
-use thoth_plugin_sdk::theme::color_to_hex;
+use thoth_plugin_sdk::theme::{FIELD_HEIGHT, FONT_CONTROL};
 
 use super::{
     Aggregation, ChartOptions, ChartSpec, ChartType, ColumnInfo, ProducerKind, ProducerRef,
     SortMode, series_palette,
 };
 use crate::app::tab_manager::TabId;
-use crate::theme::ThemeColors;
+use crate::theme::{GUTTER_GAP, ThemeColors};
 
-/// Horizontal inset, matching `SidebarHeader`/list rows.
-const PAD_X: f32 = 8.0;
+/// Horizontal inset, matching `SidebarHeader`/list rows and the sibling sidebar
+/// panels (all of which inset by [`GUTTER_GAP`]).
+const PAD_X: f32 = GUTTER_GAP;
+/// Trailing inset under the last section — design `.cs-side{padding:0 0 12px}`.
+const PAD_BOTTOM: f32 = 12.0;
+/// Space above each group label — design `.cs-sec{padding-top:12px}`.
+const SECTION_GAP: f32 = 12.0;
+/// Gap under a group label — design `.glabel{margin:0 0 7px}`.
+const LABEL_GAP: f32 = 7.0;
+/// Gap between the field caption and its control — design `.fl{margin-bottom:4px}`.
+const CAPTION_GAP: f32 = 4.0;
+/// Gap between form rows inside a section — design `.frow{margin-bottom:9px}`.
+const ROW_GAP: f32 = 9.0;
+/// Gap between the parts of a Y-series row — design `.yrow{gap:7px}`.
+const SERIES_GAP: f32 = 7.0;
+/// Gap between successive Y-series rows — design `.yrow{margin-bottom:6px}`.
+const SERIES_ROW_GAP: f32 = 6.0;
+/// Chart-type grid gutter — design `.cs-types{gap:6px}`.
+const TYPE_GAP: f32 = 6.0;
+/// Glyph inside a chart-type tile — design `.ct{font-size:20px}`.
+const TYPE_GLYPH: f32 = 20.0;
+/// Upper bound on a chart-type tile, so a wide sidebar doesn't grow huge squares
+/// (the tiles are `aspect-ratio:1`, sized by the 4-column grid).
+const TYPE_CELL_MAX: f32 = 84.0;
+/// Series colour chip — design `.yrow .sw{width:13px;height:13px}`.
+const SWATCH: f32 = 13.0;
+/// …and its corner radius — design `.sw{border-radius:3px}`. Below the control
+/// rung of the radius ladder: this is a 13px decoration, not a control.
+const SWATCH_RADIUS: f32 = 3.0;
+/// Vertical padding on an options row — design `.togrow{padding:5px 0}`.
+const TOGGLE_PAD_Y: f32 = 5.0;
+/// Toggle track width, reserved so the switch sits hard right — design
+/// `.switch{width:32px}` / `.togrow{justify-content:space-between}`.
+const TOGGLE_TRACK_W: f32 = 32.0;
+/// Full-width primary action — design `.btn.wide{height:30px}`.
+const WIDE_BUTTON_H: f32 = 30.0;
 
 /// What the config panel is asking the app to do.
 pub enum ChartStudioEvent {
@@ -136,32 +172,31 @@ impl ChartStudio {
             .inner_margin(egui::Margin {
                 left: PAD_X as i8,
                 right: PAD_X as i8,
-                top: 4,
-                bottom: 8,
+                // Each section opens with its own `SECTION_GAP`; the panel only
+                // owns the trailing inset — design `.cs-side{padding:0 0 12px}`.
+                top: 0,
+                bottom: PAD_BOTTOM as i8,
             })
             .show(ui, |ui| {
-                ui.spacing_mut().item_spacing = egui::vec2(6.0, 8.0);
+                // Every gap in the panel is explicit, straight off the design's
+                // `.cs-sec` / `.frow` / `.yrow` / `.togrow` metrics.
+                ui.spacing_mut().item_spacing = egui::Vec2::ZERO;
                 // Fit the panel width exactly — no horizontal scrolling.
                 let width = ui.available_width();
 
-                self.data_source_section(ui, &colors, width, &mut events);
-                ui.add_space(6.0);
+                self.data_source_section(ui, width, &mut events);
                 self.chart_type_section(ui, width);
 
                 if !self.columns.is_empty() {
-                    ui.add_space(6.0);
                     self.axes_section(ui, &colors, width);
-                    ui.add_space(6.0);
                     self.data_section(ui, width);
-                    ui.add_space(6.0);
                     self.options_section(ui);
                 }
 
-                ui.add_space(10.0);
-                self.generate_button(ui, width, &mut events);
+                ui.add_space(SECTION_GAP);
+                self.generate_button(ui, &mut events);
 
                 if !self.open_charts.is_empty() {
-                    ui.add_space(14.0);
                     self.open_charts_section(ui, &mut events);
                 }
             });
@@ -169,30 +204,34 @@ impl ChartStudio {
         events
     }
 
+    /// Section heading — design `.glabel`, with `.cs-sec`'s 12px top padding
+    /// above it and its own 7px bottom margin below.
     fn group_label(ui: &mut egui::Ui, text: &str) {
-        ui.add_space(2.0);
+        ui.add_space(SECTION_GAP);
         ui.add(
             Typography::builder()
                 .text(text)
                 .variant(TypographyVariant::GroupLabel)
                 .build(),
         );
-        ui.add_space(2.0);
+        ui.add_space(LABEL_GAP);
     }
 
+    /// Caption above a control — design `.frow .fl{font-size:11px;color:overlay1;
+    /// margin-bottom:4px}`, i.e. the 11px muted `Caption` variant.
     fn field_label(ui: &mut egui::Ui, text: &str) {
         ui.add(
             Typography::builder()
                 .text(text)
-                .variant(TypographyVariant::Label)
+                .variant(TypographyVariant::Caption)
                 .build(),
         );
+        ui.add_space(CAPTION_GAP);
     }
 
     fn data_source_section(
         &mut self,
         ui: &mut egui::Ui,
-        colors: &ThemeColors,
         width: f32,
         events: &mut Vec<ChartStudioEvent>,
     ) {
@@ -223,11 +262,13 @@ impl ChartStudio {
                 );
             }
         }
-        let _ = colors;
         let mut select = Select::builder()
             .id("chart_ds")
             .value(self.selected.map(|t| t.to_string()).unwrap_or_default())
             .options(options)
+            // Design leads the source trigger with an accent database glyph.
+            .icon(egui_phosphor::regular::DATABASE)
+            .icon_color("accent")
             .width(width)
             .size(Size::Medium)
             .build();
@@ -240,16 +281,22 @@ impl ChartStudio {
         }
     }
 
+    /// The 4-column grid of square type tiles — design
+    /// `.cs-types{grid-template-columns:repeat(4,1fr);gap:6px}` with `.ct`
+    /// tiles (surface + hairline edge, accent fill + glow when `.on`), which is
+    /// exactly what a framed/selected `IconButton` paints.
     fn chart_type_section(&mut self, ui: &mut egui::Ui, width: f32) {
         Self::group_label(ui, "CHART TYPE");
-        let spacing = 5.0;
         let cols = 4;
         // Never exceed the row width (avoids horizontal overflow on narrow panels).
-        let cell = ((width - spacing * (cols as f32 - 1.0)) / cols as f32).clamp(1.0, 84.0);
-        let prev = ui.spacing().item_spacing;
-        ui.spacing_mut().item_spacing = egui::vec2(spacing, spacing);
-        for chunk in ChartType::ALL.chunks(cols) {
+        let cell =
+            ((width - TYPE_GAP * (cols as f32 - 1.0)) / cols as f32).clamp(1.0, TYPE_CELL_MAX);
+        for (row, chunk) in ChartType::ALL.chunks(cols).enumerate() {
+            if row > 0 {
+                ui.add_space(TYPE_GAP);
+            }
             ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = TYPE_GAP;
                 for &ct in chunk {
                     let clicked = ui
                         .add(
@@ -259,7 +306,7 @@ impl ChartStudio {
                                 .frame(true)
                                 .selected(self.chart_type == ct)
                                 .size_px(cell)
-                                .icon_size(22.0)
+                                .icon_size(TYPE_GLYPH)
                                 .build(),
                         )
                         .clicked();
@@ -269,7 +316,6 @@ impl ChartStudio {
                 }
             });
         }
-        ui.spacing_mut().item_spacing = prev;
     }
 
     fn axes_section(&mut self, ui: &mut egui::Ui, colors: &ThemeColors, width: f32) {
@@ -301,7 +347,7 @@ impl ChartStudio {
             self.x_col = i;
         }
 
-        ui.add_space(6.0);
+        ui.add_space(ROW_GAP);
         // Heatmap plots every numeric column and ignores the Y selection, so
         // don't offer a (no-op) Y picker for it.
         if self.chart_type == ChartType::Heatmap {
@@ -334,18 +380,18 @@ impl ChartStudio {
         }
 
         let multi = !self.chart_type.single_series() && self.y_cols.len() > 1;
-        // Leave room for the colour swatch (and the remove button when multi).
-        let combo_w = if multi { width - 52.0 } else { width - 22.0 };
+        // Leave room for the colour chip (and the remove button when multi) —
+        // design `.yrow{gap:7px}` with `.sw` 13px and a 26px `.ib`.
+        let remove_w = Size::Medium.metrics().1 + SERIES_GAP;
+        let combo_w = width - SWATCH - SERIES_GAP - if multi { remove_w } else { 0.0 };
         let mut remove: Option<usize> = None;
         for i in 0..self.y_cols.len() {
+            if i > 0 {
+                ui.add_space(SERIES_ROW_GAP);
+            }
             ui.horizontal(|ui| {
-                ui.add(
-                    Icon::builder()
-                        .glyph(egui_phosphor::regular::SQUARE)
-                        .color(color_to_hex(palette[i % palette.len()]))
-                        .size(12.0)
-                        .build(),
-                );
+                Self::series_swatch(ui, palette[i % palette.len()]);
+                ui.add_space(SERIES_GAP);
                 let mut y_select = Select::builder()
                     .id(format!("chart_y_{i}"))
                     .value(self.y_cols[i].to_string())
@@ -358,8 +404,9 @@ impl ChartStudio {
                 {
                     self.y_cols[i] = c;
                 }
-                if multi
-                    && ui
+                if multi {
+                    ui.add_space(SERIES_GAP);
+                    if ui
                         .add(
                             IconButton::builder()
                                 .icon(egui_phosphor::regular::X)
@@ -367,8 +414,9 @@ impl ChartStudio {
                                 .build(),
                         )
                         .clicked()
-                {
-                    remove = Some(i);
+                    {
+                        remove = Some(i);
+                    }
                 }
             });
         }
@@ -376,28 +424,44 @@ impl ChartStudio {
             self.y_cols.remove(i);
         }
 
-        if !self.chart_type.single_series()
+        let can_add = !self.chart_type.single_series()
             && self.y_cols.len() < palette.len()
-            && !numeric.is_empty()
-            && ui
+            && !numeric.is_empty();
+        if can_add {
+            ui.add_space(SERIES_ROW_GAP);
+            // Design `<button class="btn text sm">` — a small ghost text button
+            // in the muted role, not an accent one.
+            let clicked = ui
                 .add(
                     Button::builder()
                         .label("Add series")
                         .icon(egui_phosphor::regular::PLUS)
                         .button_type(ButtonType::Text)
-                        .color(ButtonColor::Secondary)
-                        .size(11.0)
+                        .button_size(Size::Small)
                         .build(),
                 )
-                .clicked()
-        {
-            let next = numeric
-                .iter()
-                .find(|c| !self.y_cols.contains(c))
-                .copied()
-                .unwrap_or(numeric[0]);
-            self.y_cols.push(next);
+                .clicked();
+            if clicked {
+                let next = numeric
+                    .iter()
+                    .find(|c| !self.y_cols.contains(c))
+                    .copied()
+                    .unwrap_or(numeric[0]);
+                self.y_cols.push(next);
+            }
         }
+    }
+
+    /// The series colour chip beside a Y picker — design
+    /// `.yrow .sw{width:13px;height:13px;border-radius:3px}`. No SDK component
+    /// paints a bare colour chip, so it is a direct fill in the series colour.
+    /// Claims the select's full height so the chip centres on it
+    /// (design `.yrow{align-items:center}`).
+    fn series_swatch(ui: &mut egui::Ui, color: egui::Color32) {
+        let (rect, _) =
+            ui.allocate_exact_size(egui::vec2(SWATCH, FIELD_HEIGHT), egui::Sense::hover());
+        let chip = egui::Rect::from_center_size(rect.center(), egui::Vec2::splat(SWATCH));
+        ui.painter().rect_filled(chip, SWATCH_RADIUS, color);
     }
 
     fn data_section(&mut self, ui: &mut egui::Ui, width: f32) {
@@ -432,7 +496,7 @@ impl ChartStudio {
             self.aggregation = *a;
         }
 
-        ui.add_space(6.0);
+        ui.add_space(ROW_GAP);
         Self::field_label(ui, "Sort");
         let sort_opts: Vec<SelectOption> = SortMode::ALL
             .iter()
@@ -462,7 +526,7 @@ impl ChartStudio {
             self.sort = *s;
         }
 
-        ui.add_space(6.0);
+        ui.add_space(ROW_GAP);
         Self::field_label(ui, "Top N (0 = all)");
         let mut top = NumberInput::builder()
             .id("chart_topn")
@@ -474,6 +538,9 @@ impl ChartStudio {
         self.top_n = top.value.max(0.0) as usize;
     }
 
+    /// Option rows — design `.togrow{display:flex;justify-content:space-between;
+    /// padding:5px 0;font-size:12.5px;color:var(--text)}`: the label reads on the
+    /// left in body colour, the switch sits hard right.
     fn options_section(&mut self, ui: &mut egui::Ui) {
         Self::group_label(ui, "OPTIONS");
         let rows = [
@@ -484,7 +551,19 @@ impl ChartStudio {
         ];
         let mut toggled = [false; 4];
         for (i, (label, enabled)) in rows.iter().enumerate() {
+            ui.add_space(TOGGLE_PAD_Y);
             ui.horizontal(|ui| {
+                ui.add(
+                    Typography::builder()
+                        .text(*label)
+                        .variant(TypographyVariant::Body)
+                        .size(FONT_CONTROL)
+                        .build(),
+                );
+                // Push the switch to the row's right edge without a centred
+                // right-to-left layout (which would claim the full pane height).
+                let gap = (ui.available_width() - TOGGLE_TRACK_W).max(0.0);
+                ui.add_space(gap);
                 if ui
                     .add(
                         ToggleSwitch::builder()
@@ -496,9 +575,8 @@ impl ChartStudio {
                 {
                     toggled[i] = true;
                 }
-                ui.add_space(4.0);
-                Self::field_label(ui, label);
             });
+            ui.add_space(TOGGLE_PAD_Y);
         }
         if toggled[0] {
             self.options.legend = !self.options.legend;
@@ -514,12 +592,10 @@ impl ChartStudio {
         }
     }
 
-    fn generate_button(
-        &mut self,
-        ui: &mut egui::Ui,
-        width: f32,
-        events: &mut Vec<ChartStudioEvent>,
-    ) {
+    /// The panel's primary action — design `<button class="btn secondary wide">`:
+    /// a full-width 30px neutral *surface* button (`ButtonColor::Default` is the
+    /// design's `.btn.secondary`), not a filled accent one.
+    fn generate_button(&mut self, ui: &mut egui::Ui, events: &mut Vec<ChartStudioEvent>) {
         let ready = self.selected.is_some() && !self.columns.is_empty() && !self.y_cols.is_empty();
         let editing = self.editing.is_some();
         let (label, icon) = if editing {
@@ -535,9 +611,9 @@ impl ChartStudio {
                     .label(label)
                     .icon(icon)
                     .button_type(ButtonType::Elevated)
-                    .color(ButtonColor::Secondary)
-                    .width(width)
-                    .height(30.0)
+                    .color(ButtonColor::Default)
+                    .full_width(true)
+                    .height(WIDE_BUTTON_H)
                     .build(),
             )
             .clicked();
@@ -562,18 +638,21 @@ impl ChartStudio {
             }));
             self.editing = None;
         }
-        if editing
-            && ui
+        if editing {
+            ui.add_space(SERIES_ROW_GAP);
+            // Design `.btn.text.sm` — a quiet escape hatch under the CTA.
+            let cancelled = ui
                 .add(
                     Button::builder()
                         .label("Cancel edit")
                         .button_type(ButtonType::Text)
-                        .size(11.0)
+                        .button_size(Size::Small)
                         .build(),
                 )
-                .clicked()
-        {
-            self.editing = None;
+                .clicked();
+            if cancelled {
+                self.editing = None;
+            }
         }
     }
 

--- a/src/components/drag_and_drop.rs
+++ b/src/components/drag_and_drop.rs
@@ -1,32 +1,55 @@
+// File drop overlay — design `screens.html` §6 “File drop overlay”: a black-alpha
+// scrim over the whole window carrying the prompt and the incoming path.
+
 use crate::{app, file::detect_file_type::sniff_file_type};
-use eframe::egui;
+use eframe::egui::{
+    self,
+    text::{LayoutJob, TextFormat},
+};
+use thoth_plugin_sdk::theme::with_alpha;
+
+/// `.drop-scrim{background:rgba(0,0,0,.7)}` — 70% of 255. Not a palette colour:
+/// the scrim is a neutral dim over whatever the window was showing, so it stays
+/// black in every theme.
+const SCRIM_ALPHA: u8 = 179;
+/// `.drop-scrim .msg{font-size:20px;font-weight:600}`.
+const MSG_FONT: f32 = 20.0;
+/// `.drop-scrim .msg{line-height:1.9}` — 1.9 × 20px.
+const MSG_LINE_H: f32 = 38.0;
+/// `.drop-scrim .path{font-family:var(--mono);font-size:14px;font-weight:400}`.
+const PATH_FONT: f32 = 14.0;
+/// `.path{color:#e9e9f4}` — near-white over the scrim, expressed as an alpha of
+/// white so it holds in any theme.
+const PATH_ALPHA: u8 = 235;
 
 impl app::ThothApp {
     pub fn handle_file_drop(&mut self, ctx: &egui::Context) {
         let hovering_files = ctx.input(|i| i.raw.hovered_files.clone());
         if !hovering_files.is_empty() {
-            let mut text = String::from("Drop file to open:\n");
+            // One `.path` line per incoming file: its path, or its MIME type when
+            // the platform hands us no path.
+            let mut paths: Vec<String> = Vec::new();
             for file in &hovering_files {
-                if let Some(path) = &file.path {
-                    use std::fmt::Write as _;
-                    if let Err(e) = write!(text, "\n{}", path.display())
-                        && let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                    {
-                        tab.error = Some(crate::error::ThothError::UIRenderError {
-                            component: "DragAndDrop".to_string(),
-                            reason: format!("Failed to format file path: {e}"),
-                        });
-                    }
+                let mut line = String::new();
+                use std::fmt::Write as _;
+                let written = if let Some(path) = &file.path {
+                    Some(("file path", write!(line, "{}", path.display())))
                 } else if !file.mime.is_empty() {
-                    use std::fmt::Write as _;
-                    if let Err(e) = write!(text, "\n{}", file.mime)
-                        && let Some(tab) = self.window_state.tab_manager.active_tab_mut()
-                    {
-                        tab.error = Some(crate::error::ThothError::UIRenderError {
-                            component: "DragAndDrop".to_string(),
-                            reason: format!("Failed to format MIME type: {e}"),
-                        });
+                    Some(("MIME type", write!(line, "{}", file.mime)))
+                } else {
+                    None
+                };
+                match written {
+                    Some((what, Err(e))) => {
+                        if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                            tab.error = Some(crate::error::ThothError::UIRenderError {
+                                component: "DragAndDrop".to_string(),
+                                reason: format!("Failed to format {what}: {e}"),
+                            });
+                        }
                     }
+                    Some((_, Ok(()))) => paths.push(line),
+                    None => {}
                 }
             }
 
@@ -35,12 +58,44 @@ impl app::ThothApp {
                 egui::Id::new("file_drop_overlay"),
             ));
             let screen_rect = ctx.content_rect();
-            painter.rect_filled(screen_rect, 0.0, egui::Color32::from_black_alpha(180));
-            painter.text(
-                screen_rect.center(),
-                egui::Align2::CENTER_CENTER,
-                text,
-                egui::TextStyle::Heading.resolve(&ctx.global_style()),
+            painter.rect_filled(
+                screen_rect,
+                0.0,
+                egui::Color32::from_black_alpha(SCRIM_ALPHA),
+            );
+
+            // `.msg` over `.path`: one centred block, the prompt at 20px semibold
+            // white and each path under it in mono.
+            let mut job = LayoutJob {
+                halign: egui::Align::Center,
+                ..Default::default()
+            };
+            job.append(
+                "Drop file to open:",
+                0.0,
+                TextFormat {
+                    font_id: egui::FontId::proportional(MSG_FONT),
+                    color: egui::Color32::WHITE,
+                    line_height: Some(MSG_LINE_H),
+                    ..Default::default()
+                },
+            );
+            for path in &paths {
+                job.append(
+                    &format!("\n{path}"),
+                    0.0,
+                    TextFormat {
+                        font_id: egui::FontId::monospace(PATH_FONT),
+                        color: with_alpha(egui::Color32::WHITE, PATH_ALPHA),
+                        line_height: Some(MSG_LINE_H),
+                        ..Default::default()
+                    },
+                );
+            }
+            let galley = painter.layout_job(job);
+            painter.galley(
+                screen_rect.center() - egui::vec2(0.0, galley.size().y / 2.0),
+                galley,
                 egui::Color32::WHITE,
             );
         }

--- a/src/components/error_modal.rs
+++ b/src/components/error_modal.rs
@@ -1,7 +1,12 @@
+use std::cell::Cell;
+
 use crate::components::traits::StatefulComponent;
 use crate::error::{ErrorHandler, ErrorRecovery, RecoveryAction, ThothError};
 use eframe::egui;
-use thoth_plugin_sdk::components::{Button, ButtonColor, ButtonType};
+use thoth_plugin_sdk::components::{
+    Button, ButtonColor, ButtonType, Icon, Modal, Separator, Typography, TypographyVariant,
+};
+use thoth_plugin_sdk::theme::{FONT_BODY, ThemeColors, color_to_hex, with_alpha};
 
 /// Props for the error modal
 pub struct ErrorModalProps<'a> {
@@ -10,6 +15,7 @@ pub struct ErrorModalProps<'a> {
 }
 
 /// Events emitted by the error modal
+#[derive(Clone, Copy)]
 pub enum ErrorModalEvent {
     Close,
     Retry,
@@ -40,106 +46,136 @@ impl StatefulComponent for ErrorModal {
             };
         }
 
+        let colors = ThemeColors::from_ctx(ui.ctx());
+
         // Get user-friendly message and recovery suggestion
         let user_message = ErrorHandler::get_user_message(props.error);
         let recovery_suggestion = ErrorRecovery::get_recovery_suggestion(props.error);
         let action = ErrorRecovery::get_recovery_action(props.error);
+        let recoverable = ErrorHandler::is_recoverable(props.error);
+        let resettable = matches!(action, RecoveryAction::Reset);
 
         // Log the technical error
         ErrorHandler::log_error(props.error);
 
-        // Create modal window
-        egui::Window::new("Error")
-            .collapsible(false)
-            .resizable(false)
-            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-            .show(ui.ctx(), |ui| {
-                ui.set_min_width(400.0);
-                ui.set_max_width(600.0);
+        // The card's head carries the title plus the message as its subtitle
+        // (design `.m-head`: `An error occurred` over a `pre-line` detail line).
+        let modal = Modal::builder()
+            .id("error_modal")
+            .title("An error occurred")
+            .subtitle(user_message)
+            .width(480.0)
+            // Design leads the head with the 30px status glyph (`.glyph`).
+            .glyph(egui_phosphor::regular::WARNING_CIRCLE)
+            .glyph_color("error")
+            .build();
 
-                // Error icon and message
-                ui.horizontal(|ui| {
-                    ui.label(
-                        egui::RichText::new("⚠")
-                            .size(32.0)
-                            .color(egui::Color32::from_rgb(255, 100, 100)),
-                    );
-                    ui.add_space(12.0);
-                    ui.vertical(|ui| {
-                        ui.label(egui::RichText::new("An error occurred").strong().size(16.0));
-                        ui.add_space(4.0);
-                        ui.label(user_message);
-                    });
-                });
+        // The footer closure may borrow locals, so the pick is a plain `Cell`.
+        let picked: Cell<Option<ErrorModalEvent>> = Cell::new(None);
 
-                ui.add_space(12.0);
-
-                // Recovery suggestion if available
+        let closed = modal.show_with_footer(
+            ui,
+            |ui| {
+                // Recovery hint — design `.sep` + a `.m-body` row of the yellow
+                // lightbulb and the italic suggestion.
                 if let Some(suggestion) = recovery_suggestion {
-                    ui.add(egui::Separator::default());
-                    ui.add_space(8.0);
-                    ui.horizontal(|ui| {
-                        ui.label(egui::RichText::new("💡").size(18.0));
-                        ui.label(
-                            egui::RichText::new(suggestion)
-                                .italics()
-                                .color(ui.visuals().weak_text_color()),
-                        );
-                    });
-                    ui.add_space(8.0);
-                }
-
-                ui.add(egui::Separator::default());
-                ui.add_space(8.0);
-
-                // Buttons based on recovery action
-                ui.horizontal(|ui| {
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        // Close button (always available)
-                        let close_btn = ui.add(
-                            Button::builder()
-                                .label("Close")
-                                .button_type(ButtonType::Elevated)
-                                .color(ButtonColor::Default)
+                    ui.spacing_mut().item_spacing.y = 0.0;
+                    // `.sep`: hairline inset 20px each side — the body padding
+                    // already insets us, so it spans the available width.
+                    ui.add(Separator::rule(color_to_hex(with_alpha(
+                        colors.surface_raised,
+                        77, // surface1@30%
+                    ))));
+                    ui.add_space(13.0); // `.m-body{padding-top:13px}`
+                    ui.horizontal_top(|ui| {
+                        ui.spacing_mut().item_spacing.x = 9.0;
+                        ui.add(
+                            Icon::builder()
+                                .glyph(egui_phosphor::regular::LIGHTBULB)
+                                .color("warning")
+                                .size(17.0)
                                 .build(),
                         );
-                        if close_btn.clicked() {
-                            events.push(ErrorModalEvent::Close);
-                            recovery_action = Some(RecoveryAction::ClearError);
-                        }
-
-                        // Only show Retry button if error is recoverable
-                        if ErrorHandler::is_recoverable(props.error) {
-                            let retry_btn = ui.add(
-                                Button::builder()
-                                    .label("Retry")
-                                    .button_type(ButtonType::Elevated)
-                                    .color(ButtonColor::Danger)
+                        // Labels don't wrap inside a horizontal layout, so the
+                        // copy gets its own strip across the remaining width.
+                        ui.vertical(|ui| {
+                            ui.add(
+                                Typography::builder()
+                                    .text(suggestion)
+                                    .variant(TypographyVariant::Body)
+                                    .size(FONT_BODY)
+                                    .italic(true)
+                                    .color("fg-muted")
                                     .build(),
                             );
-                            if retry_btn.clicked() {
-                                events.push(ErrorModalEvent::Retry);
-                                recovery_action = Some(RecoveryAction::Retry);
-                            }
-                        }
-
-                        // Show Reset button for specific recovery actions
-                        if matches!(action, RecoveryAction::Reset) {
-                            let reset_btn = ui.add(
-                                Button::builder()
-                                    .label("Reset")
-                                    .button_type(ButtonType::Elevated)
-                                    .color(ButtonColor::Danger)
-                                    .build(),
-                            );
-                            if reset_btn.clicked() {
-                                events.push(ErrorModalEvent::Reset);
-                                recovery_action = Some(RecoveryAction::Reset);
-                            }
-                        }
+                        });
                     });
-                });
+                }
+            },
+            // `.m-foot` lays out right-to-left: the recovery actions sit at the
+            // right edge, `Close` to their left.
+            |ui| {
+                // Only offer Retry if the error is recoverable
+                if recoverable
+                    && ui
+                        .add(
+                            Button::builder()
+                                .label("Retry")
+                                .button_type(ButtonType::Elevated)
+                                .color(ButtonColor::Danger)
+                                .build(),
+                        )
+                        .clicked()
+                {
+                    picked.set(Some(ErrorModalEvent::Retry));
+                }
+
+                // Show Reset button for specific recovery actions
+                if resettable
+                    && ui
+                        .add(
+                            Button::builder()
+                                .label("Reset")
+                                .button_type(ButtonType::Elevated)
+                                .color(ButtonColor::Danger)
+                                .build(),
+                        )
+                        .clicked()
+                {
+                    picked.set(Some(ErrorModalEvent::Reset));
+                }
+
+                // Close button (always available)
+                if ui
+                    .add(
+                        Button::builder()
+                            .label("Close")
+                            .button_type(ButtonType::Elevated)
+                            .color(ButtonColor::Default)
+                            .build(),
+                    )
+                    .clicked()
+                {
+                    picked.set(Some(ErrorModalEvent::Close));
+                }
+            },
+        );
+
+        // Escape / backdrop / ✕ dismiss the card the same way `Close` does.
+        let event = picked.get().or(if closed {
+            Some(ErrorModalEvent::Close)
+        } else {
+            None
+        });
+
+        if let Some(event) = event {
+            recovery_action = Some(match event {
+                ErrorModalEvent::Close => RecoveryAction::ClearError,
+                ErrorModalEvent::Retry => RecoveryAction::Retry,
+                ErrorModalEvent::Reset => RecoveryAction::Reset,
             });
+            events.push(event);
+        }
 
         ErrorModalOutput {
             events,

--- a/src/components/error_modal.rs
+++ b/src/components/error_modal.rs
@@ -29,7 +29,11 @@ pub struct ErrorModalOutput {
 
 /// Error modal component - displays errors with recovery options
 #[derive(Default)]
-pub struct ErrorModal;
+pub struct ErrorModal {
+    /// The error already written to the log, so a modal that stays open for
+    /// hundreds of frames logs once instead of once per frame.
+    logged: Option<String>,
+}
 
 impl StatefulComponent for ErrorModal {
     type Props<'a> = ErrorModalProps<'a>;
@@ -40,6 +44,7 @@ impl StatefulComponent for ErrorModal {
         let mut recovery_action = None;
 
         if !props.open {
+            self.logged = None;
             return ErrorModalOutput {
                 events,
                 recovery_action,
@@ -55,8 +60,12 @@ impl StatefulComponent for ErrorModal {
         let recoverable = ErrorHandler::is_recoverable(props.error);
         let resettable = matches!(action, RecoveryAction::Reset);
 
-        // Log the technical error
-        ErrorHandler::log_error(props.error);
+        // Log the technical error once per error instance, not once per frame.
+        let signature = props.error.to_string();
+        if self.logged.as_deref() != Some(signature.as_str()) {
+            ErrorHandler::log_error(props.error);
+            self.logged = Some(signature);
+        }
 
         // The card's head carries the title plus the message as its subtitle
         // (design `.m-head`: `An error occurred` over a `pre-line` detail line).

--- a/src/components/file_viewer/plugin_table_viewer.rs
+++ b/src/components/file_viewer/plugin_table_viewer.rs
@@ -94,30 +94,19 @@ impl FileFormatViewer for PluginTableViewer {
         let num_rows = indices.len();
         let render_cache = &mut self.render_cache;
 
-        TableView::show_rows(ui, &headers, num_rows, None, &mut Vec::new(), move |i| {
-            let idx = indices[i];
+        // Standalone grid — it owns its container fill, edge and corners.
+        TableView::show_rows(
+            ui,
+            &headers,
+            num_rows,
+            None,
+            true,
+            &mut Vec::new(),
+            move |i| {
+                let idx = indices[i];
 
-            match display_mode {
-                DisplayMode::Table => {
-                    let cached = cache.get(&idx).cloned();
-                    let record = match cached {
-                        Some(v) => Some(v),
-                        None => loader.get(idx).ok().inspect(|v| {
-                            cache.put(idx, v.clone());
-                        }),
-                    };
-                    headers_for_closure
-                        .iter()
-                        .map(|h| match record.as_ref().and_then(|v| v.get(h)) {
-                            // Colour each cell by its JSON type, like the tree.
-                            Some(v) => RenderNode::json_cell(v),
-                            None => RenderNode::text(""),
-                        })
-                        .collect()
-                }
-
-                DisplayMode::Custom => {
-                    if let std::collections::hash_map::Entry::Vacant(e) = render_cache.entry(idx) {
+                match display_mode {
+                    DisplayMode::Table => {
                         let cached = cache.get(&idx).cloned();
                         let record = match cached {
                             Some(v) => Some(v),
@@ -125,29 +114,51 @@ impl FileFormatViewer for PluginTableViewer {
                                 cache.put(idx, v.clone());
                             }),
                         };
-                        if let Some(r) = record {
-                            let json = serde_json::to_string(&r).unwrap_or_default();
-                            if let Some(node_json) = loader.render_record(&json) {
-                                e.insert(node_json);
-                            }
-                        }
-                    }
-
-                    if let Some(node_json) = render_cache.get(&idx) {
-                        match serde_json::from_str::<RenderNode>(node_json) {
-                            Ok(RenderNode::Row(row)) => row.children,
-                            Ok(other) => vec![other],
-                            Err(_) => vec![RenderNode::text("—")],
-                        }
-                    } else {
                         headers_for_closure
                             .iter()
-                            .map(|_| RenderNode::text("—"))
+                            .map(|h| match record.as_ref().and_then(|v| v.get(h)) {
+                                // Colour each cell by its JSON type, like the tree.
+                                Some(v) => RenderNode::json_cell(v),
+                                None => RenderNode::text(""),
+                            })
                             .collect()
                     }
+
+                    DisplayMode::Custom => {
+                        if let std::collections::hash_map::Entry::Vacant(e) =
+                            render_cache.entry(idx)
+                        {
+                            let cached = cache.get(&idx).cloned();
+                            let record = match cached {
+                                Some(v) => Some(v),
+                                None => loader.get(idx).ok().inspect(|v| {
+                                    cache.put(idx, v.clone());
+                                }),
+                            };
+                            if let Some(r) = record {
+                                let json = serde_json::to_string(&r).unwrap_or_default();
+                                if let Some(node_json) = loader.render_record(&json) {
+                                    e.insert(node_json);
+                                }
+                            }
+                        }
+
+                        if let Some(node_json) = render_cache.get(&idx) {
+                            match serde_json::from_str::<RenderNode>(node_json) {
+                                Ok(RenderNode::Row(row)) => row.children,
+                                Ok(other) => vec![other],
+                                Err(_) => vec![RenderNode::text("—")],
+                            }
+                        } else {
+                            headers_for_closure
+                                .iter()
+                                .map(|_| RenderNode::text("—"))
+                                .collect()
+                        }
+                    }
                 }
-            }
-        });
+            },
+        );
 
         false
     }

--- a/src/components/marketplace/detail.rs
+++ b/src/components/marketplace/detail.rs
@@ -2,6 +2,7 @@
 // `.dt-head` identity block with its `.dt-actions`, over a `.dt-body` two-column
 // grid of README and `.meta-side` metadata.
 
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use eframe::egui;
@@ -106,13 +107,16 @@ pub(super) fn render(
     ui: &mut egui::Ui,
     plugin: &MarketPlacePlugin,
     install_state: &InstallState,
+    // Icon path resolved once when the manifest loaded — see
+    // `MarketplaceUiState::icon_files`.
+    icon_file: Option<&Path>,
     colors: &ThemeColors,
 ) -> Option<DetailAction> {
     let mut action = None;
 
     egui::Frame::NONE.fill(colors.bg).show(ui, |ui| {
         // Header: fixed above scroll, contains icon + content + actions top-right
-        render_header(ui, plugin, install_state, colors, &mut action);
+        render_header(ui, plugin, install_state, icon_file, colors, &mut action);
 
         // `.dt-head{box-shadow:inset 0 -1px 0 var(--surface)}`
         ui.add(Separator::rule(color_to_hex(colors.surface)));
@@ -195,6 +199,7 @@ fn render_header(
     ui: &mut egui::Ui,
     plugin: &MarketPlacePlugin,
     install_state: &InstallState,
+    icon_file: Option<&Path>,
     colors: &ThemeColors,
     action: &mut Option<DetailAction>,
 ) {
@@ -236,7 +241,7 @@ fn render_header(
                     egui::Layout::left_to_right(egui::Align::TOP),
                     |ui| {
                         ui.spacing_mut().item_spacing.x = 0.0;
-                        render_icon(ui, plugin, colors);
+                        render_icon(ui, plugin, icon_file, colors);
                         ui.add_space(HEAD_GAP);
                         ui.vertical(|ui| render_identity(ui, plugin, install_state, colors));
                     },
@@ -247,16 +252,18 @@ fn render_header(
 
 /// `.dt-icon`: the plugin's own 64px icon, or an accent-tinted tile with its
 /// category glyph.
-fn render_icon(ui: &mut egui::Ui, plugin: &MarketPlacePlugin, colors: &ThemeColors) {
+fn render_icon(
+    ui: &mut egui::Ui,
+    plugin: &MarketPlacePlugin,
+    icon_file: Option<&Path>,
+    colors: &ThemeColors,
+) {
     let (ir, _) = ui.allocate_exact_size(egui::Vec2::splat(ICON_BOX), egui::Sense::hover());
     if !ui.is_rect_visible(ir) {
         return;
     }
 
-    let texture = plugin
-        .get_icon_file(ui.ctx().clone())
-        .ok()
-        .and_then(|p| load_icon_texture(ui.ctx(), &p, "mp_detail_icon"));
+    let texture = icon_file.and_then(|p| load_icon_texture(ui.ctx(), p, "mp_detail_icon"));
 
     if let Some(tex) = texture {
         ui.put(
@@ -690,8 +697,11 @@ fn render_sidebar_meta(ui: &mut egui::Ui, plugin: &MarketPlacePlugin, colors: &T
 
     // `.sha`: mono caption on `--bg-sunken` behind the shared hairline edge.
     if !plugin.sha256.is_empty() {
-        let sha_short = if plugin.sha256.len() > SHA_CHARS {
-            format!("{}…", &plugin.sha256[..SHA_CHARS])
+        // Truncate by characters: the digest comes from the registry manifest,
+        // so byte slicing could land inside a multi-byte character and panic.
+        let sha_short = if plugin.sha256.chars().count() > SHA_CHARS {
+            let head: String = plugin.sha256.chars().take(SHA_CHARS).collect();
+            format!("{head}…")
         } else {
             plugin.sha256.clone()
         };

--- a/src/components/marketplace/detail.rs
+++ b/src/components/marketplace/detail.rs
@@ -1,15 +1,104 @@
+// Marketplace detail — design `screens.html` §3 “Marketplace”, right pane: the
+// `.dt-head` identity block with its `.dt-actions`, over a `.dt-body` two-column
+// grid of README and `.meta-side` metadata.
+
 use std::sync::{Arc, Mutex};
 
 use eframe::egui;
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
 
-use thoth_plugin_sdk::components::{Button, ButtonColor, ButtonSize, Typography};
+use thoth_plugin_sdk::components::{
+    Badge, Button, ButtonColor, ButtonSize, ButtonType, Icon, Progress, Separator, Size, Spinner,
+    Typography, TypographyVariant,
+};
 
 use crate::components::common::helpers::load_icon_texture;
 use crate::plugin::marketplace::MarketPlacePlugin;
-use crate::theme::{ThemeColors, icon_rich_text, phosphor_font_id};
+use crate::theme::{
+    FONT_CAPTION, FONT_CONTROL, RADIUS_CHIP, RADIUS_WINDOW, ThemeColors, color_to_hex, edge_stroke,
+    phosphor_font_id, with_alpha,
+};
 
 use super::state::{DetailAction, InstallState, ReadmeCacheEntry, category_glyph, category_label};
+
+// ── Head — design `.dt-head` ─────────────────────────────────────────────────
+
+/// `.dt-head{padding:20px 26px 16px}`.
+const HEAD_PAD_X: i8 = 26;
+const HEAD_PAD_TOP: i8 = 20;
+const HEAD_PAD_BOTTOM: i8 = 16;
+/// `.dt-head{gap:16px}`.
+const HEAD_GAP: f32 = 16.0;
+/// `.dt-icon{width:64px;height:64px}`.
+const ICON_BOX: f32 = 64.0;
+/// `.dt-icon{font-size:34px}`.
+const ICON_GLYPH: f32 = 34.0;
+/// `.dt-icon{background:color-mix(accent 16%,transparent)}`.
+const ICON_TINT_ALPHA: u8 = 41; // 16% of 255
+/// `.dt-nm{font-size:22px;font-weight:700}`.
+const NAME_FONT: f32 = 22.0;
+/// `.dt-t{gap:10px}`.
+const TITLE_GAP: f32 = 10.0;
+/// `.dt-v{font-family:var(--mono);font-size:13px}`.
+const VERSION_FONT: f32 = 13.0;
+/// `.dt-desc{margin-top:7px}`.
+const DESC_TOP: f32 = 7.0;
+/// `.dt-meta-inline{margin-top:9px}`.
+const META_TOP: f32 = 9.0;
+/// `.dt-meta-inline{gap:16px}` between the author and category groups.
+const META_GAP: f32 = 16.0;
+/// `.dt-meta-inline i{margin-right:5px}`.
+const META_ICON_GAP: f32 = 5.0;
+/// `.dt-actions{gap:8px}`.
+const ACTIONS_GAP: f32 = 8.0;
+
+// ── Body — design `.dt-body` ─────────────────────────────────────────────────
+
+/// `.dt-body{padding:20px 26px}`.
+const BODY_PAD_X: i8 = 26;
+const BODY_PAD_Y: i8 = 20;
+/// `.dt-body{grid-template-columns:1fr 220px}`.
+const SIDEBAR_W: f32 = 220.0;
+/// `.dt-body{gap:28px}`.
+const BODY_GAP: f32 = 28.0;
+/// The README column never grows past a comfortable measure.
+const README_MAX_W: f32 = 760.0;
+
+// ── Metadata side — design `.meta-side` ──────────────────────────────────────
+
+/// `.meta-side .mf{margin-bottom:13px}`.
+const META_FIELD_GAP: f32 = 13.0;
+/// `.meta-side .ml{font-size:10px;font-weight:700;text-transform:uppercase}`.
+const META_LABEL_FONT: f32 = 10.0;
+/// `.meta-side .ml{margin-bottom:3px}`.
+const META_LABEL_GAP: f32 = 3.0;
+/// `.meta-side .mv.mono{font-size:11.5px}` — the caption rung of the type scale.
+const META_MONO_FONT: f32 = FONT_CAPTION;
+/// `.meta-side .sha{padding:6px 8px}`.
+const SHA_PAD_X: i8 = 8;
+const SHA_PAD_Y: i8 = 6;
+/// How much of the digest the field shows before eliding it.
+const SHA_CHARS: usize = 32;
+
+// ── Banners (no sheet counterpart — Thoth-only install feedback) ─────────────
+
+/// Tint behind a banner — the sheet's 8% status wash.
+const BANNER_TINT_ALPHA: u8 = 20; // 8% of 255
+/// …and the hairline under it, at the `--edge` 34%.
+const BANNER_RULE_ALPHA: u8 = 87; // 34% of 255
+/// Banner padding, aligned with `.dt-head`'s side gutter.
+const BANNER_PAD_Y: i8 = 10;
+/// Gap between a banner's icon and its text.
+const BANNER_GAP: f32 = 10.0;
+
+// ── Empty state (no sheet counterpart) ───────────────────────────────────────
+
+/// Placeholder glyph size.
+const EMPTY_GLYPH: f32 = 48.0;
+/// Space above the placeholder glyph.
+const EMPTY_TOP: f32 = 80.0;
+/// Space under it, and under the heading.
+const EMPTY_GAP: f32 = 16.0;
 
 // ── Entry points ──────────────────────────────────────────────────────────────
 
@@ -25,10 +114,8 @@ pub(super) fn render(
         // Header: fixed above scroll, contains icon + content + actions top-right
         render_header(ui, plugin, install_state, colors, &mut action);
 
-        // 1px border-bottom beneath header
-        let (line_rect, _) =
-            ui.allocate_exact_size(egui::vec2(ui.available_width(), 1.0), egui::Sense::hover());
-        ui.painter().rect_filled(line_rect, 0.0, colors.surface);
+        // `.dt-head{box-shadow:inset 0 -1px 0 var(--surface)}`
+        ui.add(Separator::rule(color_to_hex(colors.surface)));
 
         // Banners (between header and scroll content)
         if let InstallState::Failed(msg) = install_state {
@@ -38,32 +125,31 @@ pub(super) fn render(
             render_banner_installing(ui, plugin, *progress, colors);
         }
 
-        // Two-column scroll area
+        // `.dt-body{display:grid;grid-template-columns:1fr 220px;gap:28px}`
         egui::ScrollArea::both()
             .id_salt("mp_detail_scroll")
             .show(ui, |ui| {
                 let avail = ui.available_width();
-                let sidebar_w = 220.0_f32;
-                let gap = 28.0_f32;
-                let h_pad = 28.0_f32;
-                let readme_w = (avail - sidebar_w - gap - h_pad * 2.0).clamp(100.0, 760.0);
+                let readme_w = (avail - SIDEBAR_W - BODY_GAP - f32::from(BODY_PAD_X) * 2.0)
+                    .clamp(100.0, README_MAX_W);
 
                 egui::Frame::NONE
                     .inner_margin(egui::Margin {
-                        left: 28,
-                        right: 28,
-                        top: 20,
-                        bottom: 20,
+                        left: BODY_PAD_X,
+                        right: BODY_PAD_X,
+                        top: BODY_PAD_Y,
+                        bottom: BODY_PAD_Y,
                     })
                     .show(ui, |ui| {
                         ui.horizontal_top(|ui| {
+                            ui.spacing_mut().item_spacing.x = 0.0;
                             ui.vertical(|ui| {
                                 ui.set_width(readme_w);
                                 render_readme(ui, plugin, colors);
                             });
-                            ui.add_space(gap);
+                            ui.add_space(BODY_GAP);
                             ui.vertical(|ui| {
-                                ui.set_width(sidebar_w);
+                                ui.set_width(SIDEBAR_W);
                                 render_sidebar_meta(ui, plugin, colors);
                             });
                         });
@@ -75,34 +161,35 @@ pub(super) fn render(
 }
 
 pub(super) fn render_empty(ui: &mut egui::Ui, colors: &ThemeColors) {
-    egui::Frame::NONE
-        .fill(colors.bg)
-        .show(ui, |ui| {
-            ui.set_min_size(ui.available_size());
-            ui.centered_and_justified(|ui| {
-                ui.vertical_centered(|ui| {
-                    ui.add_space(80.0);
-                    ui.label(
-                        egui::RichText::new(egui_phosphor::regular::PUZZLE_PIECE)
-                            .font(phosphor_font_id(48.0))
-                            .color(colors.surface_active),
-                    );
-                    ui.add_space(16.0);
-                    Typography::heading(ui, "Plugin Store");
-                    ui.add_space(8.0);
-                    ui.label(
-                        egui::RichText::new(
+    egui::Frame::NONE.fill(colors.bg).show(ui, |ui| {
+        ui.set_min_size(ui.available_size());
+        ui.centered_and_justified(|ui| {
+            ui.vertical_centered(|ui| {
+                ui.add_space(EMPTY_TOP);
+                ui.add(
+                    Icon::builder()
+                        .glyph(egui_phosphor::regular::PUZZLE_PIECE)
+                        .size(EMPTY_GLYPH)
+                        .color(color_to_hex(colors.surface_active))
+                        .build(),
+                );
+                ui.add_space(EMPTY_GAP);
+                Typography::heading(ui, "Plugin Store");
+                ui.add_space(ACTIONS_GAP);
+                ui.add(
+                    Typography::builder()
+                        .text(
                             "Select a plugin from the list to see its details and install options.\nPlugins extend Thoth with themes, formatters, validators, and integrations.",
                         )
-                        .size(13.0)
-                        .color(colors.fg_muted),
-                    );
-                });
+                        .variant(TypographyVariant::Subtitle)
+                        .build(),
+                );
             });
         });
+    });
 }
 
-// ── Header ────────────────────────────────────────────────────────────────────
+// ── Head ──────────────────────────────────────────────────────────────────────
 
 fn render_header(
     ui: &mut egui::Ui,
@@ -113,355 +200,302 @@ fn render_header(
 ) {
     egui::Frame::NONE
         .inner_margin(egui::Margin {
-            left: 28,
-            right: 28,
-            top: 20,
-            bottom: 16,
+            left: HEAD_PAD_X,
+            right: HEAD_PAD_X,
+            top: HEAD_PAD_TOP,
+            bottom: HEAD_PAD_BOTTOM,
         })
         .show(ui, |ui| {
-            ui.horizontal_top(|ui| {
-                // 64×64 icon — real image if downloaded, otherwise glyph tile
-                let (ir, _) = ui.allocate_exact_size(egui::vec2(64.0, 64.0), egui::Sense::hover());
-                if ui.is_rect_visible(ir) {
-                    let icon_path = plugin.get_icon_file(ui.ctx().clone()).ok();
-                    let texture = icon_path
-                        .as_deref()
-                        .and_then(|p| load_icon_texture(ui.ctx(), p, "mp_detail_icon"));
+            // `.dt-actions{margin-left:auto}` — the buttons are laid out first so
+            // they keep their natural width and the identity block takes the rest,
+            // exactly as the CSS grid does. `Align::TOP` (not `Center`) so the row
+            // stays as tall as its content instead of centring in the pane.
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+                // Every gap in the row is explicit.
+                ui.spacing_mut().item_spacing.x = 0.0;
 
-                    if let Some(tex) = texture {
-                        ui.put(
-                            ir,
-                            egui::Image::new(&tex)
-                                .fit_to_exact_size(ir.size())
-                                .corner_radius(egui::CornerRadius::same(8)),
-                        );
-                    } else {
-                        // Fallback: accent-tinted rounded tile with category glyph
-                        ui.painter().rect_filled(
-                            ir,
-                            6.0,
-                            egui::Color32::from_rgba_unmultiplied(
-                                colors.accent.r(),
-                                colors.accent.g(),
-                                colors.accent.b(),
-                                0x33,
-                            ),
-                        );
-                        ui.painter().rect_stroke(
-                            ir,
-                            6.0,
-                            egui::Stroke::new(
-                                1.0,
-                                egui::Color32::from_rgba_unmultiplied(
-                                    colors.accent.r(),
-                                    colors.accent.g(),
-                                    colors.accent.b(),
-                                    0x55,
-                                ),
-                            ),
-                            egui::StrokeKind::Middle,
-                        );
-                        let cap_glyph = plugin
-                            .categories
-                            .first()
-                            .map(|c| category_glyph(c))
-                            .unwrap_or(egui_phosphor::regular::PUZZLE_PIECE);
-                        ui.painter().text(
-                            ir.center(),
-                            egui::Align2::CENTER_CENTER,
-                            cap_glyph,
-                            phosphor_font_id(36.0),
-                            colors.accent,
-                        );
+                // Right-to-left, so the design order is added back-to-front.
+                for (i, (button, act)) in
+                    action_buttons(install_state).into_iter().rev().enumerate()
+                {
+                    if i > 0 {
+                        ui.add_space(ACTIONS_GAP);
+                    }
+                    if ui.add(button).clicked() {
+                        *action = Some(act);
                     }
                 }
+                ui.add_space(HEAD_GAP);
 
-                ui.add_space(16.0);
-
-                // Reserve enough for the widest action combo (Disable + Uninstall ≈ 155px).
-                let actions_w = 160.0_f32;
-                let content_w = (ui.available_width() - actions_w).max(80.0);
-
-                // Content column (explicit width so available_width() is correct inside)
+                // `.dt-icon` + `.dt-main` fill what is left of the row. The
+                // height is only a hint — the block is allocated at whatever its
+                // content measures, so a long description still fits.
+                let rest = ui.available_width();
                 ui.allocate_ui_with_layout(
-                    egui::vec2(content_w, 200.0),
-                    egui::Layout::top_down(egui::Align::Min),
+                    egui::vec2(rest, ICON_BOX),
+                    egui::Layout::left_to_right(egui::Align::TOP),
                     |ui| {
-                        // Row 1: name · version · state badge
-                        ui.horizontal_wrapped(|ui| {
-                            ui.spacing_mut().item_spacing.x = 10.0;
-                            ui.add(
-                                Typography::builder()
-                                    .text(&plugin.name)
-                                    .bold(true)
-                                    .size(22.0)
-                                    .build(),
-                            );
-                            ui.label(
-                                egui::RichText::new(format!("v{}", plugin.version))
-                                    .size(13.0)
-                                    .monospace()
-                                    .color(colors.fg_muted),
-                            );
-                            state_badge(ui, install_state, colors);
-                        });
-
-                        ui.add_space(4.0);
-
-                        // Description
-                        ui.label(
-                            egui::RichText::new(&plugin.description)
-                                .size(13.0)
-                                .color(colors.fg_muted),
-                        );
-
-                        ui.add_space(10.0);
-
-                        // Metadata row: author  ·  categories
-                        // Each item is an icon+text group; 16px between groups.
-                        ui.horizontal_wrapped(|ui| {
-                            ui.spacing_mut().item_spacing = egui::vec2(16.0, 4.0);
-
-                            ui.horizontal(|ui| {
-                                ui.spacing_mut().item_spacing.x = 4.0;
-                                ui.label(
-                                    icon_rich_text(egui_phosphor::regular::USER, 11.0)
-                                        .color(colors.fg_muted),
-                                );
-                                ui.label(
-                                    egui::RichText::new(&plugin.author)
-                                        .size(11.0)
-                                        .color(colors.fg_muted),
-                                );
-                            });
-
-                            if !plugin.categories.is_empty() {
-                                let cats = plugin
-                                    .categories
-                                    .iter()
-                                    .map(|c| category_label(c))
-                                    .collect::<Vec<_>>()
-                                    .join(", ");
-                                ui.horizontal(|ui| {
-                                    ui.spacing_mut().item_spacing.x = 4.0;
-                                    ui.label(
-                                        icon_rich_text(egui_phosphor::regular::FOLDER, 11.0)
-                                            .color(colors.fg_muted),
-                                    );
-                                    ui.label(
-                                        egui::RichText::new(cats).size(11.0).color(colors.fg_muted),
-                                    );
-                                });
-                            }
-                        });
+                        ui.spacing_mut().item_spacing.x = 0.0;
+                        render_icon(ui, plugin, colors);
+                        ui.add_space(HEAD_GAP);
+                        ui.vertical(|ui| render_identity(ui, plugin, install_state, colors));
                     },
                 );
-
-                // Actions — right_to_left fills the remaining space and anchors
-                // the buttons to the right edge (no vertical wrapper, which would
-                // expand to full width and push buttons back to the left).
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-                    render_action_buttons(ui, install_state, colors, action);
-                });
             });
         });
 }
 
-fn state_badge(ui: &mut egui::Ui, install_state: &InstallState, colors: &ThemeColors) {
-    let (text, icon, color): (&str, &str, egui::Color32) = match install_state {
-        InstallState::Installed => (
-            "Installed",
-            egui_phosphor::regular::CHECK_CIRCLE,
-            colors.success,
-        ),
-        InstallState::Disabled => (
-            "Disabled",
-            egui_phosphor::regular::PAUSE_CIRCLE,
-            colors.fg_muted,
-        ),
-        InstallState::Installing(_) => (
-            "Installing",
-            egui_phosphor::regular::ARROW_CLOCKWISE,
-            colors.info,
-        ),
-        InstallState::Failed(_) => ("Failed", egui_phosphor::regular::WARNING, colors.error),
-        InstallState::NotInstalled => return,
-        InstallState::Update => (
-            "Update",
-            egui_phosphor::regular::UPLOAD,
-            colors.accent_secondary,
-        ),
-    };
-    ui.horizontal(|ui| {
-        ui.spacing_mut().item_spacing.x = 3.0;
-        ui.label(icon_rich_text(icon, 11.0).color(color));
-        ui.label(egui::RichText::new(text).size(11.0).color(color));
+/// `.dt-icon`: the plugin's own 64px icon, or an accent-tinted tile with its
+/// category glyph.
+fn render_icon(ui: &mut egui::Ui, plugin: &MarketPlacePlugin, colors: &ThemeColors) {
+    let (ir, _) = ui.allocate_exact_size(egui::Vec2::splat(ICON_BOX), egui::Sense::hover());
+    if !ui.is_rect_visible(ir) {
+        return;
+    }
+
+    let texture = plugin
+        .get_icon_file(ui.ctx().clone())
+        .ok()
+        .and_then(|p| load_icon_texture(ui.ctx(), &p, "mp_detail_icon"));
+
+    if let Some(tex) = texture {
+        ui.put(
+            ir,
+            egui::Image::new(&tex)
+                .fit_to_exact_size(ir.size())
+                .corner_radius(egui::CornerRadius::from(RADIUS_WINDOW)),
+        );
+        return;
+    }
+
+    ui.painter().rect_filled(
+        ir,
+        egui::CornerRadius::from(RADIUS_WINDOW),
+        with_alpha(colors.accent, ICON_TINT_ALPHA),
+    );
+    let cap_glyph = plugin
+        .categories
+        .first()
+        .map(|c| category_glyph(c))
+        .unwrap_or(egui_phosphor::regular::PUZZLE_PIECE);
+    ui.painter().text(
+        ir.center(),
+        egui::Align2::CENTER_CENTER,
+        cap_glyph,
+        phosphor_font_id(ICON_GLYPH),
+        colors.accent,
+    );
+}
+
+/// `.dt-main`: name · version · state badge, the description, then the inline
+/// author / categories metadata.
+fn render_identity(
+    ui: &mut egui::Ui,
+    plugin: &MarketPlacePlugin,
+    install_state: &InstallState,
+    colors: &ThemeColors,
+) {
+    // `.dt-t{display:flex;align-items:center;gap:10px;flex-wrap:wrap}`
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing.x = TITLE_GAP;
+        ui.add(
+            Typography::builder()
+                .text(&plugin.name)
+                .variant(TypographyVariant::Heading)
+                .size(NAME_FONT)
+                .bold(true)
+                .build(),
+        );
+        ui.add(
+            Typography::builder()
+                .text(format!("v{}", plugin.version))
+                .variant(TypographyVariant::Mono)
+                .color(color_to_hex(colors.fg_muted))
+                .size(VERSION_FONT)
+                .build(),
+        );
+        state_badge(ui, install_state, colors);
+    });
+
+    // `.dt-desc{font-size:13px;color:var(--fg-muted);margin-top:7px}`
+    ui.add_space(DESC_TOP);
+    ui.add(
+        Typography::builder()
+            .text(&plugin.description)
+            .variant(TypographyVariant::Subtitle)
+            .build(),
+    );
+
+    // `.dt-meta-inline`: author and categories, each an icon + caption group.
+    ui.add_space(META_TOP);
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing = egui::vec2(META_GAP, META_ICON_GAP);
+        meta_inline(ui, egui_phosphor::regular::USER, &plugin.author, colors);
+        if !plugin.categories.is_empty() {
+            let cats = plugin
+                .categories
+                .iter()
+                .map(|c| category_label(c))
+                .collect::<Vec<_>>()
+                .join(", ");
+            meta_inline(ui, egui_phosphor::regular::FOLDER, &cats, colors);
+        }
     });
 }
 
-// ── Action buttons (inside header, top-right) ─────────────────────────────────
+/// One `.dt-meta-inline` group: a caption-sized glyph, 5px, then the value.
+fn meta_inline(ui: &mut egui::Ui, glyph: &str, text: &str, colors: &ThemeColors) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 0.0;
+        ui.add(
+            Icon::builder()
+                .glyph(glyph)
+                .size(FONT_CAPTION)
+                .color(color_to_hex(colors.fg_muted))
+                .build(),
+        );
+        ui.add_space(META_ICON_GAP);
+        Typography::caption(ui, text);
+    });
+}
 
-fn render_action_buttons(
-    ui: &mut egui::Ui,
-    install_state: &InstallState,
-    colors: &ThemeColors,
-    action: &mut Option<DetailAction>,
-) {
-    let _ = colors;
+/// `.dt-badge`: a fully-round soft status pill — an 18% wash of the status colour
+/// behind a leading glyph and an 11px proportional label
+/// (`<i class="ph ph-check-circle"></i>Installed`).
+fn state_badge(ui: &mut egui::Ui, install_state: &InstallState, colors: &ThemeColors) {
+    let (text, color, glyph): (&str, egui::Color32, &str) = match install_state {
+        InstallState::Installed => (
+            "Installed",
+            colors.success,
+            egui_phosphor::regular::CHECK_CIRCLE,
+        ),
+        InstallState::Disabled => (
+            "Disabled",
+            colors.fg_muted,
+            egui_phosphor::regular::PAUSE_CIRCLE,
+        ),
+        InstallState::Installing(_) => (
+            "Installing",
+            colors.info,
+            egui_phosphor::regular::ARROW_CIRCLE_DOWN,
+        ),
+        InstallState::Failed(_) => (
+            "Failed",
+            colors.error,
+            egui_phosphor::regular::WARNING_CIRCLE,
+        ),
+        InstallState::NotInstalled => return,
+        InstallState::Update => (
+            "Update",
+            colors.accent_secondary,
+            egui_phosphor::regular::ARROW_CIRCLE_UP,
+        ),
+    };
+    ui.add(
+        Badge::builder()
+            .label(text)
+            .icon(glyph)
+            .color(color_to_hex(color))
+            .soft(true)
+            .pill(true)
+            // The label is prose in the body family, not a code token.
+            .mono(false)
+            .size(Size::Large)
+            .font_size(FONT_CAPTION)
+            .build(),
+    );
+}
+
+// ── Action buttons (inside the head, top-right) ───────────────────────────────
+
+/// The `.dt-actions` buttons for a state, in design (left-to-right) order.
+///
+/// The semantic hues are deliberate: `Uninstall` is destructive and irreversible
+/// so it carries the error hue, but `Soft` keeps it a red-labelled wash rather
+/// than a solid red slab shouting over the button beside it; `Disable` is
+/// cautionary but reversible, so it takes the warning hue as a soft tint; and
+/// `Enable` is the call to action for a disabled plugin, so it stays solid
+/// accent.
+fn action_buttons(install_state: &InstallState) -> Vec<(Button, DetailAction)> {
+    let uninstall = || {
+        (
+            Button::builder()
+                .label("Uninstall")
+                .color(ButtonColor::Danger)
+                .button_type(ButtonType::Soft)
+                .icon(egui_phosphor::regular::TRASH)
+                .button_size(ButtonSize::Medium)
+                .build(),
+            DetailAction::Uninstall,
+        )
+    };
+    let disable = || {
+        (
+            Button::builder()
+                .label("Disable")
+                .color(ButtonColor::Warning)
+                .button_type(ButtonType::Soft)
+                .icon(egui_phosphor::regular::PAUSE)
+                .button_size(ButtonSize::Medium)
+                .build(),
+            DetailAction::Disable,
+        )
+    };
+    let update = || {
+        (
+            Button::builder()
+                .label("Update")
+                .color(ButtonColor::Primary)
+                .icon(egui_phosphor::regular::UPLOAD)
+                .button_size(ButtonSize::Medium)
+                .build(),
+            DetailAction::Install,
+        )
+    };
+
     match install_state {
-        InstallState::NotInstalled => {
-            if ui
-                .add(
-                    Button::builder()
-                        .label("Install")
-                        .color(ButtonColor::Primary)
-                        .icon(egui_phosphor::regular::DOWNLOAD_SIMPLE)
-                        .button_size(ButtonSize::Small)
-                        .build(),
-                )
-                .clicked()
-            {
-                *action = Some(DetailAction::Install);
-            }
-        }
-
-        InstallState::Installed => {
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 6.0;
-                if ui
-                    .add(
-                        Button::builder()
-                            .label("Disable")
-                            .color(ButtonColor::Default)
-                            .button_size(ButtonSize::Small)
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    *action = Some(DetailAction::Disable);
-                }
-                if ui
-                    .add(
-                        Button::builder()
-                            .label("Uninstall")
-                            .color(ButtonColor::Default)
-                            .icon(egui_phosphor::regular::TRASH)
-                            .button_size(ButtonSize::Small)
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    *action = Some(DetailAction::Uninstall);
-                }
-            });
-        }
-
-        InstallState::Disabled => {
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 6.0;
-                if ui
-                    .add(
-                        Button::builder()
-                            .label("Enable")
-                            .color(ButtonColor::Primary)
-                            .icon(egui_phosphor::regular::PLAY)
-                            .button_size(ButtonSize::Small)
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    *action = Some(DetailAction::Enable);
-                }
-                if ui
-                    .add(
-                        Button::builder()
-                            .label("Uninstall")
-                            .color(ButtonColor::Default)
-                            .icon(egui_phosphor::regular::TRASH)
-                            .button_size(ButtonSize::Small)
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    *action = Some(DetailAction::Uninstall);
-                }
-            });
-        }
-
-        InstallState::Installing(_) => {
-            if ui
-                .add(
-                    Button::builder()
-                        .label("Cancel")
-                        .color(ButtonColor::Default)
-                        .icon(egui_phosphor::regular::X)
-                        .button_size(ButtonSize::Small)
-                        .build(),
-                )
-                .clicked()
-            {
-                *action = Some(DetailAction::Retry); // reuse as cancel signal
-            }
-        }
-
-        InstallState::Failed(_) => {
-            if ui
-                .add(
-                    Button::builder()
-                        .label("Retry install")
-                        .color(ButtonColor::Danger)
-                        .icon(egui_phosphor::regular::ARROW_CLOCKWISE)
-                        .button_size(ButtonSize::Small)
-                        .build(),
-                )
-                .clicked()
-            {
-                *action = Some(DetailAction::Retry);
-            }
-        }
-        InstallState::Update => {
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 6.0;
-                if ui
-                    .add(
-                        Button::builder()
-                            .label("Update")
-                            .color(ButtonColor::Secondary)
-                            .icon(egui_phosphor::regular::UPLOAD)
-                            .button_size(ButtonSize::Small)
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    *action = Some(DetailAction::Install);
-                }
-                if ui
-                    .add(
-                        Button::builder()
-                            .label("Disable")
-                            .color(ButtonColor::Default)
-                            .button_size(ButtonSize::Small)
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    *action = Some(DetailAction::Disable);
-                }
-                if ui
-                    .add(
-                        Button::builder()
-                            .label("Uninstall")
-                            .color(ButtonColor::Default)
-                            .icon(egui_phosphor::regular::TRASH)
-                            .button_size(ButtonSize::Small)
-                            .build(),
-                    )
-                    .clicked()
-                {
-                    *action = Some(DetailAction::Uninstall);
-                }
-            });
-        }
+        InstallState::NotInstalled => vec![(
+            Button::builder()
+                .label("Install")
+                .color(ButtonColor::Primary)
+                .icon(egui_phosphor::regular::DOWNLOAD_SIMPLE)
+                .button_size(ButtonSize::Medium)
+                .build(),
+            DetailAction::Install,
+        )],
+        InstallState::Installed => vec![disable(), uninstall()],
+        InstallState::Disabled => vec![
+            (
+                Button::builder()
+                    .label("Enable")
+                    .color(ButtonColor::Primary)
+                    .icon(egui_phosphor::regular::PLAY)
+                    .button_size(ButtonSize::Medium)
+                    .build(),
+                DetailAction::Enable,
+            ),
+            uninstall(),
+        ],
+        // `Retry` doubles as the cancel signal for an in-flight install.
+        InstallState::Installing(_) => vec![(
+            Button::builder()
+                .label("Cancel")
+                .color(ButtonColor::Default)
+                .icon(egui_phosphor::regular::X)
+                .button_size(ButtonSize::Medium)
+                .build(),
+            DetailAction::Retry,
+        )],
+        InstallState::Failed(_) => vec![(
+            Button::builder()
+                .label("Retry install")
+                .color(ButtonColor::Danger)
+                .icon(egui_phosphor::regular::ARROW_CLOCKWISE)
+                .button_size(ButtonSize::Medium)
+                .build(),
+            DetailAction::Retry,
+        )],
+        InstallState::Update => vec![update(), disable(), uninstall()],
     }
 }
 
@@ -474,31 +508,34 @@ fn render_banner_error(
     action: &mut Option<DetailAction>,
 ) {
     let err = colors.error;
-    let bg = egui::Color32::from_rgba_unmultiplied(err.r(), err.g(), err.b(), 0x15);
-    let border = egui::Color32::from_rgba_unmultiplied(err.r(), err.g(), err.b(), 0x55);
 
     egui::Frame::NONE
-        .fill(bg)
+        .fill(with_alpha(err, BANNER_TINT_ALPHA))
         .inner_margin(egui::Margin {
-            left: 28,
-            right: 28,
-            top: 10,
-            bottom: 10,
+            left: HEAD_PAD_X,
+            right: HEAD_PAD_X,
+            top: BANNER_PAD_Y,
+            bottom: BANNER_PAD_Y,
         })
         .show(ui, |ui| {
             ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 10.0;
-                ui.label(icon_rich_text(egui_phosphor::regular::WARNING, 16.0).color(err));
+                ui.spacing_mut().item_spacing.x = BANNER_GAP;
+                ui.add(
+                    Icon::builder()
+                        .glyph(egui_phosphor::regular::WARNING)
+                        .size(HEAD_GAP)
+                        .color(color_to_hex(err))
+                        .build(),
+                );
                 ui.vertical(|ui| {
                     ui.add(
                         Typography::builder()
                             .text("Install failed")
                             .bold(true)
-                            .color(thoth_plugin_sdk::theme::color_to_hex(err))
+                            .color(color_to_hex(err))
                             .build(),
                     );
-                    ui.add_space(2.0);
-                    ui.label(egui::RichText::new(msg).size(12.0).color(colors.fg_muted));
+                    Typography::body_muted(ui, msg);
                 });
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     if ui
@@ -517,10 +554,7 @@ fn render_banner_error(
                 });
             });
         });
-    // Bottom border
-    let (line, _) =
-        ui.allocate_exact_size(egui::vec2(ui.available_width(), 1.0), egui::Sense::hover());
-    ui.painter().rect_filled(line, 0.0, border);
+    banner_rule(ui, with_alpha(err, BANNER_RULE_ALPHA));
 }
 
 fn render_banner_installing(
@@ -530,45 +564,36 @@ fn render_banner_installing(
     colors: &ThemeColors,
 ) {
     let inf = colors.info;
-    let bg = egui::Color32::from_rgba_unmultiplied(inf.r(), inf.g(), inf.b(), 0x10);
-    let border = egui::Color32::from_rgba_unmultiplied(inf.r(), inf.g(), inf.b(), 0x55);
 
     egui::Frame::NONE
-        .fill(bg)
+        .fill(with_alpha(inf, BANNER_TINT_ALPHA))
         .inner_margin(egui::Margin {
-            left: 28,
-            right: 28,
-            top: 10,
-            bottom: 10,
+            left: HEAD_PAD_X,
+            right: HEAD_PAD_X,
+            top: BANNER_PAD_Y,
+            bottom: BANNER_PAD_Y,
         })
         .show(ui, |ui| {
             ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 10.0;
-                ui.label(icon_rich_text(egui_phosphor::regular::ARROW_CLOCKWISE, 14.0).color(inf));
+                ui.spacing_mut().item_spacing.x = BANNER_GAP;
+                ui.add(Spinner::builder().size(FONT_CONTROL).build());
                 Typography::bold(ui, &format!("Installing {}…", plugin.name));
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    ui.label(
-                        egui::RichText::new(format!("{}%", progress))
-                            .size(11.0)
-                            .monospace()
-                            .color(colors.fg_muted),
-                    );
-                });
             });
-            ui.add_space(6.0);
-            let bar_w = ui.available_width();
-            let (track, _) = ui.allocate_exact_size(egui::vec2(bar_w, 4.0), egui::Sense::hover());
-            ui.painter().rect_filled(track, 2.0, colors.surface);
-            let fill = egui::Rect::from_min_size(
-                track.min,
-                egui::vec2(track.width() * (progress as f32 / 100.0), 4.0),
+            ui.add_space(META_ICON_GAP);
+            ui.add(
+                Progress::builder()
+                    .value(f64::from(progress) / 100.0)
+                    .color(color_to_hex(inf))
+                    .readout(format!("{progress}%"))
+                    .build(),
             );
-            ui.painter().rect_filled(fill, 2.0, inf);
         });
-    // Bottom border
-    let (line, _) =
-        ui.allocate_exact_size(egui::vec2(ui.available_width(), 1.0), egui::Sense::hover());
-    ui.painter().rect_filled(line, 0.0, border);
+    banner_rule(ui, with_alpha(inf, BANNER_RULE_ALPHA));
+}
+
+/// The hairline closing a banner off from the content under it.
+fn banner_rule(ui: &mut egui::Ui, color: egui::Color32) {
+    ui.add(Separator::rule(color_to_hex(color)));
 }
 
 // ── README (left column) ──────────────────────────────────────────────────────
@@ -583,6 +608,9 @@ fn render_readme(ui: &mut egui::Ui, plugin: &MarketPlacePlugin, colors: &ThemeCo
 
     match (&entry.content, &entry.error, entry.pending.is_some()) {
         (Some(text), _, _) => {
+            // The SDK's `Markdown` builds a fresh `CommonMarkCache` per call,
+            // which would re-parse a long README every frame — so the viewer is
+            // driven directly off a cache kept in egui memory.
             let cache_id = egui::Id::new("mp_readme_md_cache");
             let cache_arc = ui.ctx().data_mut(|d| {
                 d.get_temp::<Arc<Mutex<CommonMarkCache>>>(cache_id)
@@ -598,101 +626,106 @@ fn render_readme(ui: &mut egui::Ui, plugin: &MarketPlacePlugin, colors: &ThemeCo
             ui.ctx().data_mut(|d| d.insert_temp(cache_id, cache_arc));
         }
         (_, Some(err), _) => {
-            ui.label(
-                egui::RichText::new(format!("Failed to load README: {err}"))
-                    .size(12.0)
-                    .color(colors.fg_muted),
-            );
+            Typography::body_muted(ui, &format!("Failed to load README: {err}"));
         }
         _ => {
             ui.horizontal(|ui| {
-                ui.spinner();
-                ui.label(
-                    egui::RichText::new("Loading README…")
-                        .size(12.0)
-                        .color(colors.fg_muted),
-                );
+                ui.spacing_mut().item_spacing.x = BANNER_GAP;
+                ui.add(Spinner::builder().build());
+                Typography::body_muted(ui, "Loading README…");
             });
         }
     }
 }
 
-// ── Sidebar metadata (right column, 220 px) ───────────────────────────────────
+// ── Metadata side (right column, 220 px) ──────────────────────────────────────
 
 fn render_sidebar_meta(ui: &mut egui::Ui, plugin: &MarketPlacePlugin, colors: &ThemeColors) {
-    // Identifier
-    meta_label(ui, "Identifier");
-    ui.label(
-        egui::RichText::new(&plugin.id)
-            .size(12.0)
-            .monospace()
-            .color(colors.fg),
-    );
-    ui.add_space(14.0);
+    // `.mv.mono` — identifier and version.
+    meta_field(ui, "Identifier", |ui| {
+        ui.add(
+            Typography::builder()
+                .text(&plugin.id)
+                .variant(TypographyVariant::Mono)
+                .size(META_MONO_FONT)
+                .build(),
+        );
+    });
+    meta_field(ui, "Version", |ui| {
+        ui.add(
+            Typography::builder()
+                .text(&plugin.version)
+                .variant(TypographyVariant::Mono)
+                .size(META_MONO_FONT)
+                .build(),
+        );
+    });
 
-    // Version
-    meta_label(ui, "Version");
-    ui.label(
-        egui::RichText::new(&plugin.version)
-            .size(12.0)
-            .monospace()
-            .color(colors.fg),
-    );
-    ui.add_space(14.0);
+    // `.mv{font-size:12.5px;color:var(--fg)}`
+    meta_field(ui, "Author", |ui| {
+        ui.add(
+            Typography::builder()
+                .text(&plugin.author)
+                .size(FONT_CONTROL)
+                .build(),
+        );
+    });
 
-    // Author
-    meta_label(ui, "Author");
-    ui.label(
-        egui::RichText::new(&plugin.author)
-            .size(12.0)
-            .color(colors.fg),
-    );
-    ui.add_space(14.0);
-
-    // Repository
+    // `.mv.link{color:var(--accent2)}`
     if !plugin.repo_url.is_empty() {
-        meta_label(ui, "Repository");
-        if ui
-            .link(
-                egui::RichText::new(plugin.repo_url.trim_start_matches("https://"))
-                    .size(12.0)
-                    .color(colors.accent),
-            )
-            .clicked()
-        {
-            ui.ctx()
-                .open_url(egui::OpenUrl::new_tab(plugin.repo_url.clone()));
-        };
-        ui.add_space(14.0);
+        meta_field(ui, "Repository", |ui| {
+            if ui
+                .link(
+                    egui::RichText::new(plugin.repo_url.trim_start_matches("https://"))
+                        .size(FONT_CONTROL)
+                        .color(colors.accent_secondary),
+                )
+                .clicked()
+            {
+                ui.ctx()
+                    .open_url(egui::OpenUrl::new_tab(plugin.repo_url.clone()));
+            }
+        });
     }
 
-    // SHA-256 (truncated, shown in code block style)
+    // `.sha`: mono caption on `--bg-sunken` behind the shared hairline edge.
     if !plugin.sha256.is_empty() {
-        meta_label(ui, "SHA-256");
-        let sha_short = if plugin.sha256.len() > 32 {
-            format!("{}…", &plugin.sha256[..32])
+        let sha_short = if plugin.sha256.len() > SHA_CHARS {
+            format!("{}…", &plugin.sha256[..SHA_CHARS])
         } else {
             plugin.sha256.clone()
         };
-        egui::Frame::NONE
-            .fill(colors.bg_sunken)
-            .corner_radius(4)
-            .stroke(egui::Stroke::new(1.0, colors.surface))
-            .inner_margin(egui::Margin::same(8))
-            .show(ui, |ui| {
-                ui.label(
-                    egui::RichText::new(&sha_short)
-                        .size(10.0)
-                        .monospace()
-                        .color(colors.fg_muted),
-                );
-            });
+        meta_field(ui, "SHA-256", |ui| {
+            egui::Frame::NONE
+                .fill(colors.bg_sunken)
+                .corner_radius(RADIUS_CHIP)
+                .stroke(edge_stroke(colors))
+                .inner_margin(egui::Margin::symmetric(SHA_PAD_X, SHA_PAD_Y))
+                .show(ui, |ui| {
+                    ui.add(
+                        Typography::builder()
+                            .text(&sha_short)
+                            .variant(TypographyVariant::Mono)
+                            .color(color_to_hex(colors.fg_muted))
+                            .size(FONT_CAPTION)
+                            .build(),
+                    );
+                });
+        });
     }
 }
 
-/// Renders the uppercase bold label used above each sidebar metadata value.
-/// 10 px · bold · uppercase · `sidebar_header` color (overlay2 equivalent).
-fn meta_label(ui: &mut egui::Ui, text: &str) {
-    Typography::panel_header(ui, &text.to_uppercase());
-    ui.add_space(4.0);
+/// One `.mf`: the 10px uppercase `.ml` label, 3px, the value, then 13px of air.
+fn meta_field(ui: &mut egui::Ui, label: &str, value: impl FnOnce(&mut egui::Ui)) {
+    ui.add(
+        Typography::builder()
+            .text(label.to_uppercase())
+            .variant(TypographyVariant::GroupLabel)
+            .size(META_LABEL_FONT)
+            .bold(true)
+            .build(),
+    );
+    ui.add_space(META_LABEL_GAP);
+    value(ui);
+    ui.add_space(META_FIELD_GAP);
 }

--- a/src/components/marketplace/list.rs
+++ b/src/components/marketplace/list.rs
@@ -1,14 +1,53 @@
+// Marketplace list — design `screens.html` §3 “Marketplace”, left pane: the
+// `.shrow` header, the `.mk-tools` search + sort row, the `.mk-cats` category
+// strip, and the `.mk-plugs` plugin rows.
+
 use eframe::egui;
 
 use thoth_plugin_sdk::components::{
     Button, ButtonColor, ButtonSize, IconButton, Input, List, ListEvent, ListItem, ListItemPostfix,
-    ListItemPrefix, Progress, Select, SelectOption, Separator, SidebarHeader, Size,
+    ListItemPrefix, ListStyle, ListTextStyle, Progress, Select, SelectOption, Separator,
+    SidebarHeader, Size, Spinner, Typography, TypographyVariant,
 };
-use thoth_plugin_sdk::theme::color_to_hex;
+use thoth_plugin_sdk::theme::{FONT_CONTROL, color_to_hex};
 
 use crate::theme::ThemeColors;
 
 use super::state::{InstallState, MarketplaceUiState, SortOrder, category_glyph, category_label};
+
+// ── Tools block — design `.mk-tools` ─────────────────────────────────────────
+
+/// `.mk-tools{padding:4px 10px 8px}`.
+const TOOLS_PAD_X: i8 = 10;
+const TOOLS_PAD_TOP: i8 = 4;
+const TOOLS_PAD_BOTTOM: i8 = 8;
+/// `.mk-tools{gap:7px}` between the search field and the sort row.
+const TOOLS_GAP: f32 = 7.0;
+/// The sort row's own `style="display:flex;gap:6px"`.
+const SORT_GAP: f32 = 6.0;
+/// `.selbox{height:26px}` — `Size::Small`'s 24px trigger is the nearest rung on
+/// the shared control scale that still sits under the 28px field above it.
+const SORT_H: f32 = 24.0;
+/// `.ib{width:26px}` — the framed refresh button, i.e. `Size::Medium`.
+const REFRESH_W: f32 = 26.0;
+
+// ── Category strip — design `.mk-cats` ───────────────────────────────────────
+
+/// `.mk-cats{padding:0 8px 6px}`.
+const CATS_PAD_X: i8 = 8;
+const CATS_PAD_BOTTOM: i8 = 6;
+
+// ── Plugin rows — design `.mk-plugs` ─────────────────────────────────────────
+
+/// `.mk-plugs{padding:6px}`.
+const PLUGS_PAD: i8 = 6;
+/// How much of a plugin's description a row shows before it is elided.
+const DESC_MAX_CHARS: usize = 200;
+
+// ── Load / error states ──────────────────────────────────────────────────────
+
+/// Padding around the loading and failure lines.
+const STATUS_PAD: i8 = 16;
 
 pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: &ThemeColors) {
     // ── Header: title + count ──────────────────────────────────────────────
@@ -22,13 +61,13 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
             .build(),
     );
 
-    // ── Search bar + sort row ──────────────────────────────────────────────
+    // ── Search bar + sort row — design `.mk-tools` ─────────────────────────
     egui::Frame::NONE
         .inner_margin(egui::Margin {
-            left: 10,
-            right: 10,
-            top: 10,
-            bottom: 0,
+            left: TOOLS_PAD_X,
+            right: TOOLS_PAD_X,
+            top: TOOLS_PAD_TOP,
+            bottom: TOOLS_PAD_BOTTOM,
         })
         .show(ui, |ui| {
             // Row 1: search input
@@ -42,13 +81,11 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                 state.search_query = search_input.value.clone();
             }
 
-            ui.add_space(8.0);
+            ui.add_space(TOOLS_GAP);
 
             // Row 2: sort select (fills available width) + gap + refresh icon
             ui.horizontal(|ui| {
-                let icon_btn_w = 26.0;
-                let gap = 6.0;
-                let select_w = (ui.available_width() - icon_btn_w - gap).max(60.0);
+                let select_w = (ui.available_width() - REFRESH_W - SORT_GAP).max(60.0);
 
                 let sort_val = match state.sort {
                     SortOrder::NameAZ => "name_az",
@@ -73,7 +110,7 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                     .size(Size::Small)
                     .build();
                 let new_val = ui
-                    .allocate_ui(egui::vec2(select_w, 22.0), |ui| {
+                    .allocate_ui(egui::vec2(select_w, SORT_H), |ui| {
                         sort_select.show(ui).inner.selected
                     })
                     .inner;
@@ -84,20 +121,21 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                     };
                 }
 
-                ui.add_space(gap);
+                ui.add_space(SORT_GAP);
 
+                // `.ib.framed` — surface fill plus the shared hairline edge.
                 let resp = ui.add(
                     IconButton::builder()
                         .icon(egui_phosphor::regular::ARROWS_CLOCKWISE)
                         .tooltip("Refresh Registry")
+                        .frame(true)
+                        .size(Size::Medium)
                         .build(),
                 );
                 if resp.clicked() {
                     state.load_if_needed(ui.ctx(), true);
                 }
             });
-
-            ui.add_space(8.0);
         });
 
     // ── Category strip ─────────────────────────────────────────────────────
@@ -166,54 +204,71 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
         .iter()
         .map(|cat| {
             let is_active = state.selected_category == cat.id;
-            let icon_color = if is_active {
+            // `.cat{color:var(--fg-muted)}` / `.cat.on{color:var(--accent)}` —
+            // a selected category tints its glyph *and* its label.
+            let label_color = if is_active {
                 colors.accent
             } else {
                 colors.fg_muted
             };
-            let badge = (cat.count > 0).then(|| ListItemPostfix::Badge {
+            // `.cat .c{margin-left:auto;font-family:var(--mono);font-size:10px}`
+            // — a bare mono count, with no chip chrome around it.
+            let count = (cat.count > 0).then(|| ListItemPostfix::Text {
                 text: cat.count.to_string(),
-                bg: Some(color_to_hex(colors.bg_sunken)),
-                fg: Some(color_to_hex(colors.fg_muted)),
+                color: None,
+                mono: true,
             });
             ListItem::builder()
                 .title(cat.label.clone())
+                .title_color(color_to_hex(label_color))
                 .prefix(ListItemPrefix::Icon {
                     glyph: cat.glyph.to_string(),
-                    color: Some(color_to_hex(icon_color)),
+                    color: Some(color_to_hex(label_color)),
                 })
                 .selected(is_active)
-                .maybe_postfix(badge)
+                .maybe_postfix(count)
                 .build()
         })
         .collect();
 
-    if let Some(ListEvent::ItemClicked(idx)) = List::builder()
-        .items(cat_items)
-        .shrink_to_fit(true)
-        .show_separators(false)
-        .compact(true)
-        .build()
-        .show(ui)
+    // `.cat` rows are 30px tall with a 12px label — the flush row shape (8px
+    // padding around a 12px title) rather than the 22px compact strip. They are
+    // parted by nothing but their own hover fill, hence no separators.
+    let cat_event = egui::Frame::NONE
+        .inner_margin(egui::Margin {
+            left: CATS_PAD_X,
+            right: CATS_PAD_X,
+            top: 0,
+            bottom: CATS_PAD_BOTTOM,
+        })
+        .show(ui, |ui| {
+            List::builder()
+                .items(cat_items)
+                .style(ListStyle::Flush)
+                .shrink_to_fit(true)
+                .show_separators(false)
+                .build()
+                .show(ui)
+        })
+        .inner;
+    if let Some(ListEvent::ItemClicked(idx)) = cat_event
         && let Some(cat) = cat_defs.get(idx)
     {
         state.selected_category = cat.id.clone();
     }
 
+    // `.mk-plugs{border-top:1px solid …}`
     ui.add(Separator::plain());
 
     // ── Plugin list ────────────────────────────────────────────────────────
     if state.loading {
         egui::Frame::NONE
-            .inner_margin(egui::Margin::same(16))
+            .inner_margin(egui::Margin::same(STATUS_PAD))
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
-                    ui.spinner();
-                    ui.label(
-                        egui::RichText::new("Loading plugin registry…")
-                            .color(colors.fg_muted)
-                            .size(12.0),
-                    );
+                    ui.spacing_mut().item_spacing.x = TOOLS_GAP;
+                    ui.add(Spinner::builder().build());
+                    Typography::body_muted(ui, "Loading plugin registry…");
                 });
             });
         return;
@@ -221,12 +276,14 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
 
     if let Some(err) = state.load_error.clone() {
         egui::Frame::NONE
-            .inner_margin(egui::Margin::same(16))
+            .inner_margin(egui::Margin::same(STATUS_PAD))
             .show(ui, |ui| {
-                ui.label(
-                    egui::RichText::new(format!("Failed to load marketplace: {err}"))
-                        .color(colors.error)
-                        .size(12.0),
+                ui.add(
+                    Typography::builder()
+                        .text(format!("Failed to load marketplace: {err}"))
+                        .variant(TypographyVariant::BodyMuted)
+                        .color(color_to_hex(colors.error))
+                        .build(),
                 );
             });
         return;
@@ -235,8 +292,8 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
     struct RowData {
         id: String,
         name: String,
-        desc: String,
-        tag_labels: Vec<&'static str>,
+        desc: Option<String>,
+        by_line: String,
         install_state: InstallState,
         is_selected: bool,
         icon_file: Option<std::path::PathBuf>,
@@ -264,21 +321,17 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                     || p.author.to_lowercase().contains(&query))
         })
         .map(|p| {
-            let tag_labels: Vec<&'static str> =
-                p.categories.iter().map(|c| category_label(c)).collect();
-
-            let meta = format!("by {} · v{}", p.author, p.version);
-            let desc = if p.description.is_empty() {
-                meta
-            } else {
-                let truncated: String = p.description.chars().take(200).collect();
-                let suffix = if p.description.chars().count() > 200 {
+            // `.pl` stacks three lines: `.nm` name, `.ds` description, `.by`
+            // author · version — the row's title, description and meta tiers.
+            let desc = (!p.description.is_empty()).then(|| {
+                let truncated: String = p.description.chars().take(DESC_MAX_CHARS).collect();
+                let suffix = if p.description.chars().count() > DESC_MAX_CHARS {
                     "…"
                 } else {
                     ""
                 };
-                format!("{truncated}{suffix}\n{meta}")
-            };
+                format!("{truncated}{suffix}")
+            });
 
             RowData {
                 is_selected: state.selected_id.as_deref() == Some(p.id.as_str()),
@@ -286,7 +339,7 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                 id: p.id.clone(),
                 name: p.name.clone(),
                 desc,
-                tag_labels,
+                by_line: format!("by {} · v{}", p.author, p.version),
                 icon_file: p.get_icon_file(ui.ctx().clone()).ok(),
             }
         })
@@ -332,19 +385,15 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                 InstallState::Update => Some(ListItemPostfix::Button(
                     Button::builder()
                         .label("Update")
-                        .color(ButtonColor::Secondary)
+                        .color(ButtonColor::Primary)
                         .button_size(ButtonSize::Small)
                         .icon(egui_phosphor::regular::UPLOAD)
                         .build(),
                 )),
             };
 
-            let icon_color = if row.is_selected {
-                colors.accent
-            } else {
-                colors.fg_muted
-            };
-
+            // `.pl .tile{background:color-mix(accent 15%,transparent);color:accent}`
+            // — the tile is always tinted; selection reads from the row wash.
             let prefix = if let Some(icon_path) = &row.icon_file {
                 ListItemPrefix::IconFile {
                     path: icon_path.to_string_lossy().into_owned(),
@@ -352,31 +401,49 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
             } else {
                 ListItemPrefix::IconTile {
                     glyph: egui_phosphor::regular::PUZZLE_PIECE.to_string(),
-                    color: color_to_hex(icon_color),
+                    color: color_to_hex(colors.accent),
                 }
             };
 
             ListItem::builder()
                 .title(row.name.clone())
-                .description(row.desc.clone())
+                .maybe_description(row.desc.clone())
+                .meta(row.by_line.clone())
                 .prefix(prefix)
                 .selected(row.is_selected)
-                .tags(
-                    row.tag_labels
-                        .iter()
-                        .map(|t| t.to_string())
-                        .collect::<Vec<_>>(),
-                )
                 .maybe_postfix(postfix)
                 .build()
         })
         .collect();
 
-    let list_event = List::builder()
-        .items(items)
-        .empty_label("No plugins found")
-        .build()
-        .show(ui);
+    // `.pl` rows: transparent, 8px padding, a `--text 5%` hover wash and an
+    // `--accent 12%` selected wash, with nothing but air between them — the
+    // flush row shape. Card rows would put each plugin on its own filled panel,
+    // which the sheet reserves for sidebar-style lists.
+    let list_event = egui::Frame::NONE
+        .inner_margin(egui::Margin::same(PLUGS_PAD))
+        .show(ui, |ui| {
+            List::builder()
+                .items(items)
+                .style(ListStyle::Flush)
+                .show_separators(false)
+                .empty_label("No plugins found")
+                // `.pl .nm{font-size:12.5px;font-weight:600}` over
+                // `.pl .ds{font-size:11px}` over a monospace
+                // `.pl .by{font-size:10.5px;color:var(--overlay0)}` — the
+                // description and author tiers already match the flush row's
+                // defaults, so only the size/weight and the mono family differ.
+                .text_style(
+                    ListTextStyle::builder()
+                        .title_size(FONT_CONTROL)
+                        .title_bold(true)
+                        .meta_mono(true)
+                        .build(),
+                )
+                .build()
+                .show(ui)
+        })
+        .inner;
 
     match list_event {
         Some(ListEvent::ItemClicked(idx)) => {

--- a/src/components/marketplace/list.rs
+++ b/src/components/marketplace/list.rs
@@ -85,6 +85,10 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
 
             // Row 2: sort select (fills available width) + gap + refresh icon
             ui.horizontal(|ui| {
+                // Every gap in the row is explicit, so the width budget below
+                // is the whole story and the refresh button can't be clipped.
+                ui.spacing_mut().item_spacing.x = 0.0;
+
                 let select_w = (ui.available_width() - REFRESH_W - SORT_GAP).max(60.0);
 
                 let sort_val = match state.sort {
@@ -340,7 +344,8 @@ pub(super) fn render(ui: &mut egui::Ui, state: &mut MarketplaceUiState, colors: 
                 name: p.name.clone(),
                 desc,
                 by_line: format!("by {} · v{}", p.author, p.version),
-                icon_file: p.get_icon_file(ui.ctx().clone()).ok(),
+                // Resolved once per manifest load, never per frame.
+                icon_file: state.icon_files.get(&p.id).cloned(),
             }
         })
         .collect();

--- a/src/components/marketplace/mod.rs
+++ b/src/components/marketplace/mod.rs
@@ -205,7 +205,14 @@ impl StatelessComponent for MarketplaceDetail {
                         });
                     }
                     DetailAction::Retry => {
-                        state.install_handles.remove(&plugin.id);
+                        // This is the Cancel button while an install is in
+                        // flight. Dropping the handle only stops the UI from
+                        // *watching* it — the worker owns its own clone of the
+                        // slot and would keep downloading and keep writing into
+                        // the plugin directory — so signal it first.
+                        if let Some(slot) = state.install_handles.remove(&plugin.id) {
+                            crate::plugin::marketplace::cancel_install(&slot);
+                        }
                         state.install_states.remove(&plugin.id);
                     }
                 }

--- a/src/components/marketplace/mod.rs
+++ b/src/components/marketplace/mod.rs
@@ -28,7 +28,7 @@ impl StatelessComponent for Marketplace {
 
         state.load_if_needed(ui.ctx(), false);
         let setting = settings::Settings::read(ui.ctx());
-        state.poll_pending(&setting.plugins.disabled_plugin_ids);
+        state.poll_pending(ui.ctx(), &setting.plugins.disabled_plugin_ids);
 
         let colors = ui.ctx().memory(|mem| {
             mem.data
@@ -64,7 +64,7 @@ impl StatelessComponent for MarketplaceDetail {
             .is_some_and(|slot| slot.lock().ok().is_some_and(|g| g.is_some()));
 
         let setting = settings::Settings::read(ui.ctx());
-        state.poll_pending(&setting.plugins.disabled_plugin_ids);
+        state.poll_pending(ui.ctx(), &setting.plugins.disabled_plugin_ids);
 
         let colors = ui.ctx().memory(|mem| {
             mem.data
@@ -120,7 +120,10 @@ impl StatelessComponent for MarketplaceDetail {
         }
 
         if let Some(plugin) = &selected_plugin {
-            if let Some(action) = detail::render(ui, plugin, &install_state, &colors) {
+            let icon_file = state.icon_files.get(&plugin.id).cloned();
+            if let Some(action) =
+                detail::render(ui, plugin, &install_state, icon_file.as_deref(), &colors)
+            {
                 match action {
                     DetailAction::Install => {
                         let slot = plugin.download_and_install(ui.ctx().clone());

--- a/src/components/marketplace/state.rs
+++ b/src/components/marketplace/state.rs
@@ -200,6 +200,7 @@ impl MarketplaceUiState {
     pub fn poll_installs(&mut self) -> Vec<(String, Result<(), String>)> {
         let mut state_updates: Vec<(String, InstallState)> = Vec::new();
         let mut completed: Vec<(String, Result<(), String>)> = Vec::new();
+        let mut cancelled: Vec<String> = Vec::new();
 
         for (id, slot) in &self.install_handles {
             let progress = slot.lock().ok().map(|g| g.clone());
@@ -215,6 +216,13 @@ impl MarketplaceUiState {
                     state_updates.push((id.clone(), InstallState::Failed(e.clone())));
                     completed.push((id.clone(), Err(e)));
                 }
+                // The cancelling handler already dropped this plugin's handle and
+                // state, so a slot seen here was cancelled elsewhere: drop the
+                // handle and leave no state, returning the row to "not installed"
+                // rather than reporting a failure the user caused.
+                Some(PluginInstallProgress::Cancelled) => {
+                    cancelled.push(id.clone());
+                }
                 None => {}
             }
         }
@@ -224,6 +232,10 @@ impl MarketplaceUiState {
         }
         for (id, _) in &completed {
             self.install_handles.remove(id);
+        }
+        for id in cancelled {
+            self.install_handles.remove(&id);
+            self.install_states.remove(&id);
         }
 
         completed

--- a/src/components/marketplace/state.rs
+++ b/src/components/marketplace/state.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    path::PathBuf,
     sync::{Arc, Mutex},
     thread,
 };
@@ -132,6 +133,10 @@ pub struct MarketplaceUiState {
     /// "all" | "installed" | "updates"
     pub selected_category: String,
     pub plugins: Vec<MarketPlacePlugin>,
+    /// On-disk icon path per plugin id. Resolving one stats the file and may
+    /// schedule a download, so it happens once per manifest load instead of on
+    /// every frame of the list and the detail header.
+    pub icon_files: HashMap<String, PathBuf>,
     pub install_states: HashMap<String, InstallState>,
     /// Active download/install threads keyed by plugin id.
     pub install_handles: HashMap<String, InstallSlot>,
@@ -151,6 +156,7 @@ impl Default for MarketplaceUiState {
             selected_id: None,
             selected_category: "all".to_string(),
             plugins: Vec::new(),
+            icon_files: HashMap::new(),
             install_states: HashMap::new(),
             install_handles: HashMap::new(),
             load_error: None,
@@ -225,7 +231,7 @@ impl MarketplaceUiState {
 
     /// Check whether the background fetch has completed and apply the result.
     /// Must be called every frame.
-    pub fn poll_pending(&mut self, disabled_plugins: &[String]) {
+    pub fn poll_pending(&mut self, ctx: &egui::Context, disabled_plugins: &[String]) {
         let result = self
             .pending
             .as_ref()
@@ -253,6 +259,17 @@ impl MarketplaceUiState {
 
                 let mut plugins: Vec<MarketPlacePlugin> = data.into_values().collect();
                 plugins.sort_by(|a, b| a.name.cmp(&b.name));
+
+                // Resolve every icon path once, here, so the render passes only
+                // read the map (see `icon_files`).
+                self.icon_files = plugins
+                    .iter()
+                    .filter_map(|p| {
+                        p.get_icon_file(ctx.clone())
+                            .ok()
+                            .map(|file| (p.id.clone(), file))
+                    })
+                    .collect();
 
                 self.plugins = plugins;
                 self.install_states = install_states;

--- a/src/components/recent_files.rs
+++ b/src/components/recent_files.rs
@@ -1,8 +1,9 @@
 use crate::components::traits::StatefulComponent;
+use crate::theme::{FIELD_HEIGHT, FONT_BODY, GUTTER_GAP};
 use eframe::egui;
 use thoth_plugin_sdk::components::{
-    Button, ButtonColor, ButtonType, IconButton, List, ListEvent, ListItem, ListItemPostfix,
-    ListItemPrefix, SidebarHeader,
+    Button, ButtonColor, ButtonType, List, ListEvent, ListItem, ListItemAction, ListItemPrefix,
+    SidebarHeader,
 };
 
 pub struct RecentFilesProps<'a> {
@@ -38,75 +39,81 @@ impl StatefulComponent for RecentFiles {
         }
 
         ui.add(SidebarHeader::builder().title("RECENT FILES").build());
-        ui.add_space(4.0);
 
-        egui::ScrollArea::vertical()
-            .scroll([false, true])
-            .auto_shrink([false, false])
-            .show(ui, |ui| {
-                let items: Vec<ListItem> = props
-                    .recent_files
-                    .iter()
-                    .map(|path| {
-                        let filename = std::path::Path::new(path)
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or(path.as_str());
-                        ListItem::builder()
-                            .title(filename.to_string())
-                            .prefix(ListItemPrefix::Icon {
-                                glyph: egui_phosphor::regular::FILE.to_string(),
-                                color: None,
-                            })
-                            .postfix(ListItemPostfix::IconButton(
-                                IconButton::builder()
-                                    .icon(egui_phosphor::regular::X)
-                                    .frame(true)
-                                    .tooltip("Remove")
-                                    .build(),
-                            ))
-                            .build()
+        // Design (app-mockup `.conns`): the panel's primary action sits directly
+        // under the header, above the scrolling rows — not appended below them.
+        ui.add_space(GUTTER_GAP / 2.0);
+        ui.horizontal(|ui| {
+            ui.add_space(GUTTER_GAP);
+            let avail = ui.available_width() - GUTTER_GAP;
+            let clicked = ui
+                .add(
+                    Button::builder()
+                        .label("Open File...")
+                        .button_type(ButtonType::Elevated)
+                        .color(ButtonColor::Default)
+                        .size(FONT_BODY)
+                        .width(avail)
+                        .height(FIELD_HEIGHT)
+                        .icon(egui_phosphor::regular::FILE_PLUS)
+                        .build(),
+                )
+                .clicked();
+            if clicked {
+                events.push(RecentFilesEvent::OpenFilePicker);
+            }
+        });
+        ui.add_space(GUTTER_GAP);
+
+        let items: Vec<ListItem> = props
+            .recent_files
+            .iter()
+            .map(|path| {
+                let filename = std::path::Path::new(path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(path.as_str());
+                ListItem::builder()
+                    .title(filename.to_string())
+                    .prefix(ListItemPrefix::Icon {
+                        glyph: egui_phosphor::regular::FILE.to_string(),
+                        color: None,
                     })
-                    .collect();
-
-                match List::builder()
-                    .items(items)
-                    .empty_label("No recent files")
-                    .build()
-                    .show(ui)
-                {
-                    Some(ListEvent::PostfixClicked(i)) => {
-                        if let Some(path) = props.recent_files.get(i) {
-                            events.push(RecentFilesEvent::RemoveFile(path.clone()));
-                        }
-                    }
-                    Some(ListEvent::ItemClicked(i)) => {
-                        if let Some(path) = props.recent_files.get(i) {
-                            events.push(RecentFilesEvent::OpenFile(path.clone()));
-                        }
-                    }
-                    _ => {}
-                }
-                ui.add_space(8.0);
-
-                let avail = ui.available_width();
-                let clicked = ui
-                    .add(
-                        Button::builder()
-                            .label("Open File...")
-                            .button_type(ButtonType::Elevated)
-                            .color(ButtonColor::Default)
-                            .size(13.0)
-                            .width(avail - 16.0)
-                            .height(28.0)
-                            .icon(egui_phosphor::regular::FILE_PLUS)
+                    // Design `.card .cact` / `.li .lacts`: row affordances are
+                    // ghost icons revealed on hover, not a framed button riding
+                    // in the row's postfix slot.
+                    .actions(vec![
+                        ListItemAction::builder()
+                            .icon(egui_phosphor::regular::X)
+                            .tooltip("Remove")
                             .build(),
-                    )
-                    .clicked();
-                if clicked {
-                    events.push(RecentFilesEvent::OpenFilePicker);
+                    ])
+                    .build()
+            })
+            .collect();
+
+        // `List` owns its own scroll area, so this panel must not nest another
+        // one around it. `shrink_to_fit` keeps the rows sized to their content —
+        // the sidebar's scroll area is the one that scrolls.
+        match List::builder()
+            .items(items)
+            .empty_label("No recent files")
+            .shrink_to_fit(true)
+            .build()
+            .show(ui)
+        {
+            Some(ListEvent::ActionClicked { item, .. }) => {
+                if let Some(path) = props.recent_files.get(item) {
+                    events.push(RecentFilesEvent::RemoveFile(path.clone()));
                 }
-            });
+            }
+            Some(ListEvent::ItemClicked(i)) => {
+                if let Some(path) = props.recent_files.get(i) {
+                    events.push(RecentFilesEvent::OpenFile(path.clone()));
+                }
+            }
+            _ => {}
+        }
 
         RecentFilesOutput { events }
     }

--- a/src/components/search.rs
+++ b/src/components/search.rs
@@ -1,10 +1,17 @@
 use crate::components::traits::StatefulComponent;
 use crate::search::{QueryMode, Search as SearchState, SearchMessage, decode_history_entry};
+use crate::theme::GUTTER_GAP;
 use eframe::egui;
 use thoth_plugin_sdk::components::{
-    IconButton, Input, List, ListEvent, ListItem, ListItemPrefix, Separator, SidebarHeader,
+    Checkbox, Input, List, ListEvent, ListItem, ListItemPrefix, Separator, SidebarHeader,
     SidebarHeaderAction, Typography,
 };
+
+/// Height cap on the recent-searches list, so it can't crowd out the results.
+const HISTORY_MAX_H: f32 = 300.0;
+/// Height cap on the results list. A cap is what keeps the list's own scroll
+/// area (and therefore its row virtualisation) alive inside the sidebar's.
+const RESULTS_MAX_H: f32 = 300.0;
 
 /// Detect query mode based on whether the query starts with '$'
 fn detect_query_mode(query: &str) -> QueryMode {
@@ -94,17 +101,25 @@ impl StatefulComponent for Search {
             }
             _ => {}
         }
-        ui.add_space(8.0);
+        ui.add_space(GUTTER_GAP);
 
-        let mut search_input = Input::builder()
-            .id("search_query")
-            .value(self.search_query.clone())
-            .placeholder("Search… ($ prefix for JSONPath, e.g. $.user.name = \"alice\")")
-            .icon(egui_phosphor::regular::MAGNIFYING_GLASS)
-            .build();
-        let search_out = search_input.show(ui);
+        // The query field and the match-case box sit in the panel's content
+        // gutter, aligned with the row cards below (design `.cscroll` padding).
+        let (search_out, edited_query) = egui::Frame::new()
+            .inner_margin(egui::Margin::symmetric(GUTTER_GAP as i8, 0))
+            .show(ui, |ui| {
+                let mut search_input = Input::builder()
+                    .id("search_query")
+                    .value(self.search_query.clone())
+                    .placeholder("Search… ($ prefix for JSONPath, e.g. $.user.name = \"alice\")")
+                    .icon(egui_phosphor::regular::MAGNIFYING_GLASS)
+                    .build();
+                let out = search_input.show(ui);
+                (out, search_input.value)
+            })
+            .inner;
         if search_out.inner {
-            self.search_query = search_input.value.clone();
+            self.search_query = edited_query;
         }
         let response = search_out.response;
 
@@ -133,10 +148,22 @@ impl StatefulComponent for Search {
             }
         }
 
-        ui.add_space(8.0);
+        ui.add_space(GUTTER_GAP);
 
-        // Match case checkbox with accessibility info
-        let checkbox_response = ui.checkbox(&mut self.match_case, "Match case");
+        // Match case — the SDK checkbox (design `.cb`), not egui's default.
+        let checkbox_response = egui::Frame::new()
+            .inner_margin(egui::Margin::symmetric(GUTTER_GAP as i8, 0))
+            .show(ui, |ui| {
+                let mut checkbox = Checkbox::builder()
+                    .id("search_match_case")
+                    .label("Match case")
+                    .checked(self.match_case)
+                    .build();
+                let response = checkbox.show(ui);
+                self.match_case = checkbox.checked;
+                response
+            })
+            .inner;
         checkbox_response.widget_info(|| {
             egui::WidgetInfo::selected(
                 egui::WidgetType::Checkbox,
@@ -146,7 +173,7 @@ impl StatefulComponent for Search {
             )
         });
 
-        ui.add_space(8.0);
+        ui.add_space(GUTTER_GAP);
 
         // Display search history if no active search and history exists
         if props.search_state.query.is_empty()
@@ -159,27 +186,25 @@ impl StatefulComponent for Search {
                 .collect();
 
             if !queries.is_empty() {
-                ui.add(Separator::with_margins(0.0, 8.0));
+                ui.add(Separator::with_margins(0.0, GUTTER_GAP));
 
-                ui.horizontal(|ui| {
-                    Typography::panel_header(ui, "RECENT SEARCHES");
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        let clicked = ui
-                            .add(
-                                IconButton::builder()
-                                    .icon(egui_phosphor::regular::X)
-                                    .frame(false)
-                                    .tooltip("Clear search history")
-                                    .size_px(16.0)
-                                    .build(),
-                            )
-                            .clicked();
-                        if clicked {
-                            events.push(SearchEvent::ClearHistory);
-                        }
-                    });
-                });
-                ui.add_space(4.0);
+                // A titled section with a trailing action *is* SidebarHeader
+                // (design `.sh` / `.shacts`) — no need to hand-roll one.
+                let cleared = SidebarHeader::builder()
+                    .title("RECENT SEARCHES")
+                    .actions(vec![
+                        SidebarHeaderAction::builder()
+                            .icon(egui_phosphor::regular::X)
+                            .tooltip("Clear search history")
+                            .build(),
+                    ])
+                    .build()
+                    .show(ui)
+                    .inner;
+                if cleared == Some(0) {
+                    events.push(SearchEvent::ClearHistory);
+                }
+                ui.add_space(GUTTER_GAP / 2.0);
 
                 let items: Vec<ListItem> = queries
                     .iter()
@@ -196,7 +221,10 @@ impl StatefulComponent for Search {
 
                 if let Some(ListEvent::ItemClicked(idx)) = List::builder()
                     .items(items)
-                    .max_height(300.0)
+                    // Size to the rows, but cap the box so a long history can't
+                    // push the results out of the panel.
+                    .shrink_to_fit(true)
+                    .max_height(HISTORY_MAX_H)
                     .build()
                     .show(ui)
                     && let Some(q) = queries.get(idx)
@@ -225,7 +253,7 @@ impl StatefulComponent for Search {
                 });
             } else if result_count > 0 {
                 Typography::caption(ui, &format!("{} result(s)", result_count));
-                ui.add_space(4.0);
+                ui.add_space(GUTTER_GAP / 2.0);
 
                 let hits = props.search_state.results.hits();
                 let titles: Vec<String> = hits
@@ -260,22 +288,21 @@ impl StatefulComponent for Search {
                     })
                     .collect();
 
-                egui::ScrollArea::vertical()
-                    .id_salt("search_results_scroll")
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
-                        if let Some(ListEvent::ItemClicked(idx)) = List::builder()
-                            .items(items)
-                            .max_height(300.0)
-                            .build()
-                            .show(ui)
-                            && let Some(hit) = props.search_state.results.hits().get(idx)
-                        {
-                            events.push(SearchEvent::NavigateToResult {
-                                record_index: hit.record_index,
-                            });
-                        }
+                // `List` scrolls and virtualises its own rows — the results pane
+                // must not nest another scroll area around it. The cap keeps that
+                // virtualisation alive inside the sidebar's own scroll area.
+                if let Some(ListEvent::ItemClicked(idx)) = List::builder()
+                    .items(items)
+                    .shrink_to_fit(true)
+                    .max_height(RESULTS_MAX_H)
+                    .build()
+                    .show(ui)
+                    && let Some(hit) = props.search_state.results.hits().get(idx)
+                {
+                    events.push(SearchEvent::NavigateToResult {
+                        record_index: hit.record_index,
                     });
+                }
             } else {
                 Typography::body_muted(ui, "No results found");
             }

--- a/src/components/settings_dialog/advanced.rs
+++ b/src/components/settings_dialog/advanced.rs
@@ -1,4 +1,4 @@
-use eframe::egui::{self, RichText};
+use eframe::egui;
 
 use crate::components::settings_dialog::helpers::{group_rows, section_header, setting_row};
 use crate::components::traits::StatelessComponent;
@@ -6,7 +6,9 @@ use crate::settings::DeveloperSettings;
 use crate::theme::ThemeColors;
 #[cfg(feature = "profiling")]
 use thoth_plugin_sdk::components::ToggleSwitch;
-use thoth_plugin_sdk::components::{Button, ButtonColor, ButtonType};
+use thoth_plugin_sdk::components::{
+    Button, ButtonColor, ButtonType, Typography, TypographyVariant,
+};
 
 pub struct AdvancedTab;
 
@@ -47,7 +49,7 @@ impl StatelessComponent for AdvancedTab {
                 );
 
                 // ── Profiler ─────────────────────────────────────────────────────
-                group_rows(ui, "PROFILER", "dev-profiler", colors, |ui| {
+                group_rows(ui, "PROFILER", |ui| {
                     #[cfg(feature = "profiling")]
                     setting_row(
                         ui,
@@ -76,13 +78,13 @@ impl StatelessComponent for AdvancedTab {
                         None,
                         colors,
                         |ui| {
-                            ui.label(RichText::new("Disabled").size(12.0).color(colors.fg_muted));
+                            Typography::body_muted(ui, "Disabled");
                         },
                     );
                 });
 
                 // ── Config file ──────────────────────────────────────────────────
-                group_rows(ui, "CONFIGURATION FILE", "dev-config", colors, |ui| {
+                group_rows(ui, "CONFIGURATION FILE", |ui| {
                     let path_str = crate::settings::Settings::settings_file_path()
                         .map(|p| p.to_string_lossy().to_string())
                         .unwrap_or_else(|_| "—".to_string());
@@ -101,7 +103,6 @@ impl StatelessComponent for AdvancedTab {
                                         .label("Open")
                                         .button_type(ButtonType::Elevated)
                                         .color(ButtonColor::Default)
-                                        .size(12.0)
                                         .build(),
                                 )
                                 .clicked()
@@ -114,7 +115,7 @@ impl StatelessComponent for AdvancedTab {
                 });
 
                 // ── System integration ───────────────────────────────────────────
-                group_rows(ui, "SYSTEM INTEGRATION", "dev-path", colors, |ui| {
+                group_rows(ui, "SYSTEM INTEGRATION", |ui| {
                     let (status_text, status_color) = if props.is_in_path {
                         (
                             format!("{} Available in PATH", egui_phosphor::regular::CHECK_CIRCLE),
@@ -142,7 +143,6 @@ impl StatelessComponent for AdvancedTab {
                                             .label("Remove from PATH")
                                             .button_type(ButtonType::Elevated)
                                             .color(ButtonColor::Danger)
-                                            .size(12.0)
                                             .build(),
                                     )
                                     .clicked()
@@ -156,7 +156,6 @@ impl StatelessComponent for AdvancedTab {
                                             .label("Add to PATH")
                                             .button_type(ButtonType::Elevated)
                                             .color(ButtonColor::Success)
-                                            .size(12.0)
                                             .build(),
                                     )
                                     .clicked()
@@ -165,12 +164,16 @@ impl StatelessComponent for AdvancedTab {
                                 }
                             }
                             ui.add_space(8.0);
-                            ui.label(RichText::new(&status_text).size(12.0).color(status_color));
+                            ui.add(
+                                Typography::builder()
+                                    .text(&status_text)
+                                    .variant(TypographyVariant::Body)
+                                    .color(thoth_plugin_sdk::theme::color_to_hex(status_color))
+                                    .build(),
+                            );
                         },
                     );
                 });
-
-                ui.add_space(24.0);
             });
 
         AdvancedTabOutput { events }

--- a/src/components/settings_dialog/general.rs
+++ b/src/components/settings_dialog/general.rs
@@ -1,11 +1,13 @@
 use eframe::egui;
 
-use crate::components::settings_dialog::helpers::{group_rows, section_header, setting_row};
+use crate::components::settings_dialog::helpers::{
+    group_rows, section_header, setting_row, slider_control,
+};
 use crate::components::settings_dialog::theme_picker::{ThemePicker, ThemePickerProps};
 use crate::components::traits::StatelessComponent;
 use crate::settings::Settings;
 use crate::theme::ThemeColors;
-use thoth_plugin_sdk::components::{Select, SelectOption};
+use thoth_plugin_sdk::components::{NumberInput, Select, SelectOption};
 
 #[derive(Debug, Clone)]
 pub enum GeneralTabEvent {
@@ -49,7 +51,7 @@ impl StatelessComponent for GeneralTab {
                     colors,
                 );
 
-                group_rows(ui, "THEME", "general-theme", colors, |ui| {
+                group_rows(ui, "THEME", |ui| {
                     let picker_out = ThemePicker::render(
                         ui,
                         ThemePickerProps {
@@ -66,7 +68,7 @@ impl StatelessComponent for GeneralTab {
                 });
 
                 // ── Typography ───────────────────────────────────────────────
-                group_rows(ui, "TYPOGRAPHY", "general-typography", colors, |ui| {
+                group_rows(ui, "TYPOGRAPHY", |ui| {
                     setting_row(
                         ui,
                         "Font size",
@@ -75,16 +77,12 @@ impl StatelessComponent for GeneralTab {
                         None,
                         colors,
                         |ui| {
-                            let mut val = s.font_size;
-                            if ui
-                                .add(
-                                    egui::Slider::new(&mut val, 8.0..=24.0)
-                                        .step_by(0.5)
-                                        .suffix(" px"),
-                                )
-                                .changed()
+                            if let Some(val) =
+                                slider_control(ui, s.font_size as f64, 8.0, 24.0, "px")
                             {
-                                events.push(GeneralTabEvent::FontSize(val));
+                                // Keep the old half-point granularity.
+                                let snapped = (val * 2.0).round() / 2.0;
+                                events.push(GeneralTabEvent::FontSize(snapped as f32));
                             }
                         },
                     );
@@ -142,7 +140,7 @@ impl StatelessComponent for GeneralTab {
                 });
 
                 // ── Window ───────────────────────────────────────────────────
-                group_rows(ui, "WINDOW", "general-window", colors, |ui| {
+                group_rows(ui, "WINDOW", |ui| {
                     setting_row(
                         ui,
                         "Default width",
@@ -151,16 +149,15 @@ impl StatelessComponent for GeneralTab {
                         None,
                         colors,
                         |ui| {
-                            let mut val = s.window.default_width as i32;
-                            if ui
-                                .add(
-                                    egui::DragValue::new(&mut val)
-                                        .range(400..=7680)
-                                        .suffix(" px"),
-                                )
-                                .changed()
-                            {
-                                events.push(GeneralTabEvent::WindowWidth(val as f32));
+                            let mut num = NumberInput::builder()
+                                .id("window_default_width")
+                                .value(s.window.default_width as f64)
+                                .min(400.0)
+                                .max(7680.0)
+                                .unit("px")
+                                .build();
+                            if num.show(ui).changed() {
+                                events.push(GeneralTabEvent::WindowWidth(num.value as f32));
                             }
                         },
                     );
@@ -173,22 +170,19 @@ impl StatelessComponent for GeneralTab {
                         None,
                         colors,
                         |ui| {
-                            let mut val = s.window.default_height as i32;
-                            if ui
-                                .add(
-                                    egui::DragValue::new(&mut val)
-                                        .range(300..=4320)
-                                        .suffix(" px"),
-                                )
-                                .changed()
-                            {
-                                events.push(GeneralTabEvent::WindowHeight(val as f32));
+                            let mut num = NumberInput::builder()
+                                .id("window_default_height")
+                                .value(s.window.default_height as f64)
+                                .min(300.0)
+                                .max(4320.0)
+                                .unit("px")
+                                .build();
+                            if num.show(ui).changed() {
+                                events.push(GeneralTabEvent::WindowHeight(num.value as f32));
                             }
                         },
                     );
                 });
-
-                ui.add_space(24.0);
             });
 
         GeneralTabOutput { events }

--- a/src/components/settings_dialog/helpers.rs
+++ b/src/components/settings_dialog/helpers.rs
@@ -1,20 +1,75 @@
-use eframe::egui::{self, Color32, RichText};
+// Shared building blocks for the settings panes — design `.shead`, `.grouplabel`
+// and `.srow`. Rows are flat: no card frame, just a hairline along the bottom
+// edge of each row.
 
-use crate::theme::{
-    CARD_OUTER_H, CARD_RADIUS, CONTROL_WIDTH, DIRTY_DOT_RADIUS, GROUP_SPACING, ROW_INNER_H,
-    ROW_PADDING_H, ROW_PADDING_V, ThemeColors, icon_rich_text,
-};
-use thoth_plugin_sdk::components::Typography;
+use eframe::egui;
 
+use crate::theme::{ThemeColors, phosphor_font_id};
+use thoth_plugin_sdk::components::{Separator, Slider, Typography, TypographyVariant};
+use thoth_plugin_sdk::theme::{FIELD_HEIGHT, RADIUS_PANEL, color_to_hex, with_alpha};
+
+// ── Section head — design `.shead` ───────────────────────────────────────────
+
+/// Icon tile beside the section title — design `.shead .si{width:34px}`.
+const TILE: f32 = 34.0;
+/// …with an 18px glyph centred in it — design `.shead .si{font-size:18px}`.
+const TILE_GLYPH: f32 = 18.0;
+/// Tile tint — design `.si{background:color-mix(mauve 14%,transparent)}`.
+const TILE_TINT_ALPHA: u8 = 36; // 14% of 255
+/// Gap between the tile and the title block — design `.shead{gap:11px}`.
+const HEAD_GAP: f32 = 11.0;
+/// Space below the whole head — design `.shead{margin-bottom:16px}`.
+const HEAD_BOTTOM: f32 = 16.0;
+/// Title size — design `.shead .st{font-size:15px;font-weight:600}`.
+const HEAD_TITLE: f32 = 15.0;
+
+// ── Group label — design `.grouplabel` ───────────────────────────────────────
+
+/// Space above a group label — design `.grouplabel{margin:14px 0 7px}`.
+const GROUP_TOP: f32 = 14.0;
+/// …and below it.
+const GROUP_BOTTOM: f32 = 7.0;
+
+// ── Setting row — design `.srow` ─────────────────────────────────────────────
+
+/// Vertical padding — design `.srow{padding:11px 0}`.
+const ROW_PAD_V: f32 = 11.0;
+/// Gap between the label block and the control — design `.srow{gap:16px}`.
+const ROW_GAP: f32 = 16.0;
+/// Description size — design `.srow .rd{font-size:11.5px}`.
+const ROW_DESC: f32 = 11.5;
+/// Description offset under the label — design `.srow .rd{margin-top:2px}`.
+const ROW_DESC_GAP: f32 = 2.0;
+/// Bottom hairline — design `.srow{box-shadow:inset 0 -1px 0 surface1@22%}`.
+const ROW_RULE_ALPHA: u8 = 56; // 22% of 255
+/// Width reserved for the right-hand control column. The design lets `.ctl` size
+/// itself and `.lt` take the rest, which egui can't resolve in one pass, so the
+/// control side gets a fixed slot instead.
+const ROW_CONTROL_W: f32 = 220.0;
+/// Unsaved-change marker — design `.nitem .dot{width:6px}`.
+const DIRTY_DOT_RADIUS: f32 = 3.0;
+/// Gap between a label and its dirty dot.
+const DIRTY_DOT_GAP: f32 = 4.0;
+
+/// Slider cell width — design `.sldr{width:150px}` plus the SDK slider's own
+/// 12px gap and 34px value readout.
+const SLIDER_W: f32 = 196.0;
+
+/// A small accent dot marking a value that differs from the baseline.
 pub fn dirty_dot(ui: &mut egui::Ui, colors: &ThemeColors) {
     let (rect, _) = ui.allocate_exact_size(
-        egui::vec2(DIRTY_DOT_RADIUS * 2.0 + 4.0, DIRTY_DOT_RADIUS * 2.0),
+        egui::vec2(
+            DIRTY_DOT_RADIUS * 2.0 + DIRTY_DOT_GAP,
+            DIRTY_DOT_RADIUS * 2.0,
+        ),
         egui::Sense::hover(),
     );
     ui.painter()
         .circle_filled(rect.center(), DIRTY_DOT_RADIUS, colors.accent);
 }
 
+/// Render a pane's head: an accent icon tile, the section title, and a muted
+/// one-line description under it — design `.shead`.
 pub fn section_header(
     ui: &mut egui::Ui,
     icon: &str,
@@ -22,76 +77,60 @@ pub fn section_header(
     subtitle: &str,
     colors: &ThemeColors,
 ) {
-    ui.add_space(24.0);
-    ui.horizontal(|ui| {
-        ui.add_space(ROW_PADDING_H);
-        ui.label(icon_rich_text(icon, 20.0).color(colors.fg));
-        ui.add_space(10.0);
+    ui.horizontal_top(|ui| {
+        // Every gap here is explicit — design `.shead{gap:11px}`.
+        ui.spacing_mut().item_spacing.x = 0.0;
+
+        let (tile, _) = ui.allocate_exact_size(egui::vec2(TILE, TILE), egui::Sense::hover());
+        ui.painter().rect_filled(
+            tile,
+            egui::CornerRadius::from(RADIUS_PANEL),
+            with_alpha(colors.accent, TILE_TINT_ALPHA),
+        );
+        ui.painter().text(
+            tile.center(),
+            egui::Align2::CENTER_CENTER,
+            icon,
+            phosphor_font_id(TILE_GLYPH),
+            colors.accent,
+        );
+
+        ui.add_space(HEAD_GAP);
         ui.vertical(|ui| {
-            Typography::heading(ui, title);
+            ui.add(
+                Typography::builder()
+                    .text(title)
+                    .variant(TypographyVariant::Heading)
+                    .size(HEAD_TITLE)
+                    .build(),
+            );
             if !subtitle.is_empty() {
-                ui.add_space(2.0);
+                ui.add_space(ROW_DESC_GAP);
                 Typography::body_muted(ui, subtitle);
             }
         });
     });
-    ui.add_space(20.0);
-    // Separator inset by CARD_OUTER_H so it aligns with the card edges below
-    let r = ui.available_rect_before_wrap();
-    ui.painter().hline(
-        egui::Rangef::new(r.left() + CARD_OUTER_H, r.right() - CARD_OUTER_H),
-        ui.cursor().top(),
-        egui::Stroke::new(1.0, colors.surface_raised),
-    );
-    ui.add_space(1.0);
+    ui.add_space(HEAD_BOTTOM);
 }
 
-/// Render a titled card that wraps setting rows.
-/// Rows drawn inside the closure share borders and rounded corners.
-/// Pass a stable `id` string unique to this group (used to track the first-row flag).
-pub fn group_rows(
-    ui: &mut egui::Ui,
-    title: &str,
-    id: &str,
-    colors: &ThemeColors,
-    content: impl FnOnce(&mut egui::Ui),
-) {
-    // Group title (small-caps label above the card)
-    ui.add_space(GROUP_SPACING);
-    ui.horizontal(|ui| {
-        ui.add_space(ROW_PADDING_H);
-        Typography::group_label(ui, title);
+/// Label a run of related setting rows — design `.grouplabel`. Rows are flat, so
+/// this only prints the label and spaces the rows beneath it.
+pub fn group_rows(ui: &mut egui::Ui, title: &str, content: impl FnOnce(&mut egui::Ui)) {
+    ui.add_space(GROUP_TOP);
+    Typography::group_label(ui, title);
+    ui.add_space(GROUP_BOTTOM);
+    // Rows abut: their own padding is the whole gap, so the hairline between two
+    // of them lands exactly on the boundary.
+    ui.vertical(|ui| {
+        ui.spacing_mut().item_spacing.y = 0.0;
+        content(ui);
     });
-    ui.add_space(6.0);
-
-    // Reset "first row" flag so the first setting_row inside this card omits its top separator
-    let flag_id = egui::Id::new(("group_first_row", id));
-    ui.ctx().data_mut(|d| d.insert_temp(flag_id, true));
-
-    // Card frame: bg_panel fill, 1px surface border, 8px radius, indented by CARD_OUTER_H
-    let stroke_color = colors.surface_raised;
-    egui::Frame::new()
-        .fill(colors.bg_panel)
-        .stroke(egui::Stroke::new(1.0, stroke_color))
-        .corner_radius(egui::CornerRadius::same(CARD_RADIUS as u8))
-        .outer_margin(egui::Margin {
-            left: CARD_OUTER_H as i8,
-            right: CARD_OUTER_H as i8,
-            top: 0,
-            bottom: 0,
-        })
-        .inner_margin(egui::Margin::ZERO)
-        .show(ui, |ui| {
-            // Store the flag id so setting_row can find it
-            ui.ctx()
-                .data_mut(|d| d.insert_temp(egui::Id::new("current_group_flag"), flag_id));
-            content(ui);
-        });
 }
 
-/// Render a two-column setting row inside a `group_rows` card.
+/// Render a setting row: label (plus optional description and error) on the
+/// left, the control right-aligned, and a hairline along the bottom edge —
+/// design `.srow`.
 ///
-/// Automatically draws a top separator between consecutive rows (not before the first).
 /// `dirty = true` shows an accent dot next to the label.
 pub fn setting_row(
     ui: &mut egui::Ui,
@@ -102,95 +141,112 @@ pub fn setting_row(
     colors: &ThemeColors,
     content: impl FnOnce(&mut egui::Ui),
 ) {
-    // Draw top separator for every row except the first in the group
-    let flag_id: Option<egui::Id> = ui
-        .ctx()
-        .data(|d| d.get_temp(egui::Id::new("current_group_flag")));
-
-    if let Some(fid) = flag_id {
-        let is_first: bool = ui.ctx().data(|d| d.get_temp(fid).unwrap_or(false));
-        if !is_first {
-            let sep_y = ui.cursor().top();
-            // Use the frame's available rect, not clip_rect, so the line stays
-            // within the card's visual bounds and respects its corner radius.
-            let r = ui.available_rect_before_wrap();
-            ui.painter().hline(
-                egui::Rangef::new(r.left(), r.right()),
-                sep_y,
-                egui::Stroke::new(1.0, colors.surface_raised),
-            );
-        } else {
-            ui.ctx().data_mut(|d| d.insert_temp(fid, false));
-        }
-    }
-
-    egui::Frame::new()
-        .fill(Color32::TRANSPARENT)
-        .inner_margin(egui::Margin {
-            left: ROW_INNER_H as i8,
-            right: ROW_INNER_H as i8,
-            top: ROW_PADDING_V as i8,
-            bottom: ROW_PADDING_V as i8,
-        })
+    let row = egui::Frame::new()
+        .inner_margin(egui::Margin::symmetric(0, ROW_PAD_V as i8))
         .show(ui, |ui| {
-            let available_w = ui.available_width();
-            let label_width = (available_w - CONTROL_WIDTH - 8.0).max(0.0);
+            // Always span the pane's content column so the hairline below lines
+            // up from row to row.
+            ui.set_min_width(ui.available_width());
+            let label_w = (ui.available_width() - ROW_CONTROL_W - ROW_GAP).max(0.0);
             let has_extra = hint.is_some() || error.is_some();
 
+            // The label block: 13px label, then the 11.5px muted description.
+            let label_block = |ui: &mut egui::Ui| {
+                ui.horizontal(|ui| {
+                    Typography::body_large(ui, label);
+                    if dirty {
+                        dirty_dot(ui, colors);
+                    }
+                });
+                if let Some(h) = hint {
+                    ui.add_space(ROW_DESC_GAP);
+                    ui.add(
+                        Typography::builder()
+                            .text(h)
+                            .variant(TypographyVariant::Caption)
+                            .size(ROW_DESC)
+                            .build(),
+                    );
+                }
+                if let Some(e) = error {
+                    ui.horizontal(|ui| {
+                        ui.label(
+                            crate::theme::icon_rich_text(egui_phosphor::regular::WARNING, ROW_DESC)
+                                .color(colors.error),
+                        );
+                        ui.add_space(2.0);
+                        ui.add(
+                            Typography::builder()
+                                .text(e)
+                                .variant(TypographyVariant::Caption)
+                                .size(ROW_DESC)
+                                .color(thoth_plugin_sdk::theme::color_to_hex(colors.error))
+                                .build(),
+                        );
+                    });
+                }
+            };
+
             if has_extra {
-                // Multi-line rows: auto-height, label top-aligned, hint stacks below.
+                // Multi-line rows grow to fit; the control centres against the block.
                 ui.horizontal(|ui| {
                     ui.vertical(|ui| {
-                        ui.set_min_width(label_width);
-                        ui.horizontal(|ui| {
-                            Typography::body_large(ui, label);
-                            if dirty {
-                                ui.add_space(4.0);
-                                dirty_dot(ui, colors);
-                            }
-                        });
-                        if let Some(h) = hint {
-                            ui.add_space(1.0);
-                            Typography::caption(ui, h);
-                        }
-                        if let Some(e) = error {
-                            ui.horizontal(|ui| {
-                                ui.label(
-                                    icon_rich_text(egui_phosphor::regular::WARNING, 11.0)
-                                        .color(colors.error),
-                                );
-                                ui.add_space(2.0);
-                                ui.label(RichText::new(e).size(11.0).color(colors.error));
-                            });
-                        }
+                        ui.set_min_width(label_w);
+                        label_block(ui);
                     });
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        content(ui);
-                    });
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), content);
                 });
             } else {
-                // Single-line rows: allocate a finite row height so Align::Center
-                // actually centres the label text with the control widget.
-                let row_h = ui.text_style_height(&egui::TextStyle::Body) + 8.0;
+                // Single-line rows get a control-height row so the label centres
+                // against the widget beside it.
                 ui.allocate_ui_with_layout(
-                    egui::vec2(available_w, row_h),
+                    egui::vec2(ui.available_width(), FIELD_HEIGHT),
                     egui::Layout::left_to_right(egui::Align::Center),
                     |ui| {
-                        // Label side
                         ui.scope(|ui| {
-                            ui.set_min_width(label_width);
-                            Typography::body_large(ui, label);
-                            if dirty {
-                                ui.add_space(4.0);
-                                dirty_dot(ui, colors);
-                            }
+                            ui.set_min_width(label_w);
+                            label_block(ui);
                         });
-                        // Control side
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            content(ui);
-                        });
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), content);
                     },
                 );
             }
         });
+
+    // Bottom hairline — design `.srow{box-shadow:inset 0 -1px 0 …}`. Painted
+    // rather than added: the row is already laid out, and a separator that
+    // claimed a point of height would push the next row down.
+    let r = row.response.rect;
+    Separator::rule(color_to_hex(with_alpha(
+        colors.surface_raised,
+        ROW_RULE_ALPHA,
+    )))
+    .paint_at(ui, r.x_range(), r.bottom());
+}
+
+/// Render an SDK [`Slider`] at the design's fixed track width, with the unit
+/// suffix after the value readout — design `.sldr` + `.pfield .val`.
+///
+/// Call from inside a [`setting_row`] control closure (a right-to-left layout,
+/// so the unit is added first to land to the right of the track). Returns the
+/// new value when the user moves the slider.
+pub fn slider_control(
+    ui: &mut egui::Ui,
+    value: f64,
+    min: f64,
+    max: f64,
+    unit: &str,
+) -> Option<f64> {
+    if !unit.is_empty() {
+        Typography::caption(ui, unit);
+    }
+
+    let mut changed = None;
+    ui.allocate_ui(egui::vec2(SLIDER_W, FIELD_HEIGHT), |ui| {
+        let mut slider = Slider::builder().value(value).min(min).max(max).build();
+        if slider.show(ui).changed() {
+            changed = Some(slider.value);
+        }
+    });
+    changed
 }

--- a/src/components/settings_dialog/interface.rs
+++ b/src/components/settings_dialog/interface.rs
@@ -1,6 +1,8 @@
 use eframe::egui;
 
-use crate::components::settings_dialog::helpers::{group_rows, section_header, setting_row};
+use crate::components::settings_dialog::helpers::{
+    group_rows, section_header, setting_row, slider_control,
+};
 use crate::components::traits::StatelessComponent;
 use crate::settings::UiSettings;
 use crate::theme::ThemeColors;
@@ -50,7 +52,7 @@ impl StatelessComponent for InterfaceTab {
                 );
 
                 // ── Sidebar ──────────────────────────────────────────────────
-                group_rows(ui, "SIDEBAR", "interface-sidebar", colors, |ui| {
+                group_rows(ui, "SIDEBAR", |ui| {
                     setting_row(
                         ui,
                         "Sidebar width",
@@ -59,16 +61,12 @@ impl StatelessComponent for InterfaceTab {
                         None,
                         colors,
                         |ui| {
-                            let mut val = s.sidebar_width as i32;
-                            if ui
-                                .add(
-                                    egui::Slider::new(&mut val, 200..=1000)
-                                        .suffix(" px")
-                                        .clamping(egui::SliderClamping::Always),
-                                )
-                                .changed()
+                            if let Some(val) =
+                                slider_control(ui, s.sidebar_width as f64, 200.0, 1000.0, "px")
                             {
-                                events.push(InterfaceTabEvent::SidebarWidthChanged(val as f32));
+                                events.push(InterfaceTabEvent::SidebarWidthChanged(
+                                    val.round() as f32
+                                ));
                             }
                         },
                     );
@@ -93,7 +91,7 @@ impl StatelessComponent for InterfaceTab {
                 });
 
                 // ── Chrome ───────────────────────────────────────────────────
-                group_rows(ui, "CHROME", "interface-chrome", colors, |ui| {
+                group_rows(ui, "CHROME", |ui| {
                     setting_row(
                         ui,
                         "Show toolbar",
@@ -132,7 +130,7 @@ impl StatelessComponent for InterfaceTab {
                 });
 
                 // ── Motion ───────────────────────────────────────────────────
-                group_rows(ui, "MOTION", "interface-motion", colors, |ui| {
+                group_rows(ui, "MOTION", |ui| {
                     setting_row(
                         ui,
                         "Enable animations",
@@ -151,8 +149,6 @@ impl StatelessComponent for InterfaceTab {
                         },
                     );
                 });
-
-                ui.add_space(24.0);
             });
 
         InterfaceTabOutput { events }

--- a/src/components/settings_dialog/mod.rs
+++ b/src/components/settings_dialog/mod.rs
@@ -1085,17 +1085,22 @@ impl ContextComponent for SettingsDialog {
                             ui.spacing_mut().item_spacing.x = 0.0;
 
                             // Dirty indicator — design `.sfoot .dirty`.
-                            let (is_dirty, dirty_count) = if let (Ok(draft), Ok(baseline)) =
-                                (draft_settings.lock(), viewport_baseline.lock())
-                            {
-                                let count = SettingsTab::all()
-                                    .iter()
-                                    .filter(|&&t| section_is_dirty(t, &draft, &baseline))
-                                    .count();
-                                (count > 0, count)
-                            } else {
-                                (false, 0)
-                            };
+                            // `section_dirty` is the selected tab alone — the
+                            // reset action below only touches that section.
+                            let (is_dirty, dirty_count, section_dirty) =
+                                if let (Ok(draft), Ok(baseline), Ok(tab)) = (
+                                    draft_settings.lock(),
+                                    viewport_baseline.lock(),
+                                    selected_tab.lock(),
+                                ) {
+                                    let count = SettingsTab::all()
+                                        .iter()
+                                        .filter(|&&t| section_is_dirty(t, &draft, &baseline))
+                                        .count();
+                                    (count > 0, count, section_is_dirty(*tab, &draft, &baseline))
+                                } else {
+                                    (false, 0, false)
+                                };
 
                             if is_dirty {
                                 let (dot, _) = ui.allocate_exact_size(
@@ -1166,7 +1171,7 @@ impl ContextComponent for SettingsDialog {
                                     }
 
                                     // `.btn.text` — only offered when there is something to reset.
-                                    if is_dirty {
+                                    if section_dirty {
                                         ui.add_space(FOOT_BTN_GAP);
                                         let reset_btn = ui.add(
                                             Button::builder()

--- a/src/components/settings_dialog/mod.rs
+++ b/src/components/settings_dialog/mod.rs
@@ -38,7 +38,99 @@ use crate::settings::Settings;
 use crate::theme::{self, Theme, ThemeColors, icon_rich_text, phosphor_font_id};
 use eframe::egui;
 use std::sync::{Arc, Mutex};
-use thoth_plugin_sdk::components::{Button, ButtonColor, ButtonType, IconButton, Input};
+use thoth_plugin_sdk::components::{
+    Button, ButtonColor, ButtonType, IconButton, Input, Typography, TypographyVariant,
+};
+use thoth_plugin_sdk::theme::{
+    FONT_CONTROL, ICON_CONTROL, RADIUS_CONTROL, color_to_hex, with_alpha,
+};
+
+// ── Window chrome metrics ────────────────────────────────────────────────────
+
+/// Smallest the window may get before the two-column layout stops working.
+const MIN_W: f32 = 800.0;
+/// …and its vertical counterpart.
+const MIN_H: f32 = 520.0;
+/// Fraction of the parent window the settings window opens at.
+const OPEN_FRACTION: f32 = 0.85;
+
+/// Title bar height — design `.stitle{height:32px}`.
+const TITLE_H: f32 = 32.0;
+/// …and the gap between its items — design `.stitle{gap:8px}`.
+const TITLE_GAP: f32 = 8.0;
+/// Close button — design `.stitle .x{width:24px;height:24px}`…
+const CLOSE_SIZE: f32 = 24.0;
+/// …with a 14px glyph — design `.stitle .x{font-size:14px}`.
+const CLOSE_GLYPH: f32 = 14.0;
+
+/// Nav rail width — design `.snav{width:230px}`.
+const NAV_W: f32 = 230.0;
+/// Rail padding — design `.snav{padding:12px 10px}`.
+const NAV_PAD_H: i8 = 10;
+/// …vertical component of the same rule.
+const NAV_PAD_V: i8 = 12;
+/// Space under the rail heading — design `.snav .h{padding:0 4px 8px}`.
+const NAV_HEADING_BOTTOM: f32 = 8.0;
+/// …and its side inset.
+const NAV_HEADING_PAD: f32 = 4.0;
+/// Space under the search field — design `.snav .search{margin-bottom:8px}`.
+const NAV_SEARCH_BOTTOM: f32 = 8.0;
+
+/// Nav row height — design `.nitem{height:34px}`.
+const NAV_ITEM_H: f32 = 34.0;
+/// …its horizontal padding — design `.nitem{padding:0 9px}`.
+const NAV_ITEM_PAD: f32 = 9.0;
+/// …the gap between glyph and label — design `.nitem{gap:9px}`.
+const NAV_ITEM_GAP: f32 = 9.0;
+/// …and the space between rows — design `.snav .items{gap:1px}`.
+const NAV_ITEM_SPACING: f32 = 1.0;
+/// Nav glyph size — design `.nitem i{font-size:16px}`.
+const NAV_GLYPH: f32 = 16.0;
+/// Hover wash — design `.nitem:hover{background:text@6%}`.
+const NAV_HOVER_ALPHA: u8 = 15; // 6% of 255
+/// Selected wash — design `.nitem.on{background:mauve@14%}`.
+const NAV_SELECTED_ALPHA: u8 = 36; // 14% of 255
+/// Selected stripe — design `.nitem.on::before{width:3px;border-radius:3px}`…
+const NAV_STRIPE_W: f32 = 3.0;
+/// …inset this far from the row's top and bottom — design `{top:8px;bottom:8px}`.
+const NAV_STRIPE_INSET_Y: f32 = 8.0;
+/// …and sitting at the rail's own left edge — design `{left:-10px}`.
+const NAV_STRIPE_OFFSET_X: f32 = NAV_PAD_H as f32;
+/// Trailing unsaved-change dot — design `.nitem .dot{width:6px}`.
+const NAV_DOT_RADIUS: f32 = 3.0;
+
+/// Rail footer — design `.snav .foot{padding:8px 6px 2px}`.
+const NAV_FOOT_PAD_H: f32 = 6.0;
+/// …its top padding.
+const NAV_FOOT_PAD_TOP: f32 = 8.0;
+/// …the gap between glyph and filename — design `.snav .foot{gap:7px}`.
+const NAV_FOOT_GAP: f32 = 7.0;
+/// …its text size — design `.snav .foot{font-size:11.5px}`.
+const NAV_FOOT_FONT: f32 = 11.5;
+/// …and its glyph size — design `.snav .foot i{font-size:14px}`.
+const NAV_FOOT_GLYPH: f32 = 14.0;
+/// Height reserved for the footer row: 8px top padding, one 11.5px line, 2px below.
+const NAV_FOOT_H: f32 = 26.0;
+
+/// Content padding — design `.spane{padding:18px 20px}`.
+const PANE_PAD_V: i8 = 18;
+/// …horizontal component of the same rule.
+const PANE_PAD_H: i8 = 20;
+
+/// Footer bar height — design `.sfoot{height:52px}`.
+const FOOT_H: f32 = 52.0;
+/// …its horizontal padding — design `.sfoot{padding:0 18px}`.
+const FOOT_PAD_H: i8 = 18;
+/// Top hairline — design `.sfoot{box-shadow:inset 0 1px 0 surface1@26%}`.
+const FOOT_RULE_ALPHA: u8 = 66; // 26% of 255
+/// Dirty dot — design `.sfoot .dirty .d{width:7px}`.
+const FOOT_DOT_RADIUS: f32 = 3.5;
+/// …the gap after it — design `.sfoot .dirty{gap:7px}`.
+const FOOT_DOT_GAP: f32 = 7.0;
+/// Gap between the footer's action buttons — design `.sfoot .sp{gap:8px}`.
+const FOOT_BTN_GAP: f32 = 8.0;
+/// Dirty label size — design `.sfoot .dirty{font-size:12px}`.
+const FOOT_LABEL_FONT: f32 = 12.0;
 
 /// Settings dialog with modern UI
 pub struct SettingsDialog {
@@ -562,6 +654,35 @@ fn reset_section(tab: SettingsTab, draft: &mut Settings) {
     }
 }
 
+/// Build the settings window — design `.swin`, which is a window in its own
+/// right, so it wears the same chrome as the app's main window (`app-mockup`'s
+/// squircle `.win`).
+///
+/// The rounded corners and the drop shadow are the platform's: macOS only rounds
+/// a *titled* window, and an undecorated one is borderless — which is what left
+/// this window square. So instead of dropping the decorations, keep the native
+/// frame and make its title bar transparent and button-less, exactly as
+/// `main.rs` does for the main window; our own `.stitle` then owns the top row.
+/// No other platform splits a window that way, so there they stay undecorated.
+fn settings_viewport(width: f32, height: f32) -> egui::ViewportBuilder {
+    let builder = egui::ViewportBuilder::default()
+        .with_title("Thoth - Settings")
+        .with_inner_size([width, height])
+        .with_min_inner_size([MIN_W, MIN_H]);
+
+    #[cfg(target_os = "macos")]
+    let builder = builder
+        .with_fullsize_content_view(true)
+        .with_titlebar_shown(false)
+        .with_title_shown(false)
+        .with_titlebar_buttons_shown(false);
+
+    #[cfg(not(target_os = "macos"))]
+    let builder = builder.with_decorations(false);
+
+    builder
+}
+
 impl ContextComponent for SettingsDialog {
     type Props<'a> = SettingsDialogProps<'a>;
     type Output = SettingsDialogOutput;
@@ -592,19 +713,15 @@ impl ContextComponent for SettingsDialog {
         let last_check_clone = props.last_check;
         let current_version = props.current_version.to_string();
 
-        // Size the settings window to 75% of the parent window, clamped to a
-        // sensible minimum so the layout never breaks on small screens.
+        // Size the settings window to a fraction of the parent window, clamped
+        // to a sensible minimum so the layout never breaks on small screens.
         let parent_size = ui.ctx().content_rect().size();
-        let settings_w = (parent_size.x * 0.85).max(800.0);
-        let settings_h = (parent_size.y * 0.85).max(520.0);
+        let settings_w = (parent_size.x * OPEN_FRACTION).max(MIN_W);
+        let settings_h = (parent_size.y * OPEN_FRACTION).max(MIN_H);
 
         ui.ctx().show_viewport_deferred(
             viewport_id,
-            egui::ViewportBuilder::default()
-                .with_title("Thoth - Settings")
-                .with_decorations(false)
-                .with_inner_size([settings_w, settings_h])
-                .with_min_inner_size([800.0, 520.0]),
+            settings_viewport(settings_w, settings_h),
             move |ui, class| {
                 let ctx = ui.ctx().clone();
 
@@ -635,13 +752,18 @@ impl ContextComponent for SettingsDialog {
 
                 let mut new_settings = None;
 
-                // ── Custom title bar (32px) ───────────────────────────────
+                // ── Title bar — design `.stitle` ──────────────────────────
                 egui::Panel::top("settings_titlebar")
-                    .exact_size(32.0)
+                    .exact_size(TITLE_H)
                     .frame(
                         egui::Frame::default()
-                            .fill(theme_colors.bg_sunken)
-                            .inner_margin(egui::Margin::symmetric(12, 0)),
+                            .fill(theme_colors.bg_panel)
+                            .inner_margin(egui::Margin {
+                                left: 12,
+                                right: 8,
+                                top: 0,
+                                bottom: 0,
+                            }),
                     )
                     .show_inside(ui, |ui| {
                         // Make the whole bar draggable so the window can be moved
@@ -655,19 +777,28 @@ impl ContextComponent for SettingsDialog {
                         }
 
                         ui.horizontal_centered(|ui| {
-                            // App icon glyph
+                            // Every gap is explicit — design `.stitle{gap:8px}`.
+                            ui.spacing_mut().item_spacing.x = 0.0;
+
+                            // Leading accent glyph — design `.stitle .ico`.
                             ui.label(
-                                icon_rich_text(egui_phosphor::regular::TREE_STRUCTURE, 13.0)
-                                    .color(theme_colors.accent),
+                                icon_rich_text(
+                                    egui_phosphor::regular::TREE_STRUCTURE,
+                                    ICON_CONTROL,
+                                )
+                                .color(theme_colors.accent),
                             );
-                            ui.add_space(6.0);
-                            ui.label(
-                                egui::RichText::new("Settings")
-                                    .size(13.0)
-                                    .color(theme_colors.fg),
+                            ui.add_space(TITLE_GAP);
+                            // `.stitle .t` — 12.5px in the subdued title colour.
+                            ui.add(
+                                Typography::builder()
+                                    .text("Settings")
+                                    .size(FONT_CONTROL)
+                                    .color(color_to_hex(theme_colors.fg_subtle()))
+                                    .build(),
                             );
 
-                            // Close button (right-aligned)
+                            // Ghost close button — design `.stitle .x`.
                             ui.with_layout(
                                 egui::Layout::right_to_left(egui::Align::Center),
                                 |ui| {
@@ -676,7 +807,8 @@ impl ContextComponent for SettingsDialog {
                                             .icon(egui_phosphor::regular::X)
                                             .tooltip("Close")
                                             .frame(false)
-                                            .size_px(20.0)
+                                            .size_px(CLOSE_SIZE)
+                                            .icon_size(CLOSE_GLYPH)
                                             .build(),
                                     );
                                     if close_out.clicked() {
@@ -688,206 +820,44 @@ impl ContextComponent for SettingsDialog {
                                 },
                             );
                         });
-
-                        // Bottom divider
-                        ui.painter().hline(
-                            ui.clip_rect().x_range(),
-                            ui.clip_rect().bottom(),
-                            egui::Stroke::new(1.0, theme_colors.surface),
-                        );
                     });
 
-                // ── Footer (56px) ────────────────────────────────────────
-                egui::Panel::bottom("settings_bottom")
-                    .exact_size(56.0)
-                    .frame(
-                        egui::Frame::default()
-                            .fill(theme_colors.bg_sunken)
-                            .inner_margin(egui::Margin::symmetric(16, 0)),
-                    )
-                    .show_inside(ui, |ui| {
-                        // Top divider
-                        ui.painter().hline(
-                            ui.clip_rect().x_range(),
-                            ui.clip_rect().top(),
-                            egui::Stroke::new(1.0, theme_colors.surface_raised),
-                        );
-
-                        ui.horizontal_centered(|ui| {
-                            // Dirty indicator (left side)
-                            let (is_dirty, dirty_count) = if let (Ok(draft), Ok(baseline)) =
-                                (draft_settings.lock(), viewport_baseline.lock())
-                            {
-                                let count = SettingsTab::all()
-                                    .iter()
-                                    .filter(|&&t| section_is_dirty(t, &draft, &baseline))
-                                    .count();
-                                (count > 0, count)
-                            } else {
-                                (false, 0)
-                            };
-
-                            if is_dirty {
-                                ui.painter().circle_filled(
-                                    ui.cursor().center_top() + egui::vec2(5.0, 10.0),
-                                    4.0,
-                                    theme_colors.accent,
-                                );
-                                ui.add_space(14.0);
-                                let label = if dirty_count == 1 {
-                                    "1 unsaved change".to_string()
-                                } else {
-                                    format!("{dirty_count} unsaved changes")
-                                };
-                                ui.label(
-                                    egui::RichText::new(label)
-                                        .size(12.0)
-                                        .color(theme_colors.fg_muted),
-                                );
-                            }
-
-                            // Buttons (right side)
-                            ui.with_layout(
-                                egui::Layout::right_to_left(egui::Align::Center),
-                                |ui| {
-                                    // Save button
-                                    let save_btn = ui.add(
-                                        Button::builder()
-                                            .label("Save changes")
-                                            .button_type(ButtonType::Elevated)
-                                            .color(ButtonColor::Primary)
-                                            .size(13.0)
-                                            .enabled(is_dirty)
-                                            .build(),
-                                    );
-                                    if save_btn.clicked()
-                                        && let Ok(settings) = draft_settings.lock()
-                                    {
-                                        new_settings = Some(settings.clone());
-                                        NotificationManager::notify(
-                                            Notification::new("Setting saved.", "")
-                                                .with_toast(true)
-                                                .with_status(NotificationStatus::Completed),
-                                        );
-                                    }
-
-                                    ui.add_space(8.0);
-
-                                    // Cancel button
-                                    let cancel_btn = ui.add(
-                                        Button::builder()
-                                            .label("Cancel")
-                                            .button_type(ButtonType::Elevated)
-                                            .color(ButtonColor::Default)
-                                            .size(13.0)
-                                            .build(),
-                                    );
-                                    if cancel_btn.clicked() {
-                                        if let Ok(mut closed) = viewport_closed.lock() {
-                                            *closed = true;
-                                        }
-                                        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
-                                    }
-
-                                    ui.add_space(8.0);
-
-                                    // Reset section button
-                                    if is_dirty {
-                                        let reset_btn = ui.add(
-                                            Button::builder()
-                                                .label("Reset section")
-                                                .button_type(ButtonType::Text)
-                                                .color(ButtonColor::Default)
-                                                .size(12.0)
-                                                .build(),
-                                        );
-                                        if reset_btn.clicked()
-                                            && let (Ok(mut draft), Ok(tab)) =
-                                                (draft_settings.lock(), selected_tab.lock())
-                                        {
-                                            reset_section(*tab, &mut draft);
-                                        }
-                                    }
-                                },
-                            );
-                        });
-                    });
-
-                // ── Sidebar (240px) ─────────────────────────────────────
+                // ── Nav rail — design `.snav` ─────────────────────────────
                 egui::Panel::left("settings_sidebar")
                     .resizable(false)
-                    .exact_size(240.0)
+                    .exact_size(NAV_W)
                     .frame(
                         egui::Frame::default()
                             .fill(theme_colors.bg_panel)
-                            .inner_margin(egui::Margin::ZERO),
+                            .inner_margin(egui::Margin::symmetric(NAV_PAD_H, NAV_PAD_V)),
                     )
                     .show_inside(ui, |ui| {
-                        // Title
-                        egui::Frame::new()
-                            .inner_margin(egui::Margin {
-                                left: 16,
-                                right: 16,
-                                top: 16,
-                                bottom: 8,
-                            })
-                            .show(ui, |ui| {
-                                ui.label(
-                                    egui::RichText::new("Settings")
-                                        .size(14.0)
-                                        .strong()
-                                        .color(theme_colors.fg),
-                                );
-                            });
-
-                        // Search box
-                        let search_id = egui::Id::new("settings_search_query");
-                        let mut search_query: String =
-                            ctx.data(|d| d.get_temp(search_id).unwrap_or_default());
-                        egui::Frame::NONE
-                            .outer_margin(egui::Margin::symmetric(12, 4))
-                            .show(ui, |ui| {
-                                let mut input = Input::builder()
-                                    .value(search_query.clone())
-                                    .placeholder("Search settings…")
-                                    .icon(egui_phosphor::regular::MAGNIFYING_GLASS)
-                                    .rows(1)
-                                    .build();
-                                let r = input.show(ui);
-                                if r.inner {
-                                    search_query = input.value.clone();
-                                }
-                            });
-                        ctx.data_mut(|d| d.insert_temp(search_id, search_query.clone()));
-
-                        ui.add_space(4.0);
-                        ui.painter().hline(
-                            ui.clip_rect().x_range(),
-                            ui.cursor().top(),
-                            egui::Stroke::new(0.5, theme_colors.surface_raised),
-                        );
-                        ui.add_space(4.0);
-
-                        // ── Settings file path (sidebar bottom) ─────────
+                        // ── Settings file, pinned to the bottom — design `.snav .foot`
                         egui::Panel::bottom("sidebar_settings_file")
-                            .exact_size(36.0)
+                            .exact_size(NAV_FOOT_H)
                             .frame(
                                 egui::Frame::default()
                                     .fill(theme_colors.bg_panel)
-                                    .inner_margin(egui::Margin::symmetric(12, 0)),
+                                    .inner_margin(egui::Margin {
+                                        left: NAV_FOOT_PAD_H as i8,
+                                        right: NAV_FOOT_PAD_H as i8,
+                                        top: NAV_FOOT_PAD_TOP as i8,
+                                        bottom: 0,
+                                    }),
                             )
                             .show_inside(ui, |ui| {
-                                ui.painter().hline(
-                                    ui.clip_rect().x_range(),
-                                    ui.clip_rect().top(),
-                                    egui::Stroke::new(0.5, theme_colors.surface_raised),
-                                );
-                                ui.horizontal_centered(|ui| {
+                                ui.horizontal(|ui| {
+                                    // Every gap is explicit — design `.foot{gap:7px}`.
+                                    ui.spacing_mut().item_spacing.x = 0.0;
                                     ui.label(
-                                        icon_rich_text(egui_phosphor::regular::FILE_TEXT, 11.0)
-                                            .color(theme_colors.fg_muted),
+                                        icon_rich_text(
+                                            egui_phosphor::regular::FILE_TEXT,
+                                            NAV_FOOT_GLYPH,
+                                        )
+                                        .color(theme_colors.fg_muted),
                                     );
-                                    ui.add_space(4.0);
+                                    ui.add_space(NAV_FOOT_GAP);
+
                                     let path_str = crate::settings::Settings::settings_file_path()
                                         .map(|p| {
                                             p.file_name()
@@ -896,22 +866,28 @@ impl ContextComponent for SettingsDialog {
                                                 .to_string()
                                         })
                                         .unwrap_or_else(|_| "settings.toml".to_string());
-                                    let btn = ui.add(
-                                        Button::builder()
-                                            .label(path_str)
-                                            .button_type(ButtonType::Text)
-                                            .color(ButtonColor::Default)
-                                            .size(11.0)
-                                            .build(),
-                                    );
-                                    if btn.clicked()
+                                    // `.foot .fn` — the filename reads in monospace.
+                                    let name = ui
+                                        .add(
+                                            Typography::builder()
+                                                .text(path_str)
+                                                .variant(TypographyVariant::Mono)
+                                                .size(NAV_FOOT_FONT)
+                                                .color(color_to_hex(theme_colors.fg_muted))
+                                                .build(),
+                                        )
+                                        .interact(egui::Sense::click());
+                                    if name.hovered() {
+                                        ctx.set_cursor_icon(egui::CursorIcon::PointingHand);
+                                    }
+                                    if name.clicked()
                                         && let Ok(path) =
                                             crate::settings::Settings::settings_file_path()
                                     {
                                         let _ = open::that(path);
                                     }
                                     thoth_plugin_sdk::theme::hover_text(
-                                        btn,
+                                        name,
                                         crate::settings::Settings::settings_file_path()
                                             .map(|p| p.to_string_lossy().to_string())
                                             .unwrap_or_default(),
@@ -919,7 +895,30 @@ impl ContextComponent for SettingsDialog {
                                 });
                             });
 
-                        // Nav items
+                        // Heading — design `.snav .h{font-size:14px;font-weight:700}`.
+                        ui.horizontal(|ui| {
+                            ui.add_space(NAV_HEADING_PAD);
+                            Typography::title(ui, "Settings");
+                        });
+                        ui.add_space(NAV_HEADING_BOTTOM);
+
+                        // Search field — design `.snav .search`.
+                        let search_id = egui::Id::new("settings_search_query");
+                        let mut search_query: String =
+                            ctx.data(|d| d.get_temp(search_id).unwrap_or_default());
+                        let mut input = Input::builder()
+                            .value(search_query.clone())
+                            .placeholder("Search settings…")
+                            .icon(egui_phosphor::regular::MAGNIFYING_GLASS)
+                            .rows(1)
+                            .build();
+                        if input.show(ui).inner {
+                            search_query = input.value.clone();
+                        }
+                        ctx.data_mut(|d| d.insert_temp(search_id, search_query.clone()));
+                        ui.add_space(NAV_SEARCH_BOTTOM);
+
+                        // ── Nav items — design `.nitem` ──────────────────
                         egui::ScrollArea::vertical()
                             .auto_shrink([false; 2])
                             .show(ui, |ui| {
@@ -943,12 +942,11 @@ impl ContextComponent for SettingsDialog {
                                         (SettingsTab::General, Default::default())
                                     };
 
-                                let filter: String = ctx
-                                    .data(|d| d.get_temp(egui::Id::new("settings_search_query")))
-                                    .unwrap_or_default();
-                                let filter_lower = filter.to_lowercase();
+                                let filter_lower = search_query.to_lowercase();
 
-                                ui.add_space(4.0);
+                                // `.snav .items{gap:1px}`
+                                ui.spacing_mut().item_spacing.y = NAV_ITEM_SPACING;
+
                                 for &tab in SettingsTab::all() {
                                     if !filter_lower.is_empty() {
                                         let matches =
@@ -965,65 +963,88 @@ impl ContextComponent for SettingsDialog {
                                     let is_dirty = dirty_sections.contains(&tab);
 
                                     let (rect, resp) = ui.allocate_exact_size(
-                                        egui::vec2(ui.available_width(), 36.0),
+                                        egui::vec2(ui.available_width(), NAV_ITEM_H),
                                         egui::Sense::click(),
                                     );
 
-                                    // Selection / hover background
-                                    let bg = if is_selected {
-                                        theme_colors.surface_raised
+                                    // `.nitem.on` fills with mauve@14%, `:hover` with text@6%.
+                                    let (fill, tint) = if is_selected {
+                                        (
+                                            Some(with_alpha(
+                                                theme_colors.accent,
+                                                NAV_SELECTED_ALPHA,
+                                            )),
+                                            theme_colors.accent,
+                                        )
                                     } else if resp.hovered() {
-                                        egui::Color32::from_rgba_unmultiplied(
-                                            theme_colors.surface.r(),
-                                            theme_colors.surface.g(),
-                                            theme_colors.surface.b(),
-                                            120,
+                                        (
+                                            Some(with_alpha(theme_colors.fg, NAV_HOVER_ALPHA)),
+                                            theme_colors.fg,
                                         )
                                     } else {
-                                        egui::Color32::TRANSPARENT
+                                        (None, theme_colors.fg_muted)
                                     };
-                                    ui.painter().rect_filled(rect, 4.0, bg);
-
-                                    // Selection accent bar
-                                    if is_selected {
+                                    if let Some(fill) = fill {
                                         ui.painter().rect_filled(
-                                            egui::Rect::from_min_size(
-                                                rect.min,
-                                                egui::vec2(3.0, rect.height()),
+                                            rect,
+                                            egui::CornerRadius::from(RADIUS_CONTROL),
+                                            fill,
+                                        );
+                                    }
+
+                                    // `.nitem.on::before` — 3px stripe at the rail's
+                                    // edge, which sits outside the scroll
+                                    // viewport, so widen the clip to reach it.
+                                    if is_selected {
+                                        let painter = ui.painter().with_clip_rect(
+                                            ui.clip_rect()
+                                                .expand2(egui::vec2(NAV_STRIPE_OFFSET_X, 0.0)),
+                                        );
+                                        painter.rect_filled(
+                                            egui::Rect::from_min_max(
+                                                egui::pos2(
+                                                    rect.left() - NAV_STRIPE_OFFSET_X,
+                                                    rect.top() + NAV_STRIPE_INSET_Y,
+                                                ),
+                                                egui::pos2(
+                                                    rect.left() - NAV_STRIPE_OFFSET_X
+                                                        + NAV_STRIPE_W,
+                                                    rect.bottom() - NAV_STRIPE_INSET_Y,
+                                                ),
                                             ),
-                                            egui::CornerRadius::same(2),
+                                            egui::CornerRadius::from(NAV_STRIPE_W),
                                             theme_colors.accent,
                                         );
                                     }
 
-                                    // Icon
-                                    let text_color = if is_selected {
-                                        theme_colors.fg
-                                    } else {
-                                        theme_colors.fg_muted
-                                    };
+                                    // Glyph, then label one gap to its right.
+                                    let glyph_x = rect.left() + NAV_ITEM_PAD;
                                     ui.painter().text(
-                                        rect.min + egui::vec2(14.0, rect.height() / 2.0),
+                                        egui::pos2(glyph_x, rect.center().y),
                                         egui::Align2::LEFT_CENTER,
                                         tab.icon(),
-                                        phosphor_font_id(15.0),
-                                        text_color,
+                                        phosphor_font_id(NAV_GLYPH),
+                                        tint,
                                     );
-
-                                    // Label
                                     ui.painter().text(
-                                        rect.min + egui::vec2(36.0, rect.height() / 2.0),
+                                        egui::pos2(
+                                            glyph_x + NAV_GLYPH + NAV_ITEM_GAP,
+                                            rect.center().y,
+                                        ),
                                         egui::Align2::LEFT_CENTER,
                                         tab.label(),
-                                        egui::FontId::proportional(13.0),
-                                        text_color,
+                                        egui::FontId::proportional(FONT_CONTROL),
+                                        tint,
                                     );
 
-                                    // Dirty dot
+                                    // `.nitem .dot` — trailing unsaved-change marker.
                                     if is_dirty {
                                         ui.painter().circle_filled(
-                                            rect.right_center() - egui::vec2(12.0, 0.0),
-                                            3.0,
+                                            egui::pos2(
+                                                rect.right() - NAV_ITEM_PAD - NAV_DOT_RADIUS,
+                                                rect.center().y,
+                                            ),
+                                            NAV_DOT_RADIUS,
                                             theme_colors.accent,
                                         );
                                     }
@@ -1040,9 +1061,139 @@ impl ContextComponent for SettingsDialog {
                             });
                     });
 
-                // Central content area
+                // ── Footer bar — design `.sfoot` ──────────────────────────
+                egui::Panel::bottom("settings_bottom")
+                    .exact_size(FOOT_H)
+                    .frame(
+                        egui::Frame::default()
+                            .fill(theme_colors.bg_panel)
+                            .inner_margin(egui::Margin::symmetric(FOOT_PAD_H, 0)),
+                    )
+                    .show_inside(ui, |ui| {
+                        // Top hairline — design `.sfoot{box-shadow:inset 0 1px 0 …}`.
+                        ui.painter().hline(
+                            ui.clip_rect().x_range(),
+                            ui.clip_rect().top(),
+                            egui::Stroke::new(
+                                1.0,
+                                with_alpha(theme_colors.surface_raised, FOOT_RULE_ALPHA),
+                            ),
+                        );
+
+                        ui.horizontal_centered(|ui| {
+                            // Every gap in the bar is explicit.
+                            ui.spacing_mut().item_spacing.x = 0.0;
+
+                            // Dirty indicator — design `.sfoot .dirty`.
+                            let (is_dirty, dirty_count) = if let (Ok(draft), Ok(baseline)) =
+                                (draft_settings.lock(), viewport_baseline.lock())
+                            {
+                                let count = SettingsTab::all()
+                                    .iter()
+                                    .filter(|&&t| section_is_dirty(t, &draft, &baseline))
+                                    .count();
+                                (count > 0, count)
+                            } else {
+                                (false, 0)
+                            };
+
+                            if is_dirty {
+                                let (dot, _) = ui.allocate_exact_size(
+                                    egui::Vec2::splat(FOOT_DOT_RADIUS * 2.0),
+                                    egui::Sense::hover(),
+                                );
+                                ui.painter().circle_filled(
+                                    dot.center(),
+                                    FOOT_DOT_RADIUS,
+                                    theme_colors.accent,
+                                );
+                                ui.add_space(FOOT_DOT_GAP);
+                                let label = if dirty_count == 1 {
+                                    "1 unsaved change".to_string()
+                                } else {
+                                    format!("{dirty_count} unsaved changes")
+                                };
+                                ui.add(
+                                    Typography::builder()
+                                        .text(label)
+                                        .size(FOOT_LABEL_FONT)
+                                        .color(color_to_hex(theme_colors.fg_subtle()))
+                                        .build(),
+                                );
+                            }
+
+                            // Actions, right-aligned — design `.sfoot .sp{gap:8px}`.
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    ui.spacing_mut().item_spacing.x = 0.0;
+
+                                    // `.btn.primary`
+                                    let save_btn = ui.add(
+                                        Button::builder()
+                                            .label("Save changes")
+                                            .button_type(ButtonType::Elevated)
+                                            .color(ButtonColor::Primary)
+                                            .enabled(is_dirty)
+                                            .build(),
+                                    );
+                                    if save_btn.clicked()
+                                        && let Ok(settings) = draft_settings.lock()
+                                    {
+                                        new_settings = Some(settings.clone());
+                                        NotificationManager::notify(
+                                            Notification::new("Setting saved.", "")
+                                                .with_toast(true)
+                                                .with_status(NotificationStatus::Completed),
+                                        );
+                                    }
+
+                                    ui.add_space(FOOT_BTN_GAP);
+
+                                    // `.btn.default`
+                                    let cancel_btn = ui.add(
+                                        Button::builder()
+                                            .label("Cancel")
+                                            .button_type(ButtonType::Elevated)
+                                            .color(ButtonColor::Default)
+                                            .build(),
+                                    );
+                                    if cancel_btn.clicked() {
+                                        if let Ok(mut closed) = viewport_closed.lock() {
+                                            *closed = true;
+                                        }
+                                        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                                    }
+
+                                    // `.btn.text` — only offered when there is something to reset.
+                                    if is_dirty {
+                                        ui.add_space(FOOT_BTN_GAP);
+                                        let reset_btn = ui.add(
+                                            Button::builder()
+                                                .label("Reset section")
+                                                .button_type(ButtonType::Text)
+                                                .color(ButtonColor::Default)
+                                                .build(),
+                                        );
+                                        if reset_btn.clicked()
+                                            && let (Ok(mut draft), Ok(tab)) =
+                                                (draft_settings.lock(), selected_tab.lock())
+                                        {
+                                            reset_section(*tab, &mut draft);
+                                        }
+                                    }
+                                },
+                            );
+                        });
+                    });
+
+                // ── Content pane — design `.spane{padding:18px 20px}` ─────
                 egui::CentralPanel::default()
-                    .frame(egui::Frame::default().fill(theme_colors.bg))
+                    .frame(
+                        egui::Frame::default()
+                            .fill(theme_colors.bg)
+                            .inner_margin(egui::Margin::symmetric(PANE_PAD_H, PANE_PAD_V)),
+                    )
                     .show_inside(ui, |ui| {
                         if let (Ok(current_tab), Ok(mut settings), Ok(mut events), Ok(baseline)) = (
                             selected_tab.lock(),

--- a/src/components/settings_dialog/performance.rs
+++ b/src/components/settings_dialog/performance.rs
@@ -1,8 +1,11 @@
-use crate::components::settings_dialog::helpers::{group_rows, section_header, setting_row};
+use crate::components::settings_dialog::helpers::{
+    group_rows, section_header, setting_row, slider_control,
+};
 use crate::components::traits::StatelessComponent;
 use crate::settings::PerformanceSettings;
 use crate::theme::ThemeColors;
 use eframe::egui;
+use thoth_plugin_sdk::components::NumberInput;
 
 pub struct PerformanceTab;
 
@@ -44,7 +47,7 @@ impl StatelessComponent for PerformanceTab {
                     colors,
                 );
 
-                group_rows(ui, "CACHE", "perf-cache", colors, |ui| {
+                group_rows(ui, "CACHE", |ui| {
                     setting_row(
                         ui,
                         "Cache size",
@@ -53,22 +56,19 @@ impl StatelessComponent for PerformanceTab {
                         None,
                         colors,
                         |ui| {
-                            let mut val = s.cache_size as i32;
-                            if ui
-                                .add(
-                                    egui::Slider::new(&mut val, 1..=10000)
-                                        .step_by(50.0)
-                                        .suffix(" nodes"),
-                                )
-                                .changed()
+                            if let Some(val) =
+                                slider_control(ui, s.cache_size as f64, 1.0, 10000.0, "nodes")
                             {
-                                events.push(PerformanceTabEvent::CacheSizeChanged(val as usize));
+                                // Keep the old 50-node granularity.
+                                let snapped = ((val / 50.0).round() * 50.0).max(1.0);
+                                events
+                                    .push(PerformanceTabEvent::CacheSizeChanged(snapped as usize));
                             }
                         },
                     );
                 });
 
-                group_rows(ui, "FILES & HISTORY", "perf-files", colors, |ui| {
+                group_rows(ui, "FILES & HISTORY", |ui| {
                     setting_row(
                         ui,
                         "Recent files",
@@ -77,13 +77,17 @@ impl StatelessComponent for PerformanceTab {
                         None,
                         colors,
                         |ui| {
-                            let mut val = s.max_recent_files as i32;
-                            if ui
-                                .add(egui::DragValue::new(&mut val).range(1..=100))
-                                .changed()
-                            {
-                                events
-                                    .push(PerformanceTabEvent::MaxRecentFilesChanged(val as usize));
+                            let mut num = NumberInput::builder()
+                                .id("perf_max_recent_files")
+                                .value(s.max_recent_files as f64)
+                                .min(1.0)
+                                .max(100.0)
+                                .unit("files")
+                                .build();
+                            if num.show(ui).changed() {
+                                events.push(PerformanceTabEvent::MaxRecentFilesChanged(
+                                    num.value as usize,
+                                ));
                             }
                         },
                     );
@@ -96,24 +100,21 @@ impl StatelessComponent for PerformanceTab {
                         None,
                         colors,
                         |ui| {
-                            let mut val = s.navigation_history_size as i32;
-                            if ui
-                                .add(
-                                    egui::DragValue::new(&mut val)
-                                        .range(1..=1000)
-                                        .suffix(" steps"),
-                                )
-                                .changed()
-                            {
+                            let mut num = NumberInput::builder()
+                                .id("perf_navigation_history_size")
+                                .value(s.navigation_history_size as f64)
+                                .min(1.0)
+                                .max(1000.0)
+                                .unit("steps")
+                                .build();
+                            if num.show(ui).changed() {
                                 events.push(PerformanceTabEvent::NavigationHistorySizeChanged(
-                                    val as usize,
+                                    num.value as usize,
                                 ));
                             }
                         },
                     );
                 });
-
-                ui.add_space(24.0);
             });
 
         PerformanceTabOutput { events }

--- a/src/components/settings_dialog/plugins.rs
+++ b/src/components/settings_dialog/plugins.rs
@@ -13,7 +13,7 @@ use crate::plugin::{Capability, Plugin};
 use crate::settings::{PluginNetworkPolicy, PluginSettings};
 use crate::theme::{Theme, ThemeColors};
 use thoth_plugin_sdk::components::{
-    Card, CardAction, CardEvent, CardIcon, IconButton, Input, Separator, ToggleSwitch,
+    Card, CardAction, CardEvent, CardIcon, IconButton, Input, Separator, ToggleSwitch, Typography,
 };
 
 pub struct PluginsTab;
@@ -60,14 +60,7 @@ impl StatelessComponent for PluginsTab {
             egui::ScrollArea::vertical()
                 .auto_shrink([false; 2])
                 .show(ui, |ui| {
-                    ui.add_space(24.0);
-                    ui.horizontal(|ui| {
-                        ui.add_space(24.0);
-                        ui.label(
-                            egui::RichText::new("Plugin manager not available.")
-                                .color(colors.fg_muted),
-                        );
-                    });
+                    Typography::body_muted(ui, "Plugin manager not available.");
                 });
             return output;
         };
@@ -222,7 +215,7 @@ impl PluginsTab {
                 );
 
                 // ── Master toggle ────────────────────────────────���────────────
-                group_rows(ui, "SYSTEM", "plugins-system", colors, |ui| {
+                group_rows(ui, "SYSTEM", |ui| {
                     setting_row(
                         ui,
                         "Enable plugins",
@@ -242,28 +235,12 @@ impl PluginsTab {
                     );
                 });
 
-                // ── Installed section label ─────────────────────────────────���─
-                ui.add_space(20.0);
-                ui.horizontal(|ui| {
-                    ui.add_space(24.0);
-                    ui.label(
-                        egui::RichText::new("INSTALLED")
-                            .size(11.0)
-                            .strong()
-                            .color(colors.fg_muted),
-                    );
+                // ── Installed section label — design `.grouplabel` ────────────
+                group_rows(ui, "INSTALLED", |ui| {
+                    if all_plugins.is_empty() {
+                        Typography::body_muted(ui, "No plugins installed.");
+                    }
                 });
-                ui.add_space(6.0);
-
-                if all_plugins.is_empty() {
-                    ui.horizontal(|ui| {
-                        ui.add_space(24.0);
-                        ui.label(
-                            egui::RichText::new("No plugins installed.")
-                                .color(colors.fg_muted),
-                        );
-                    });
-                }
 
                 // Dim cards when plugins are disabled
                 let opacity = if props.plugin_settings.enabled { 1.0 } else { 0.4 };
@@ -271,7 +248,6 @@ impl PluginsTab {
 
                 // ── Plugin cards ──────────────────────────────────────────────
                 egui::Frame::new()
-                    .outer_margin(egui::Margin::symmetric(24, 0))
                     .show(ui, |ui| {
                         for plugin in all_plugins {
                             let is_enabled = !props

--- a/src/components/settings_dialog/shortcuts.rs
+++ b/src/components/settings_dialog/shortcuts.rs
@@ -3,7 +3,15 @@ use eframe::egui;
 use crate::components::settings_dialog::helpers::{group_rows, section_header, setting_row};
 use crate::components::traits::StatelessComponent;
 use crate::shortcuts::{KeyboardShortcuts, Shortcut};
-use crate::theme::ThemeColors;
+use crate::theme::{ThemeColors, edge_stroke};
+use thoth_plugin_sdk::theme::RADIUS_CONTROL;
+
+/// Shortcut badge height — design `.pfield{height:26px}`.
+const BADGE_H: f32 = 26.0;
+/// …and its label size — design `.pfield{font-size:12px}`.
+const BADGE_FONT: f32 = 12.0;
+/// Horizontal padding inside a badge — design `.pfield{padding:0 10px}`.
+const BADGE_PAD_H: f32 = 10.0;
 
 pub struct ShortcutsTab;
 
@@ -29,7 +37,7 @@ impl StatelessComponent for ShortcutsTab {
 
         // Pre-compute the widest badge so every badge gets the same width.
         let badge_width = {
-            let font_id = egui::FontId::proportional(12.0);
+            let font_id = egui::FontId::proportional(BADGE_FONT);
             let all: &[&Shortcut] = &[
                 &sc.open_file,
                 &sc.new_window,
@@ -72,8 +80,8 @@ impl StatelessComponent for ShortcutsTab {
                         .x
                 })
                 .fold(0.0_f32, f32::max);
-            // text width + 2×horizontal pad (8px each side)
-            (max_text_w + 16.0).ceil()
+            // text width + the design's 10px padding on each side
+            (max_text_w + BADGE_PAD_H * 2.0).ceil()
         };
 
         egui::ScrollArea::vertical()
@@ -88,13 +96,13 @@ impl StatelessComponent for ShortcutsTab {
                 );
 
                 // ── File ────────────────────────────────────────────────────
-                group_rows(ui, "FILE", "sc-file", colors, |ui| {
+                group_rows(ui, "FILE", |ui| {
                     shortcut_row(ui, "Open file", &sc.open_file, badge_width, colors);
                     shortcut_row(ui, "New window", &sc.new_window, badge_width, colors);
                 });
 
                 // ── Tabs ─────────────────────────────────────────────────────
-                group_rows(ui, "TABS", "sc-tabs", colors, |ui| {
+                group_rows(ui, "TABS", |ui| {
                     shortcut_row(ui, "New tab", &sc.new_tab, badge_width, colors);
                     shortcut_row(ui, "Close tab", &sc.close_tab, badge_width, colors);
                     shortcut_row(ui, "Next tab", &sc.next_tab, badge_width, colors);
@@ -113,7 +121,7 @@ impl StatelessComponent for ShortcutsTab {
                 });
 
                 // ── Navigation ───────────────────────────────────────────────
-                group_rows(ui, "NAVIGATION", "sc-nav", colors, |ui| {
+                group_rows(ui, "NAVIGATION", |ui| {
                     shortcut_row(ui, "Focus search", &sc.focus_search, badge_width, colors);
                     shortcut_row(ui, "Next match", &sc.next_match, badge_width, colors);
                     shortcut_row(ui, "Previous match", &sc.prev_match, badge_width, colors);
@@ -123,7 +131,7 @@ impl StatelessComponent for ShortcutsTab {
                 });
 
                 // ── Tree ─────────────────────────────────────────────────────
-                group_rows(ui, "TREE", "sc-tree", colors, |ui| {
+                group_rows(ui, "TREE", |ui| {
                     shortcut_row(ui, "Expand node", &sc.expand_node, badge_width, colors);
                     shortcut_row(ui, "Collapse node", &sc.collapse_node, badge_width, colors);
                     shortcut_row(ui, "Expand all", &sc.expand_all, badge_width, colors);
@@ -131,7 +139,7 @@ impl StatelessComponent for ShortcutsTab {
                 });
 
                 // ── Clipboard ────────────────────────────────────────────────
-                group_rows(ui, "CLIPBOARD", "sc-clip", colors, |ui| {
+                group_rows(ui, "CLIPBOARD", |ui| {
                     shortcut_row(ui, "Copy key", &sc.copy_key, badge_width, colors);
                     shortcut_row(ui, "Copy value", &sc.copy_value, badge_width, colors);
                     shortcut_row(ui, "Copy object", &sc.copy_object, badge_width, colors);
@@ -139,7 +147,7 @@ impl StatelessComponent for ShortcutsTab {
                 });
 
                 // ── Bookmarks ────────────────────────────────────────────────
-                group_rows(ui, "BOOKMARKS", "sc-marks", colors, |ui| {
+                group_rows(ui, "BOOKMARKS", |ui| {
                     shortcut_row(
                         ui,
                         "Toggle bookmark",
@@ -157,19 +165,19 @@ impl StatelessComponent for ShortcutsTab {
                 });
 
                 // ── Movement ────────────────────────────────────────────────
-                group_rows(ui, "MOVEMENT", "sc-move", colors, |ui| {
+                group_rows(ui, "MOVEMENT", |ui| {
                     shortcut_row(ui, "Move up", &sc.move_up, badge_width, colors);
                     shortcut_row(ui, "Move down", &sc.move_down, badge_width, colors);
                 });
 
                 // ── UI ───────────────────────────────────────────────────────
-                group_rows(ui, "UI", "sc-ui", colors, |ui| {
+                group_rows(ui, "UI", |ui| {
                     shortcut_row(ui, "Open settings", &sc.settings, badge_width, colors);
                     shortcut_row(ui, "Toggle theme", &sc.toggle_theme, badge_width, colors);
                 });
 
                 // ── Developer ────────────────────────────────────────────────
-                group_rows(ui, "DEVELOPER", "sc-dev", colors, |ui| {
+                group_rows(ui, "DEVELOPER", |ui| {
                     shortcut_row(
                         ui,
                         "Toggle profiler",
@@ -178,8 +186,6 @@ impl StatelessComponent for ShortcutsTab {
                         colors,
                     );
                 });
-
-                ui.add_space(24.0);
             });
 
         ShortcutsTabOutput { events: Vec::new() }
@@ -212,46 +218,45 @@ fn static_shortcut_row(
     });
 }
 
-/// A pill-shaped keyboard shortcut badge with a uniform fixed width.
+/// A keyboard shortcut badge with a uniform fixed width, styled as the design's
+/// read-only value field — `.pfield`: surface fill, hairline edge, mono label.
 fn kbd_badge(ui: &mut egui::Ui, text: &str, width: f32, colors: &ThemeColors) {
-    let pad_v = 4.0;
-    let height = ui.text_style_height(&egui::TextStyle::Body) + pad_v * 2.0;
-
     if text.is_empty() {
         // Still allocate the same width so columns stay aligned.
-        let (rect, _) = ui.allocate_exact_size(egui::vec2(width, height), egui::Sense::hover());
+        let (rect, _) = ui.allocate_exact_size(egui::vec2(width, BADGE_H), egui::Sense::hover());
         ui.painter().text(
             rect.center(),
             egui::Align2::CENTER_CENTER,
             "—",
-            egui::FontId::proportional(12.0),
-            colors.fg_muted,
+            egui::FontId::proportional(BADGE_FONT),
+            colors.fg_faint(),
         );
         return;
     }
 
-    let font_id = egui::FontId::proportional(12.0);
-    let galley = ui
-        .painter()
-        .layout_no_wrap(text.to_string(), font_id, colors.fg);
-
-    let (rect, _) = ui.allocate_exact_size(egui::vec2(width, height), egui::Sense::hover());
-
-    ui.painter().rect(
-        rect,
-        egui::CornerRadius::same(4),
-        colors.bg_sunken,
-        egui::Stroke::new(1.0, colors.surface_active),
-        egui::StrokeKind::Outside,
+    let galley = ui.painter().layout_no_wrap(
+        text.to_string(),
+        egui::FontId::proportional(BADGE_FONT),
+        colors.fg_subtle(),
     );
 
-    // Centre the text inside the fixed-width pill.
+    let (rect, _) = ui.allocate_exact_size(egui::vec2(width, BADGE_H), egui::Sense::hover());
+    let radius = egui::CornerRadius::from(RADIUS_CONTROL);
+    ui.painter().rect(
+        rect,
+        radius,
+        colors.surface,
+        edge_stroke(colors),
+        egui::StrokeKind::Inside,
+    );
+
+    // Centre the text inside the fixed-width field.
     ui.painter().galley(
         egui::pos2(
             rect.center().x - galley.size().x / 2.0,
             rect.center().y - galley.size().y / 2.0,
         ),
         galley,
-        colors.fg,
+        colors.fg_subtle(),
     );
 }

--- a/src/components/settings_dialog/shortcuts.rs
+++ b/src/components/settings_dialog/shortcuts.rs
@@ -12,6 +12,13 @@ const BADGE_H: f32 = 26.0;
 const BADGE_FONT: f32 = 12.0;
 /// Horizontal padding inside a badge — design `.pfield{padding:0 10px}`.
 const BADGE_PAD_H: f32 = 10.0;
+/// The literal badge of the tab-switching row. Held in a const so the width
+/// pre-pass measures the same string `static_shortcut_row` paints.
+const TAB_SWITCH_BADGE: &str = if cfg!(target_os = "macos") {
+    "⌘1 – ⌘9"
+} else {
+    "Ctrl+1 – Ctrl+9"
+};
 
 pub struct ShortcutsTab;
 
@@ -69,8 +76,11 @@ impl StatelessComponent for ShortcutsTab {
             ];
             let max_text_w = all
                 .iter()
-                .map(|s| {
-                    let txt = s.format();
+                .map(|s| s.format())
+                // The static rows paint literal text, which has to be measured
+                // too or a wide literal overflows its badge.
+                .chain(std::iter::once(TAB_SWITCH_BADGE.to_string()))
+                .map(|txt| {
                     if txt.is_empty() {
                         return 0.0_f32;
                     }
@@ -110,11 +120,7 @@ impl StatelessComponent for ShortcutsTab {
                     static_shortcut_row(
                         ui,
                         "Switch to tab 1–9",
-                        if cfg!(target_os = "macos") {
-                            "⌘1 – ⌘9"
-                        } else {
-                            "Ctrl+1 – Ctrl+9"
-                        },
+                        TAB_SWITCH_BADGE,
                         badge_width,
                         colors,
                     );
@@ -219,7 +225,8 @@ fn static_shortcut_row(
 }
 
 /// A keyboard shortcut badge with a uniform fixed width, styled as the design's
-/// read-only value field — `.pfield`: surface fill, hairline edge, mono label.
+/// read-only value field — `.pfield`: surface fill, hairline edge, proportional
+/// label (the same font the width pre-pass measures with).
 fn kbd_badge(ui: &mut egui::Ui, text: &str, width: f32, colors: &ThemeColors) {
     if text.is_empty() {
         // Still allocate the same width so columns stay aligned.

--- a/src/components/settings_dialog/theme_picker.rs
+++ b/src/components/settings_dialog/theme_picker.rs
@@ -1,11 +1,23 @@
-use eframe::egui::{self, Color32, RichText};
+// ThemePicker — design `screens.html` §2 “ThemePicker”: the `.tp-active` summary
+// card, the `.tp-filter` bar, then `.tp-fam` labelled `.tp-grid`s of `.pc` mini
+// chrome previews.
 
-use thoth_plugin_sdk::components::Input;
+use eframe::egui::{
+    self, Color32,
+    text::{LayoutJob, TextFormat},
+};
+
+use thoth_plugin_sdk::components::{
+    ButtonGroupItem, ButtonGroups, Input, Typography, TypographyVariant,
+};
+use thoth_plugin_sdk::theme::{
+    FIELD_HEIGHT, FONT_BODY, FONT_CAPTION, FONT_CONTROL, RADIUS_PANEL, edge_stroke, with_alpha,
+};
 
 use crate::{
-    components::{settings_dialog::helpers::setting_row, traits::StatelessComponent},
+    components::{settings_dialog::helpers::dirty_dot, traits::StatelessComponent},
     settings::Settings,
-    theme::{Theme, ThemeColors},
+    theme::{Theme, ThemeColors, phosphor_font_id},
 };
 
 pub struct ThemePicker;
@@ -25,15 +37,25 @@ pub struct ThemePickerOutput {
     pub events: Vec<ThemePickerEvent>,
 }
 
+/// The colours a preview card samples out of the theme it stands for.
+/// These are the *previewed* theme's own palette, not the host's, which is why
+/// the card is painted by hand instead of using the SDK's `Card`.
 struct CardSwatches {
+    /// `.pc{background:var(--bg)}` — the code area behind the JSON sample.
     base: Color32,
+    /// `.pc .bar` / `.pc .foot{background:var(--mantle)}`.
     mantle: Color32,
+    /// The 5th footer chip, `#313244` in the sheet.
     surface: Color32,
+    /// `.pc{box-shadow:inset 0 0 0 1px var(--surface1)}` — the card's hairline.
+    surface_raised: Color32,
     text: Color32,
     primary: Color32,
-    accent: Color32,
+    key: Color32,
     string: Color32,
     number: Color32,
+    boolean: Color32,
+    punctuation: Color32,
 }
 
 impl CardSwatches {
@@ -41,24 +63,97 @@ impl CardSwatches {
         let c = theme.colors();
         Self {
             base: c.bg,
-            mantle: c.bg_sunken,
+            mantle: c.bg_panel,
             surface: c.surface,
+            surface_raised: c.surface_raised,
             text: c.fg,
             primary: c.accent,
-            accent: c.accent_secondary,
+            key: c.syntax_key,
             string: c.syntax_string,
             number: c.syntax_number,
+            boolean: c.syntax_bool,
+            punctuation: c.syntax_punctuation,
         }
     }
 }
 
-// Card dimensions at 1.5× the original 164×106
-const CARD_W: f32 = 246.0;
-const CARD_H: f32 = 159.0;
+// ── Active theme card — design `.tp-active` ──────────────────────────────────
+
+/// `.tp-active{padding:9px 11px}`.
+const ACTIVE_PAD_X: i8 = 11;
+const ACTIVE_PAD_Y: i8 = 9;
+/// `.tp-active .dot{width:14px;height:14px}`.
+const ACTIVE_DOT: f32 = 14.0;
+/// `.tp-active{gap:10px}`.
+const ACTIVE_GAP: f32 = 10.0;
+/// `.tp-active .nm{font-size:13px;font-weight:600}`.
+const ACTIVE_NAME: f32 = FONT_BODY;
+/// `.tp-active{margin-bottom:12px}`.
+const FILTER_TOP: f32 = 12.0;
+
+// ── Filter bar — design `.tp-filter` ────────────────────────────────────────
+
+/// `.tp-filter{gap:10px}` between the search field and the mode segments.
+const FILTER_GAP: f32 = 10.0;
+/// `.tp-filter{margin-bottom:14px}`.
+const FILTER_BOTTOM: f32 = 14.0;
+
+// ── Card grid — design `.tp-fam` + `.tp-grid` ───────────────────────────────
+
+/// `.tp-fam{margin:6px 0 8px}`.
+const FAMILY_TOP: f32 = 6.0;
+const FAMILY_LABEL_GAP: f32 = 8.0;
+/// `.tp-grid{margin-bottom:14px}`.
+const FAMILY_BOTTOM: f32 = 14.0;
+/// Space around the "nothing matched" line.
+const EMPTY_PAD: f32 = 8.0;
+
+/// `.tp-grid{grid-template-columns:repeat(auto-fill,minmax(220px,1fr))}` — cards
+/// are at least this wide and then share the row equally.
+const CARD_MIN_W: f32 = 220.0;
+/// `.tp-grid{gap:12px}`, horizontally and between rows.
 const CARD_GAP: f32 = 12.0;
-const CHROME_H: f32 = 26.0;
-const SAMPLE_H: f32 = 90.0;
-const FOOT_H: f32 = CARD_H - CHROME_H - SAMPLE_H;
+/// `.pc .bar{height:24px}` — the faux window bar.
+const CHROME_H: f32 = 24.0;
+/// `.pc .code{padding:8px 10px}` around 4 lines at `line-height:1.5` × 10px.
+const SAMPLE_TOP: f32 = 8.0;
+const SAMPLE_FONT: f32 = 10.0;
+const SAMPLE_LINE_H: f32 = 15.0;
+const SAMPLE_LINES: f32 = 4.0;
+const SAMPLE_H: f32 = SAMPLE_TOP * 2.0 + SAMPLE_LINE_H * SAMPLE_LINES;
+/// `.pc .foot{padding:6px 9px}` around an 11px name line.
+const FOOT_PAD_Y: f32 = 6.0;
+const FOOT_H: f32 = FOOT_PAD_Y * 2.0 + 15.0;
+/// The whole card is the three bands stacked.
+const CARD_H: f32 = CHROME_H + SAMPLE_H + FOOT_H;
+
+/// `.pc .bar{padding:0 9px}` / `.pc .code{padding:… 10px}` / `.pc .foot{padding:… 9px}`
+/// — one inset for all three bands.
+const CARD_PAD: f32 = 9.0;
+/// `.pc.sel{box-shadow:inset 0 0 0 2px var(--accent)}`, else a hairline.
+const CARD_BORDER_ON: f32 = 2.0;
+const CARD_BORDER_OFF: f32 = 1.0;
+/// `.lights i{width:11px}` with `.lights{gap:7px}`.
+const LIGHT_R: f32 = 5.5;
+const LIGHT_PITCH: f32 = 18.0;
+/// `.pc .bar .mode{font-size:12px;opacity:.8}`.
+const CHROME_GLYPH: f32 = FONT_CONTROL;
+const CHROME_GLYPH_ALPHA: u8 = 204; // .8 of 255
+/// `.pc .chip{width:12px;height:8px}` with `.foot{gap:5px}`.
+const CHIP_W: f32 = 12.0;
+const CHIP_H: f32 = 8.0;
+const CHIP_GAP: f32 = 5.0;
+const CHIP_PITCH: f32 = CHIP_W + CHIP_GAP;
+/// `.pc .chip{border-radius:2px}` — below the radius ladder's smallest rung, so
+/// (like the SDK's `.badge` chips) the handoff pins it as a raw value.
+const CHIP_RADIUS: f32 = 2.0;
+/// `.pc .foot .nm{margin-left:5px}` — on top of the 5px flex gap.
+const NAME_GAP: f32 = CHIP_GAP * 2.0;
+/// `.pc .check{width:16px;height:16px;top:-9px;right:9px}` with a 2px ring.
+const BADGE_R: f32 = 8.0;
+const BADGE_RING: f32 = 2.0;
+const BADGE_TOP: f32 = -9.0;
+const BADGE_INSET: f32 = 9.0;
 
 impl StatelessComponent for ThemePicker {
     type Output = ThemePickerOutput;
@@ -70,98 +165,103 @@ impl StatelessComponent for ThemePicker {
         let current_name = &props.setting.theme.name;
         let baseline_name = &props.baseline.theme.name;
 
-        // ── Active theme row ─────────────────────────────────────────────────
+        // ── Active theme card — `.tp-active` ─────────────────────────────────
         let active_sw = CardSwatches::from_theme(&props.setting.theme);
         let dirty = current_name != baseline_name;
-        setting_row(ui, "Active theme", None, dirty, None, colors, |ui| {
-            ui.horizontal(|ui| {
-                // Accent swatch dot
-                let (dot_rect, _) =
-                    ui.allocate_exact_size(egui::vec2(14.0, 14.0), egui::Sense::hover());
-                ui.painter()
-                    .circle_filled(dot_rect.center(), 7.0, active_sw.primary);
-                ui.add_space(6.0);
-                ui.label(
-                    RichText::new(current_name)
-                        .size(13.0)
-                        .strong()
-                        .color(colors.fg),
-                );
-                ui.add_space(8.0);
-                // Family · dark/light meta
-                let (_, is_dark, family) = Theme::catalog()
-                    .iter()
-                    .find(|(n, _, _)| *n == current_name.as_str())
-                    .cloned()
-                    .unwrap_or(("".to_string(), true, "".to_string()));
-                let mode = if is_dark { "dark" } else { "light" };
-                ui.label(
-                    RichText::new(format!("{family} · {mode}"))
-                        .size(11.0)
-                        .color(colors.fg_muted),
-                );
-            });
-        });
+        let (_, is_dark, family) = Theme::catalog()
+            .iter()
+            .find(|(n, _, _)| n == current_name)
+            .cloned()
+            .unwrap_or((String::new(), true, String::new()));
+        let mode = if is_dark { "dark" } else { "light" };
 
-        // ── Filter bar ───────────────────────────────────────────────────────
+        egui::Frame::NONE
+            .fill(colors.surface)
+            .stroke(edge_stroke(colors))
+            .corner_radius(RADIUS_PANEL)
+            .inner_margin(egui::Margin::symmetric(ACTIVE_PAD_X, ACTIVE_PAD_Y))
+            .show(ui, |ui| {
+                ui.set_min_width(ui.available_width());
+                ui.horizontal(|ui| {
+                    // Every gap in the row is explicit.
+                    ui.spacing_mut().item_spacing.x = 0.0;
+
+                    // `.dot` — the active theme's own accent.
+                    let (dot_rect, _) =
+                        ui.allocate_exact_size(egui::Vec2::splat(ACTIVE_DOT), egui::Sense::hover());
+                    ui.painter().circle_filled(
+                        dot_rect.center(),
+                        ACTIVE_DOT / 2.0,
+                        active_sw.primary,
+                    );
+                    ui.add_space(ACTIVE_GAP);
+
+                    ui.add(
+                        Typography::builder()
+                            .text(current_name)
+                            .variant(TypographyVariant::BodyLarge)
+                            .size(ACTIVE_NAME)
+                            .bold(true)
+                            .build(),
+                    );
+                    if dirty {
+                        dirty_dot(ui, colors);
+                    }
+
+                    // `.meta{margin-left:auto}` — family · mode at the far right.
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        Typography::caption(ui, &format!("{family} · {mode}"));
+                    });
+                });
+            });
+
+        // ── Filter bar — `.tp-filter` ────────────────────────────────────────
         let filter_id = egui::Id::new("theme_picker_filter");
         let mode_id = egui::Id::new("theme_picker_mode");
         let mut filter: String = ui.ctx().data(|d| d.get_temp(filter_id).unwrap_or_default());
-        let mut mode: u8 = ui.ctx().data(|d| d.get_temp(mode_id).unwrap_or(0u8)); // 0=All 1=Dark 2=Light
+        let mut mode_filter: u8 = ui.ctx().data(|d| d.get_temp(mode_id).unwrap_or(0u8)); // 0=All 1=Dark 2=Light
 
-        ui.add_space(10.0);
-        // Render filter bar: 16px left pad | search (fills remaining) | 8px gap | tabs | 16px right pad
-        // Use right-to-left layout so tabs are allocated first (fixed size), search gets the rest.
-        ui.horizontal(|ui| {
-            ui.add_space(16.0);
+        ui.add_space(FILTER_TOP);
+        // The search field fills the row and the All/Dark/Light segments sit at
+        // its right. Right-to-left so the fixed-width segments are allocated
+        // first and the search takes what's left.
+        //
+        // The row is allocated one field tall: a centre-aligned horizontal
+        // layout stretches each item's frame to the *whole* height it is given,
+        // so laying this out in the pane's remaining space would open a void
+        // above and below it.
+        ui.allocate_ui_with_layout(
+            egui::vec2(ui.available_width(), FIELD_HEIGHT),
+            egui::Layout::right_to_left(egui::Align::Center),
+            |ui| {
+                // Every gap in the row is explicit.
+                ui.spacing_mut().item_spacing.x = 0.0;
 
-            // Reserve space for the tab pill first so search width is computed correctly.
-            // We do this by switching to right-to-left for the tabs, then adding the search.
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.add_space(16.0);
+                const MODES: [(u8, &str); 3] = [(0, "All"), (1, "Dark"), (2, "Light")];
+                let group = ButtonGroups::builder()
+                    .id("theme_picker_mode")
+                    .items(
+                        MODES
+                            .iter()
+                            .map(|(v, label)| {
+                                ButtonGroupItem::builder()
+                                    .value(v.to_string())
+                                    .label(*label)
+                                    .build()
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                    .active(mode_filter.to_string())
+                    .build();
+                if let Some(picked) = group.show(ui).inner
+                    && let Ok(v) = picked.parse::<u8>()
+                {
+                    mode_filter = v;
+                }
 
-                // All / Dark / Light segmented pill — same height as the search input
-                // The search frame is: 12px icon + 2×5px v-padding = ~22px content area.
-                // We match that with 5px v-padding on each tab button.
-                egui::Frame::new()
-                    .fill(colors.surface)
-                    .corner_radius(egui::CornerRadius::same(6))
-                    .inner_margin(egui::Margin::symmetric(2, 2))
-                    .show(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
-                            // RTL: render Light → Dark → All
-                            for (i, label) in ["Light", "Dark", "All"].iter().enumerate() {
-                                let tab_i = (2 - i) as u8;
-                                let active = mode == tab_i;
-                                let bg = if active {
-                                    colors.surface_raised
-                                } else {
-                                    Color32::TRANSPARENT
-                                };
-                                let fg = if active { colors.fg } else { colors.fg_muted };
+                ui.add_space(FILTER_GAP);
 
-                                let btn = egui::Frame::new()
-                                    .fill(bg)
-                                    .corner_radius(egui::CornerRadius::same(4))
-                                    .inner_margin(egui::Margin::symmetric(10, 5))
-                                    .show(ui, |ui| {
-                                        ui.label(RichText::new(*label).size(11.0).color(fg));
-                                    });
-
-                                if btn.response.interact(egui::Sense::click()).clicked() {
-                                    mode = tab_i;
-                                }
-                                if btn.response.interact(egui::Sense::hover()).hovered() {
-                                    ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
-                                }
-                            }
-                        });
-                    });
-
-                ui.add_space(8.0);
-
-                // Search input fills the remaining width (left of tabs)
+                // Search input fills the remaining width (left of the segments)
                 let mut input = Input::builder()
                     .value(filter.clone())
                     .placeholder("Filter themes…")
@@ -170,15 +270,13 @@ impl StatelessComponent for ThemePicker {
                     .build();
                 input.show(ui);
                 filter = input.value;
-            });
-        });
+            },
+        );
 
         ui.ctx().data_mut(|d| {
             d.insert_temp(filter_id, filter.clone());
-            d.insert_temp(mode_id, mode);
+            d.insert_temp(mode_id, mode_filter);
         });
-
-        ui.add_space(12.0);
 
         // ── Filtered + grouped catalog ────────────────────────────────────────
         let filter_lower = filter.to_lowercase();
@@ -187,7 +285,7 @@ impl StatelessComponent for ThemePicker {
         let filtered: Vec<(String, bool, String)> = catalog
             .iter()
             .filter(|&(name, is_dark, _)| {
-                let mode_ok = match mode {
+                let mode_ok = match mode_filter {
                     1 => *is_dark,
                     2 => !is_dark,
                     _ => true,
@@ -200,16 +298,9 @@ impl StatelessComponent for ThemePicker {
             .collect();
 
         if filtered.is_empty() {
-            ui.add_space(8.0);
-            ui.horizontal(|ui| {
-                ui.add_space(16.0);
-                ui.label(
-                    RichText::new(format!("No themes match \"{filter}\"."))
-                        .size(12.0)
-                        .color(colors.fg_muted),
-                );
-            });
-            ui.add_space(8.0);
+            ui.add_space(EMPTY_PAD);
+            Typography::body_muted(ui, &format!("No themes match \"{filter}\"."));
+            ui.add_space(EMPTY_PAD);
             return ThemePickerOutput { events };
         }
 
@@ -220,96 +311,111 @@ impl StatelessComponent for ThemePicker {
             }
         }
 
-        // Columns: fit as many CARD_W cards + gaps as available width allows
-        let avail = ui.available_width() - 32.0;
-        let cols = ((avail + CARD_GAP) / (CARD_W + CARD_GAP)).floor().max(1.0) as usize;
+        // `repeat(auto-fill,minmax(220px,1fr))`: fit as many 220px columns as the
+        // width allows, then let them share the leftover equally. Cards carry
+        // their own gaps (item spacing is zeroed per row), so this is the exact
+        // width a row of `cols` cards occupies.
+        let avail = ui.available_width();
+        let cols = ((avail + CARD_GAP) / (CARD_MIN_W + CARD_GAP))
+            .floor()
+            .max(1.0);
+        let card_w = ((avail - CARD_GAP * (cols - 1.0)) / cols).max(CARD_MIN_W);
+        let cols = cols as usize;
 
-        egui::ScrollArea::vertical()
-            .auto_shrink([false; 2])
-            .show(ui, |ui: &mut egui::Ui| {
-                for family in &families {
-                    let family_themes: Vec<_> =
-                        filtered.iter().filter(|(_, _, f)| f == family).collect();
+        ui.add_space(FILTER_BOTTOM);
 
-                    ui.horizontal(|ui| {
-                        ui.add_space(16.0);
-                        ui.label(
-                            RichText::new(family)
-                                .size(11.0)
-                                .strong()
-                                .color(colors.fg_muted),
-                        );
-                    });
-                    ui.add_space(6.0);
+        // No scroll area of its own: the pane around it already scrolls, and a
+        // nested one would claim the pane's remaining height and strand the
+        // grid at the bottom.
+        for family in &families {
+            let family_themes: Vec<_> = filtered.iter().filter(|(_, _, f)| f == family).collect();
 
-                    ui.horizontal(|ui| {
-                        ui.add_space(16.0);
-                        ui.vertical(|ui| {
-                            for row in family_themes.chunks(cols) {
-                                ui.horizontal(|ui| {
-                                    for (name, is_dark, _) in row {
-                                        let theme = Theme::from_name(name);
-                                        let sw = CardSwatches::from_theme(&theme);
-                                        let selected = *name == current_name.as_str();
+            ui.add_space(FAMILY_TOP);
+            Typography::group_label(ui, family);
+            ui.add_space(FAMILY_LABEL_GAP);
 
-                                        if render_card(ui, name, *is_dark, &sw, selected, colors) {
-                                            events.push(ThemePickerEvent::ThemeSelected(
-                                                name.to_string(),
-                                            ));
-                                        }
-                                        ui.add_space(CARD_GAP);
-                                    }
-                                });
-                                ui.add_space(CARD_GAP);
-                            }
-                        });
-                    });
+            for row in family_themes.chunks(cols) {
+                // `horizontal_top`, not `horizontal`: a centre-aligned row
+                // would stretch each card's frame to the row's full height.
+                ui.horizontal_top(|ui| {
+                    ui.spacing_mut().item_spacing.x = 0.0;
+                    for (i, (name, is_dark, _)) in row.iter().enumerate() {
+                        if i > 0 {
+                            ui.add_space(CARD_GAP);
+                        }
+                        let theme = Theme::from_name(name);
+                        let sw = CardSwatches::from_theme(&theme);
+                        let selected = name == current_name;
 
-                    ui.add_space(12.0);
-                }
-            });
+                        if render_card(ui, name, *is_dark, &sw, selected, card_w, colors) {
+                            events.push(ThemePickerEvent::ThemeSelected(name.to_string()));
+                        }
+                    }
+                });
+                ui.add_space(CARD_GAP);
+            }
+
+            ui.add_space(FAMILY_BOTTOM - CARD_GAP);
+        }
 
         ThemePickerOutput { events }
     }
 }
 
+/// Lay out one line of the card's JSON sample as a single galley, so the tokens
+/// sit flush against each other whatever the monospace font's real advance is.
+fn sample_line(
+    painter: &egui::Painter,
+    pos: egui::Pos2,
+    font: &egui::FontId,
+    tokens: &[(Color32, &str)],
+) {
+    let mut job = LayoutJob::default();
+    for (color, text) in tokens {
+        job.append(
+            text,
+            0.0,
+            TextFormat {
+                font_id: font.clone(),
+                color: *color,
+                ..Default::default()
+            },
+        );
+    }
+    let galley = painter.layout_job(job);
+    painter.galley(pos, galley, Color32::PLACEHOLDER);
+}
+
+/// One `.pc`: a mini window painted in the previewed theme's palette — chrome
+/// bar, JSON sample, and a swatch footer carrying the theme's name.
 fn render_card(
     ui: &mut egui::Ui,
     name: &str,
     is_dark: bool,
     sw: &CardSwatches,
     selected: bool,
+    card_w: f32,
     host: &ThemeColors,
 ) -> bool {
-    let (rect, resp) = ui.allocate_exact_size(egui::vec2(CARD_W, CARD_H), egui::Sense::click());
+    let (rect, resp) = ui.allocate_exact_size(egui::vec2(card_w, CARD_H), egui::Sense::click());
 
     if !ui.is_rect_visible(rect) {
         return resp.clicked();
     }
 
     let p = ui.painter();
-    let radius = egui::CornerRadius::same(8);
+    let radius = egui::CornerRadius::from(RADIUS_PANEL);
 
-    // Card background
+    // `.pc{background:var(--bg)}`
     p.rect_filled(rect, radius, sw.base);
 
-    // Border
-    let border_color = if selected { host.accent } else { sw.surface };
-    let border_width = if selected { 2.0 } else { 1.0 };
-    p.rect_stroke(
-        rect.shrink(border_width * 0.5),
-        radius,
-        egui::Stroke::new(border_width, border_color),
-        egui::StrokeKind::Middle,
-    );
-
-    // ── Chrome bar ───────────────────────────────────────────────────────────
-    let chrome_rect = egui::Rect::from_min_size(rect.min, egui::vec2(CARD_W, CHROME_H));
+    // ── Chrome bar — `.pc .bar` ──────────────────────────────────────────────
+    let chrome_rect = egui::Rect::from_min_size(rect.min, egui::vec2(card_w, CHROME_H));
     p.rect_filled(
         chrome_rect,
         egui::CornerRadius {
-            nw: 8,
-            ne: 8,
+            nw: radius.nw,
+            ne: radius.ne,
             sw: 0,
             se: 0,
         },
@@ -317,161 +423,149 @@ fn render_card(
     );
 
     let dot_y = chrome_rect.center().y;
-    for (i, &dot_c) in [
-        Color32::from_rgb(0xFF, 0x5F, 0x57),
-        Color32::from_rgb(0xFE, 0xBC, 0x2E),
-        Color32::from_rgb(0x28, 0xC8, 0x40),
-    ]
-    .iter()
-    .enumerate()
-    {
+    for (i, &dot_c) in [host.error, host.warning, host.success].iter().enumerate() {
         p.circle_filled(
-            egui::pos2(rect.min.x + 10.0 + i as f32 * 13.0, dot_y),
-            4.5,
+            egui::pos2(
+                rect.min.x + CARD_PAD + LIGHT_R + i as f32 * LIGHT_PITCH,
+                dot_y,
+            ),
+            LIGHT_R,
             dot_c,
         );
     }
 
-    let mode_char = if is_dark { "◐" } else { "◑" };
+    // `.mode` — a Phosphor glyph, so it renders in every theme.
+    let mode_icon = if is_dark {
+        egui_phosphor::regular::MOON
+    } else {
+        egui_phosphor::regular::SUN
+    };
     p.text(
-        egui::pos2(chrome_rect.max.x - 10.0, dot_y),
+        egui::pos2(chrome_rect.max.x - CARD_PAD, dot_y),
         egui::Align2::RIGHT_CENTER,
-        mode_char,
-        egui::FontId::proportional(11.0),
-        Color32::from_rgba_unmultiplied(sw.text.r(), sw.text.g(), sw.text.b(), 128),
+        mode_icon,
+        phosphor_font_id(CHROME_GLYPH),
+        with_alpha(sw.text, CHROME_GLYPH_ALPHA),
     );
 
-    p.hline(
-        egui::Rangef::new(rect.min.x, rect.max.x),
-        rect.min.y + CHROME_H,
-        egui::Stroke::new(1.0, sw.surface),
-    );
-
-    // ── JSON sample ──────────────────────────────────────────────────────────
-    let sample_top = rect.min.y + CHROME_H + 8.0;
-    let font = egui::FontId::monospace(10.0);
-    let cw = 6.0_f32; // approx char width at 10px mono
-    let ox = rect.min.x + 10.0;
-    let line_h = 14.0;
-
-    // { "name": "thoth" }
-    for (col, offset, txt) in [
-        (sw.text, 0.0, "{ "),
-        (sw.primary, 2.0 * cw, "\"name\""),
-        (sw.text, 8.0 * cw, ": "),
-        (sw.string, 10.0 * cw, "\"thoth\""),
-        (sw.text, 18.0 * cw, " }"),
-    ] {
-        p.text(
-            egui::pos2(ox + offset, sample_top),
-            egui::Align2::LEFT_TOP,
-            txt,
-            font.clone(),
-            col,
-        );
-    }
-
-    //   "version": 42,
-    for (col, offset, txt) in [
-        (sw.primary, 0.0, "  \"version\""),
-        (sw.text, 12.0 * cw, ": "),
-        (sw.number, 14.0 * cw, "42"),
-        (sw.text, 16.0 * cw, ","),
-    ] {
-        p.text(
-            egui::pos2(ox + offset, sample_top + line_h),
-            egui::Align2::LEFT_TOP,
-            txt,
-            font.clone(),
-            col,
-        );
-    }
-
-    //   "dark": true/false
+    // ── JSON sample — `.pc .code` ────────────────────────────────────────────
+    let sample_top = rect.min.y + CHROME_H + SAMPLE_TOP;
+    let font = egui::FontId::monospace(SAMPLE_FONT);
+    let ox = rect.min.x + CARD_PAD;
     let bool_txt = if is_dark { "true" } else { "false" };
-    for (col, offset, txt) in [
-        (sw.primary, 0.0, "  \"dark\""),
-        (sw.text, 9.0 * cw, ": "),
-        (sw.accent, 11.0 * cw, bool_txt),
-    ] {
-        p.text(
-            egui::pos2(ox + offset, sample_top + line_h * 2.0),
-            egui::Align2::LEFT_TOP,
-            txt,
-            font.clone(),
-            col,
+    let lines: [&[(Color32, &str)]; 4] = [
+        &[
+            (sw.punctuation, "{ "),
+            (sw.key, "\"name\""),
+            (sw.punctuation, ": "),
+            (sw.string, "\"thoth\""),
+        ],
+        &[
+            (sw.key, "  \"version\""),
+            (sw.punctuation, ": "),
+            (sw.number, "42"),
+            (sw.punctuation, ","),
+        ],
+        &[
+            (sw.key, "  \"dark\""),
+            (sw.punctuation, ": "),
+            (sw.boolean, bool_txt),
+        ],
+        &[(sw.punctuation, "}")],
+    ];
+    // Keep a long sample inside the card even in a theme with a wide mono font.
+    let sample_painter = p.with_clip_rect(
+        p.clip_rect()
+            .intersect(rect.shrink2(egui::vec2(CARD_PAD, 0.0))),
+    );
+    for (i, tokens) in lines.iter().enumerate() {
+        sample_line(
+            &sample_painter,
+            egui::pos2(ox, sample_top + i as f32 * SAMPLE_LINE_H),
+            &font,
+            tokens,
         );
     }
 
-    //   "theme": "..."
-    for (col, offset, txt) in [
-        (sw.primary, 0.0, "  \"theme\""),
-        (sw.text, 10.0 * cw, ": "),
-        (sw.string, 12.0 * cw, "\"thoth\""),
-    ] {
-        p.text(
-            egui::pos2(ox + offset, sample_top + line_h * 3.0),
-            egui::Align2::LEFT_TOP,
-            txt,
-            font.clone(),
-            col,
-        );
-    }
-
-    // ── Footer ───────────────────────────────────────────────────────────────
+    // ── Footer — `.pc .foot` ─────────────────────────────────────────────────
     let foot_top = rect.min.y + CHROME_H + SAMPLE_H;
     let foot_rect =
-        egui::Rect::from_min_size(egui::pos2(rect.min.x, foot_top), egui::vec2(CARD_W, FOOT_H));
+        egui::Rect::from_min_size(egui::pos2(rect.min.x, foot_top), egui::vec2(card_w, FOOT_H));
     p.rect_filled(
         foot_rect,
         egui::CornerRadius {
             nw: 0,
             ne: 0,
-            sw: 8,
-            se: 8,
+            sw: radius.sw,
+            se: radius.se,
         },
-        Color32::from_rgba_unmultiplied(sw.mantle.r(), sw.mantle.g(), sw.mantle.b(), 200),
+        sw.mantle,
     );
 
-    // Color chips
-    let chip_y = foot_top + 6.0;
-    for (i, &cc) in [sw.primary, sw.accent, sw.string, sw.number, sw.surface]
-        .iter()
-        .enumerate()
-    {
+    // `.chip` — text, accent, string, number, surface, centred in the footer.
+    let chips = [sw.text, sw.primary, sw.string, sw.number, sw.surface];
+    let chip_y = foot_rect.center().y - CHIP_H / 2.0;
+    for (i, &cc) in chips.iter().enumerate() {
         p.rect_filled(
             egui::Rect::from_min_size(
-                egui::pos2(rect.min.x + 10.0 + i as f32 * 16.0, chip_y),
-                egui::vec2(13.0, 8.0),
+                egui::pos2(rect.min.x + CARD_PAD + i as f32 * CHIP_PITCH, chip_y),
+                egui::vec2(CHIP_W, CHIP_H),
             ),
-            egui::CornerRadius::same(2),
+            egui::CornerRadius::from(CHIP_RADIUS),
             cc,
         );
     }
 
-    // Theme name
-    let name_y = chip_y + 13.0;
-    p.text(
-        egui::pos2(rect.min.x + 10.0, name_y),
-        egui::Align2::LEFT_TOP,
-        name,
-        egui::FontId::proportional(11.0),
-        Color32::from_rgba_unmultiplied(sw.text.r(), sw.text.g(), sw.text.b(), 220),
+    // `.foot .nm` — the theme's name after the chips, clear of the check badge.
+    let name_x = rect.min.x + CARD_PAD + chips.len() as f32 * CHIP_PITCH + NAME_GAP - CHIP_GAP;
+    let name_right = rect.max.x - CARD_PAD - if selected { BADGE_R * 2.0 } else { 0.0 };
+    let name_galley = p.layout(
+        name.to_owned(),
+        egui::FontId::proportional(FONT_CAPTION),
+        sw.text,
+        (name_right - name_x).max(0.0),
+    );
+    p.with_clip_rect(p.clip_rect().intersect(foot_rect)).galley(
+        egui::pos2(name_x, foot_rect.center().y - name_galley.size().y / 2.0),
+        name_galley,
+        Color32::PLACEHOLDER,
     );
 
-    // Checkmark badge when selected — filled circle so it's visible on any bg
+    // `.check` — an accent disc straddling the footer's top edge, ringed in the
+    // card's own background so it reads on any palette.
     if selected {
-        let badge_r = 9.0_f32;
-        let badge_center = egui::pos2(rect.max.x - badge_r - 6.0, name_y + badge_r);
-        p.circle_filled(badge_center, badge_r, host.accent);
+        let badge_center = egui::pos2(
+            rect.max.x - BADGE_INSET - BADGE_R,
+            foot_top + BADGE_TOP + BADGE_R,
+        );
+        p.circle_filled(badge_center, BADGE_R + BADGE_RING, sw.base);
+        p.circle_filled(badge_center, BADGE_R, host.accent);
         p.text(
             badge_center,
             egui::Align2::CENTER_CENTER,
             egui_phosphor::regular::CHECK,
-            egui::FontId::proportional(11.0),
-            Color32::WHITE,
+            phosphor_font_id(FONT_CAPTION),
+            crate::theme::get_contrast_text_color(host.accent),
         );
     }
+
+    // Border last, so it draws over the bands' square corners.
+    let border_color = if selected {
+        host.accent
+    } else {
+        sw.surface_raised
+    };
+    let border_width = if selected {
+        CARD_BORDER_ON
+    } else {
+        CARD_BORDER_OFF
+    };
+    p.rect_stroke(
+        rect.shrink(border_width * 0.5),
+        radius,
+        egui::Stroke::new(border_width, border_color),
+        egui::StrokeKind::Middle,
+    );
 
     if resp.hovered() {
         ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);

--- a/src/components/settings_dialog/updates.rs
+++ b/src/components/settings_dialog/updates.rs
@@ -1,12 +1,14 @@
 use chrono::{DateTime, Utc};
-use eframe::egui::{self, RichText};
+use eframe::egui;
 
-use crate::components::settings_dialog::helpers::{group_rows, section_header, setting_row};
+use crate::components::settings_dialog::helpers::{
+    group_rows, section_header, setting_row, slider_control,
+};
 use crate::components::traits::StatelessComponent;
 use crate::settings::UpdateSettings;
 use crate::theme::ThemeColors;
 use crate::update::UpdateState;
-use thoth_plugin_sdk::components::{Button, ButtonColor, ButtonType, ToggleSwitch};
+use thoth_plugin_sdk::components::{Button, ButtonColor, ButtonType, ToggleSwitch, Typography};
 
 pub struct UpdatesTab;
 
@@ -53,7 +55,7 @@ impl StatelessComponent for UpdatesTab {
                 );
 
                 // ── Auto-update ───────────────────────��───────────────────────────
-                group_rows(ui, "AUTO-UPDATE", "updates-auto", colors, |ui| {
+                group_rows(ui, "AUTO-UPDATE", |ui| {
                     setting_row(
                         ui,
                         "Automatically check for updates",
@@ -80,30 +82,26 @@ impl StatelessComponent for UpdatesTab {
                         None,
                         colors,
                         |ui| {
-                            let mut val = s.check_interval_hours;
-                            if ui
-                                .add(
-                                    egui::Slider::new(&mut val, 1..=168)
-                                        .suffix(" h")
-                                        .clamping(egui::SliderClamping::Always),
-                                )
-                                .changed()
-                            {
-                                events.push(UpdatesTabEvent::CheckIntervalChanged(val));
+                            if let Some(val) = slider_control(
+                                ui,
+                                s.check_interval_hours as f64,
+                                1.0,
+                                168.0,
+                                "hours",
+                            ) {
+                                events.push(UpdatesTabEvent::CheckIntervalChanged(
+                                    val.round() as u64
+                                ));
                             }
                         },
                     );
                 });
 
                 // ── Status ────────────────────────────────────────────────────────
-                group_rows(ui, "STATUS", "updates-status", colors, |ui| {
+                group_rows(ui, "STATUS", |ui| {
                     // Current version
                     setting_row(ui, "Current version", None, false, None, colors, |ui| {
-                        ui.label(
-                            RichText::new(props.current_version)
-                                .size(13.0)
-                                .color(colors.fg_muted),
-                        );
+                        Typography::subtitle(ui, props.current_version);
                     });
 
                     // Last checked
@@ -115,11 +113,7 @@ impl StatelessComponent for UpdatesTab {
                         })
                         .unwrap_or_else(|| "Never".to_string());
                     setting_row(ui, "Last checked", None, false, None, colors, |ui| {
-                        ui.label(
-                            RichText::new(&last_check_str)
-                                .size(13.0)
-                                .color(colors.fg_muted),
-                        );
+                        Typography::subtitle(ui, &last_check_str);
                     });
 
                     // Next check (only meaningful when auto-check is enabled and we have a last_check)
@@ -134,11 +128,7 @@ impl StatelessComponent for UpdatesTab {
                             })
                             .unwrap_or_else(|| "Soon".to_string());
                         setting_row(ui, "Next check", None, false, None, colors, |ui| {
-                            ui.label(
-                                RichText::new(&next_check_str)
-                                    .size(13.0)
-                                    .color(colors.fg_muted),
-                            );
+                            Typography::subtitle(ui, &next_check_str);
                         });
                     }
 
@@ -159,7 +149,6 @@ impl StatelessComponent for UpdatesTab {
                                                 .label("Download")
                                                 .button_type(ButtonType::Elevated)
                                                 .color(ButtonColor::Success)
-                                                .size(13.0)
                                                 .build(),
                                         )
                                         .clicked()
@@ -199,7 +188,6 @@ impl StatelessComponent for UpdatesTab {
                                                 .label("Install & Restart")
                                                 .button_type(ButtonType::Elevated)
                                                 .color(ButtonColor::Primary)
-                                                .size(13.0)
                                                 .build(),
                                         )
                                         .clicked()
@@ -226,7 +214,6 @@ impl StatelessComponent for UpdatesTab {
                                                 .label("Retry")
                                                 .button_type(ButtonType::Elevated)
                                                 .color(ButtonColor::Default)
-                                                .size(13.0)
                                                 .build(),
                                         )
                                         .clicked()
@@ -259,7 +246,6 @@ impl StatelessComponent for UpdatesTab {
                                                 .label("Check now")
                                                 .button_type(ButtonType::Elevated)
                                                 .color(ButtonColor::Default)
-                                                .size(13.0)
                                                 .build(),
                                         )
                                         .clicked()
@@ -271,8 +257,6 @@ impl StatelessComponent for UpdatesTab {
                         }
                     }
                 });
-
-                ui.add_space(24.0);
             });
 
         UpdatesTabOutput { events }

--- a/src/components/settings_dialog/viewer.rs
+++ b/src/components/settings_dialog/viewer.rs
@@ -42,7 +42,7 @@ impl StatelessComponent for ViewerTab {
                     colors,
                 );
 
-                group_rows(ui, "DISPLAY", "viewer-display", colors, |ui| {
+                group_rows(ui, "DISPLAY", |ui| {
                     setting_row(
                         ui,
                         "Syntax highlighting",
@@ -61,8 +61,6 @@ impl StatelessComponent for ViewerTab {
                         },
                     );
                 });
-
-                ui.add_space(24.0);
             });
 
         ViewerTabOutput { events }

--- a/src/components/sidebar.rs
+++ b/src/components/sidebar.rs
@@ -545,19 +545,25 @@ impl ContextComponent for Sidebar {
         const RAIL_W: f32 = 48.0;
         const INNER_GAP: f32 = crate::theme::GUTTER_GAP; // gap between rail and content
         const RIGHT_GAP: f32 = crate::theme::GUTTER_GAP; // gap from sidebar to dock
+        // Everything the outer panel carries besides the content frame. Props and
+        // events speak the *content* width (the persisted unit); the panel system
+        // speaks the outer width, so convert by this amount at that boundary.
+        const CHROME_W: f32 = LEFT_PAD + RAIL_W + INNER_GAP + RIGHT_GAP;
 
         // Transparent outer container — no background, no border. It purely
         // allocates space in the panel system; the visual chrome lives on the
         // inner rail and content frames painted via paint_at.
         let mut outer_panel = egui::Panel::left("sidebar");
         if props.expanded {
-            let min_w = LEFT_PAD + RAIL_W + INNER_GAP + MIN_SIDEBAR_WIDTH + RIGHT_GAP;
+            let min_w = CHROME_W + MIN_SIDEBAR_WIDTH;
             let window_width = ui.ctx().content_rect().width();
-            let max_w = window_width * MAX_SIDEBAR_WIDTH_RATIO;
+            // A narrow (or not-yet-sized) window puts the ratio below the
+            // minimum; never let the range invert, or `clamp` panics.
+            let max_w = (window_width * MAX_SIDEBAR_WIDTH_RATIO).max(min_w);
             outer_panel = outer_panel
                 .resizable(true)
                 .size_range(min_w..=max_w)
-                .default_size(props.sidebar_width.clamp(min_w, max_w));
+                .default_size((props.sidebar_width + CHROME_W).clamp(min_w, max_w));
         } else {
             outer_panel = outer_panel
                 .resizable(false)
@@ -622,9 +628,9 @@ impl ContextComponent for Sidebar {
             });
 
         if props.expanded {
-            let actual_width = outer_response.response.rect.width();
-            if (actual_width - props.sidebar_width).abs() > 0.1 {
-                events.push(SidebarEvent::WidthChanged(actual_width));
+            let content_width = (outer_response.response.rect.width() - CHROME_W).max(0.0);
+            if (content_width - props.sidebar_width).abs() > 0.1 {
+                events.push(SidebarEvent::WidthChanged(content_width));
             }
         }
 

--- a/src/components/sidebar.rs
+++ b/src/components/sidebar.rs
@@ -17,7 +17,7 @@ use crate::components::traits::{ContextComponent, StatefulComponent};
 use crate::constants::{MAX_SIDEBAR_WIDTH_RATIO, MIN_SIDEBAR_WIDTH};
 use crate::plugin::{Plugin, render_node::render_ui_node, wasm_data_source::ConsentRequest};
 use crate::search::SearchMessage;
-use eframe::egui::{self, Margin};
+use eframe::egui;
 use thoth_plugin_sdk::components::IconButton;
 
 /// Which sidebar section is currently selected
@@ -527,95 +527,102 @@ impl ContextComponent for Sidebar {
 
         let mut events = Vec::new();
 
-        // Get theme colors
-        let theme_colors = ui.ctx().memory(|mem| {
-            mem.data
-                .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
-        });
-
-        let (icon_strip_bg, content_bg) = if let Some(colors) = theme_colors {
-            (colors.bg_sunken, colors.bg_panel)
-        } else {
-            let visuals = ui.visuals();
-            (visuals.widgets.inactive.bg_fill, visuals.panel_fill)
-        };
-
-        let mut sidebar_panel = egui::Panel::left("sidebar");
-        if props.expanded {
-            let min_width = MIN_SIDEBAR_WIDTH;
-            let window_width = ui.ctx().content_rect().width();
-            let max_width = window_width * MAX_SIDEBAR_WIDTH_RATIO;
-            sidebar_panel = sidebar_panel
-                .resizable(true)
-                .size_range(min_width..=max_width)
-                .default_size(props.sidebar_width.clamp(min_width, max_width));
-        } else {
-            sidebar_panel = sidebar_panel.resizable(false).exact_size(48.0);
-        }
-
-        let sidebar_response = sidebar_panel
-            .frame(egui::Frame::NONE.fill(if props.expanded {
-                content_bg // Use content background, icon strip will override its area
-            } else {
-                icon_strip_bg
-            }))
-            .show_inside(ui, |ui| {
-                ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
-
-                if props.expanded {
-                    // Horizontal layout: icon buttons on left, content on right
-                    let available_rect = ui.available_rect_before_wrap();
-                    let available_height = available_rect.height();
-                    let actual_width = available_rect.width(); // Use actual rendered width
-
-                    // Left side: 48px icon strip with darker background
-                    let icon_strip_rect = egui::Rect::from_min_size(
-                        available_rect.min,
-                        egui::vec2(48.0, available_height),
-                    );
-                    ui.painter()
-                        .rect_filled(icon_strip_rect, 0.0, icon_strip_bg);
-
-                    let mut icon_ui = ui.new_child(
-                        egui::UiBuilder::new()
-                            .max_rect(icon_strip_rect)
-                            .layout(egui::Layout::top_down(egui::Align::Center)),
-                    );
-                    self.render_icon_buttons(&mut icon_ui, &props, &mut events);
-
-                    // Right side: expanded content (takes remaining width)
-                    let content_width = actual_width - 48.0; // Calculate from actual width
-                    let content_rect = egui::Rect::from_min_size(
-                        available_rect.min + egui::vec2(48.0, 0.0),
-                        egui::vec2(content_width, available_height),
-                    );
-
-                    let mut content_ui = ui.new_child(
-                        egui::UiBuilder::new()
-                            .max_rect(content_rect)
-                            .layout(egui::Layout::top_down(egui::Align::Min)),
-                    );
-
-                    egui::Frame::NONE
-                        .inner_margin(Margin::ZERO)
-                        .show(&mut content_ui, |ui| {
-                            // Vertical-only: sidebar content must fit the panel
-                            // width (no horizontal scrolling).
-                            egui::ScrollArea::vertical()
-                                .show(ui, |ui| self.render_content(ui, &props, &mut events));
-                        });
-
-                    // Advance the cursor to consume the full area
-                    ui.allocate_rect(available_rect, egui::Sense::hover());
-                } else {
-                    // Just show icon buttons
-                    self.render_icon_buttons(ui, &props, &mut events);
-                }
+        let colors = ui
+            .ctx()
+            .memory(|mem| {
+                mem.data
+                    .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
+            })
+            .unwrap_or_else(|| {
+                let dark_mode = ui.ctx().global_style().visuals.dark_mode;
+                crate::theme::Theme::for_dark_mode(dark_mode).colors()
             });
 
-        // Emit width change event if sidebar is being actively resized
+        let panel_bg = colors.bg_panel;
+
+        // Layout constants
+        const LEFT_PAD: f32 = 10.0; // gap from window edge to rail
+        const RAIL_W: f32 = 48.0;
+        const INNER_GAP: f32 = crate::theme::GUTTER_GAP; // gap between rail and content
+        const RIGHT_GAP: f32 = crate::theme::GUTTER_GAP; // gap from sidebar to dock
+
+        // Transparent outer container — no background, no border. It purely
+        // allocates space in the panel system; the visual chrome lives on the
+        // inner rail and content frames painted via paint_at.
+        let mut outer_panel = egui::Panel::left("sidebar");
         if props.expanded {
-            let actual_width = sidebar_response.response.rect.width();
+            let min_w = LEFT_PAD + RAIL_W + INNER_GAP + MIN_SIDEBAR_WIDTH + RIGHT_GAP;
+            let window_width = ui.ctx().content_rect().width();
+            let max_w = window_width * MAX_SIDEBAR_WIDTH_RATIO;
+            outer_panel = outer_panel
+                .resizable(true)
+                .size_range(min_w..=max_w)
+                .default_size(props.sidebar_width.clamp(min_w, max_w));
+        } else {
+            outer_panel = outer_panel
+                .resizable(false)
+                .exact_size(LEFT_PAD + RAIL_W + RIGHT_GAP);
+        }
+
+        let outer_response = outer_panel
+            .show_separator_line(false)
+            .frame(egui::Frame::NONE)
+            .show_inside(ui, |ui| {
+                let available = ui.available_rect_before_wrap();
+                let h = available.height();
+
+                // Shared floating frame style (fill, radius, shadow, stroke).
+                // paint_at uses the panel's painter so shadow bleeds into the
+                // gap/crust area without being clipped by child UI clip rects.
+                let floating = egui::Frame::NONE
+                    .fill(panel_bg)
+                    .corner_radius(egui::CornerRadius::same(crate::theme::RADIUS_PANEL as u8))
+                    .shadow(crate::theme::panel_shadow(ui.visuals().dark_mode))
+                    .stroke(crate::theme::edge_stroke(&colors));
+
+                // Leave GUTTER_GAP crust gap at the bottom so panel shadows fall
+                // into the gap rather than bleeding into the transparent status bar.
+                let panel_h = h - RIGHT_GAP; // RIGHT_GAP == GUTTER_GAP
+
+                // ── Rail ─────────────────────────────────────────────────────
+                let rail_rect = egui::Rect::from_min_size(
+                    available.min + egui::vec2(LEFT_PAD, 0.0),
+                    egui::vec2(RAIL_W, panel_h),
+                );
+                ui.painter().add(floating.paint(rail_rect));
+                let mut rail_ui = ui.new_child(
+                    egui::UiBuilder::new()
+                        .max_rect(rail_rect)
+                        .layout(egui::Layout::top_down(egui::Align::Center)),
+                );
+                self.render_icon_buttons(&mut rail_ui, &props, &mut events);
+
+                // ── Content (when expanded) ───────────────────────────────────
+                if props.expanded {
+                    let content_x = LEFT_PAD + RAIL_W + INNER_GAP;
+                    let content_w = (available.width() - content_x - RIGHT_GAP).max(0.0);
+                    if content_w > 0.0 {
+                        let content_rect = egui::Rect::from_min_size(
+                            available.min + egui::vec2(content_x, 0.0),
+                            egui::vec2(content_w, panel_h),
+                        );
+                        ui.painter().add(floating.paint(content_rect));
+                        let mut content_ui = ui.new_child(
+                            egui::UiBuilder::new()
+                                .max_rect(content_rect)
+                                .layout(egui::Layout::top_down(egui::Align::Min)),
+                        );
+                        egui::ScrollArea::vertical().show(&mut content_ui, |ui| {
+                            self.render_content(ui, &props, &mut events);
+                        });
+                    }
+                }
+
+                ui.allocate_rect(available, egui::Sense::hover());
+            });
+
+        if props.expanded {
+            let actual_width = outer_response.response.rect.width();
             if (actual_width - props.sidebar_width).abs() > 0.1 {
                 events.push(SidebarEvent::WidthChanged(actual_width));
             }

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -293,25 +293,18 @@ impl ContextComponent for StatusBar {
             },
         );
 
-        // Use theme colors from context
-        let bg_color = ui.ctx().memory(|mem| {
-            mem.data
-                .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
-                .unwrap_or_else(|| {
-                    // Fallback: create default theme based on dark mode from visuals
-                    let dark_mode = ui.ctx().global_style().visuals.dark_mode;
-                    crate::theme::Theme::for_dark_mode(dark_mode).colors()
-                })
-                .bg_sunken
-        });
-
         egui::Panel::bottom("status_bar")
-            .exact_size(24.0)
-            .frame(egui::Frame::NONE.fill(bg_color).inner_margin(egui::Margin {
+            .exact_size(26.0)
+            .show_separator_line(false)
+            // Design `.statusbar{padding:0 12px}` — no vertical padding. With 4px
+            // top and bottom the usable height was only 18px, so the 22px chips
+            // and the bell couldn't fit and the row's items drifted out of line
+            // with each other.
+            .frame(egui::Frame::NONE.inner_margin(egui::Margin {
                 left: 12,
                 right: 12,
-                top: 4,
-                bottom: 4,
+                top: 0,
+                bottom: 0,
             }))
             .show_inside(ui, |ui| {
                 // Use theme text color from context
@@ -319,15 +312,20 @@ impl ContextComponent for StatusBar {
                     mem.data
                         .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
                         .unwrap_or_else(|| {
-                            // Fallback: create default theme based on dark mode from visuals
                             let dark_mode = ui.ctx().global_style().visuals.dark_mode;
                             crate::theme::Theme::for_dark_mode(dark_mode).colors()
                         })
-                        .fg
+                        .fg_muted
                 });
                 ui.style_mut().visuals.override_text_color = Some(text_color);
+                // Design token: status bar uses 11.5px, smaller than body text.
+                ui.style_mut().override_font_id = Some(egui::FontId::proportional(11.5));
 
-                ui.horizontal(|ui| {
+                // Centre every item on the bar's full 26px height, so the taller
+                // chips (and the bell) sit on the same axis as the plain labels
+                // instead of each group settling at its own baseline.
+                ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+                    ui.set_min_height(ui.available_height());
                     ui.spacing_mut().item_spacing = egui::vec2(8.0, 0.0);
 
                     if let Some(summary) = props.chart_summary {

--- a/src/components/toolbar.rs
+++ b/src/components/toolbar.rs
@@ -63,27 +63,19 @@ impl Toolbar {
         props: ToolbarProps<'_>,
         events: &mut Vec<ToolbarEvent>,
     ) {
-        // Use theme colors from context
-        let bg_color = ui.ctx().memory(|mem| {
-            mem.data
-                .get_temp::<crate::theme::ThemeColors>(egui::Id::new("theme_colors"))
-                .map(|c| c.bg_sunken)
-                .unwrap_or(ui.ctx().global_style().visuals.extreme_bg_color)
-        });
-
-        // Row 1: Title bar (32px height - integrated with window controls, with title)
-        // Hide completely in fullscreen mode
+        // Title bar — transparent chrome strip; background comes from the window clear color.
         if !props.is_fullscreen {
             egui::Panel::top("title_bar_row")
-                .exact_size(32.0)
-                .frame(egui::Frame::NONE.fill(bg_color).inner_margin(egui::Margin {
+                .exact_size(38.0)
+                .show_separator_line(false)
+                .frame(egui::Frame::NONE.inner_margin(egui::Margin {
                     left: 8,
                     right: 8,
                     top: 0,
                     bottom: 0,
                 }))
                 .show_inside(ui, |ui| {
-                    ui.horizontal(|ui| {
+                    ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
                         ui.spacing_mut().item_spacing = egui::vec2(2.0, 0.0);
 
                         #[cfg(target_os = "macos")]
@@ -165,7 +157,8 @@ impl Toolbar {
         #[cfg(target_os = "linux")]
         egui::Panel::top("menu_bar_row")
             .exact_size(28.0)
-            .frame(egui::Frame::NONE.fill(bg_color).inner_margin(egui::Margin {
+            .show_separator_line(false)
+            .frame(egui::Frame::NONE.inner_margin(egui::Margin {
                 left: 4,
                 right: 4,
                 top: 0,

--- a/src/components/update_consent_modal.rs
+++ b/src/components/update_consent_modal.rs
@@ -1,12 +1,12 @@
-use eframe::egui::{self, Frame, Layout, Margin, RichText};
+use std::cell::Cell;
 
-use crate::{
-    components::traits::StatelessComponent,
-    theme::{ThemeColors, phosphor_font_id},
-};
+use eframe::egui;
+
+use crate::components::traits::StatelessComponent;
 use thoth_plugin_sdk::components::{
-    Button, ButtonColor, ButtonSize, ButtonType, Typography, TypographyVariant,
+    Button, ButtonColor, ButtonSize, ButtonType, Modal, Typography, TypographyVariant,
 };
+use thoth_plugin_sdk::theme::{FONT_BODY, ThemeColors, color_to_hex};
 
 pub struct UpdateConsentModal;
 
@@ -25,121 +25,79 @@ impl StatelessComponent for UpdateConsentModal {
     type Output = UpdateConsentModalOutput;
 
     fn render(ui: &mut egui::Ui, props: Self::Props<'_>) -> Self::Output {
-        let colors = ui.ctx().memory(|mem| {
-            mem.data
-                .get_temp::<ThemeColors>(egui::Id::new("theme_colors"))
-                .unwrap_or_else(|| crate::theme::Theme::default().colors())
-        });
+        let colors = ThemeColors::from_ctx(ui.ctx());
 
-        let mut output = UpdateConsentModalOutput {
-            update_now: false,
-            remind_later: false,
-        };
+        // Card chrome, head and footer strip all come from the base modal
+        // (design `.card.w400`): the head shows the title over the version delta.
+        let modal = Modal::builder()
+            .id("update_consent_modal")
+            .title("Update Available")
+            .subtitle(format!(
+                "v{} → v{}",
+                props.current_version, props.latest_version
+            ))
+            .width(400.0)
+            // Design leads the head with the update glyph.
+            .glyph(egui_phosphor::regular::ARROW_CIRCLE_UP)
+            .glyph_color("info")
+            // The design's update card has no ✕ — the user answers it either way.
+            .dismissible(false)
+            .build();
 
-        let modal = egui::Modal::new(egui::Id::new("update_consent_modal"));
-        modal.show(ui.ctx(), |ui| {
-            ui.set_width(400.0);
+        // The footer closure borrows locals, so plain cells suffice.
+        let update_now = Cell::new(false);
+        let remind_later = Cell::new(false);
 
-            // Backdrop color is handled by egui::Modal internally.
+        let closed = modal.show_with_footer(
+            ui,
+            // ── Body — one paragraph of 13px `subtext0` copy ──────────────────
+            |ui| {
+                ui.add(
+                    Typography::builder()
+                        .text("A new version of Thoth is ready to install. Update now for the latest features and improvements.")
+                        .variant(TypographyVariant::Body)
+                        .size(FONT_BODY)
+                        .color(color_to_hex(colors.fg_subtle()))
+                        .build(),
+                );
+            },
+            // ── Footer — laid out right-to-left, so the primary goes first ────
+            |ui| {
+                if ui
+                    .add(
+                        Button::builder()
+                            .label("Update Now")
+                            .button_type(ButtonType::Elevated)
+                            .color(ButtonColor::Primary)
+                            .button_size(ButtonSize::Medium)
+                            .build(),
+                    )
+                    .clicked()
+                {
+                    update_now.set(true);
+                }
 
-            // ── Header ────────────────────────────────────────────────────────
-            Frame::new()
-                .inner_margin(Margin {
-                    left: 24,
-                    right: 24,
-                    top: 24,
-                    bottom: 16,
-                })
-                .show(ui, |ui| {
-                    ui.horizontal(|ui| {
-                        ui.label(
-                            RichText::new(egui_phosphor::regular::ARROW_CIRCLE_UP)
-                                .font(phosphor_font_id(28.0))
-                                .color(colors.info),
-                        );
-                        ui.add_space(10.0);
-                        ui.vertical(|ui| {
-                            ui.add(
-                                Typography::builder()
-                                    .text("Update Available")
-                                    .variant(TypographyVariant::BodyLarge)
-                                    .bold(true)
-                                    .build(),
-                            );
-                            Typography::body_muted(
-                                ui,
-                                &format!(
-                                    "v{} → v{}",
-                                    props.current_version, props.latest_version
-                                ),
-                            );
-                        });
-                    });
-                });
+                if ui
+                    .add(
+                        Button::builder()
+                            .label("Remind Later")
+                            .button_type(ButtonType::Text)
+                            .color(ButtonColor::Default)
+                            .button_size(ButtonSize::Medium)
+                            .build(),
+                    )
+                    .clicked()
+                {
+                    remind_later.set(true);
+                }
+            },
+        );
 
-            ui.add(egui::Separator::default().spacing(0.0));
-
-            // ── Body ──────────────────────────────────────────────────────────
-            Frame::new()
-                .inner_margin(Margin {
-                    left: 24,
-                    right: 24,
-                    top: 16,
-                    bottom: 16,
-                })
-                .show(ui, |ui| {
-                    Typography::body(
-                        ui,
-                        "A new version of Thoth is ready to install. Update now for the latest features and improvements.",
-                    );
-                });
-
-            ui.add(egui::Separator::default().spacing(0.0));
-
-            // ── Footer ────────────────────────────────────────────────────────
-            Frame::new()
-                .fill(colors.bg_sunken)
-                .inner_margin(Margin {
-                    left: 24,
-                    right: 24,
-                    top: 12,
-                    bottom: 12,
-                })
-                .show(ui, |ui| {
-                    ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
-                        if ui
-                            .add(
-                                Button::builder()
-                                    .label("Update Now")
-                                    .button_type(ButtonType::Elevated)
-                                    .color(ButtonColor::Primary)
-                                    .button_size(ButtonSize::Medium)
-                                    .build(),
-                            )
-                            .clicked()
-                        {
-                            output.update_now = true;
-                        }
-
-                        ui.add_space(8.0);
-
-                        if ui
-                            .add(
-                                Button::builder()
-                                    .label("Remind Later")
-                                    .button_type(ButtonType::Text)
-                                    .color(ButtonColor::Default)
-                                    .button_size(ButtonSize::Medium)
-                                    .build(),
-                            )
-                            .clicked()
-                        {
-                            output.remind_later = true;
-                        }
-                    });
-                });
-        });
-
-        output
+        UpdateConsentModalOutput {
+            update_now: update_now.get(),
+            // Escape / backdrop / ✕ defer the update rather than dismissing it
+            // silently, so the prompt comes back on the next check.
+            remind_later: remind_later.get() || (closed && !update_now.get()),
+        }
     }
 }

--- a/src/components/welcome.rs
+++ b/src/components/welcome.rs
@@ -1,12 +1,334 @@
+// WelcomePanel — design sheet `welcome.html` (`.welcome`), which supersedes the
+// slimmer `screens.html` §1 sheet this module was first built from. One calm
+// composition: a hero, three `.acard` start actions, a drop affordance, and a
+// Recent / Tips column pair, all inside a 980px `.wrap` centred in the pane.
+//
+// The `.welcome` panel *chrome* (base fill, `--p-shadow`, `--edge`, 16px radius)
+// is deliberately not painted here: `ThothApp::render_dock` already wraps the
+// whole dock area — this panel included — in exactly that frame
+// (`fill(bg)` + `RADIUS_PANEL` + `panel_shadow` + `edge_stroke`), so painting it
+// again would double the edge and the shadow. This module owns everything inside
+// it, including the `.wrap` padding: `CentralPanel::render_ui` drops its 8px
+// content margin for the welcome screen so 40/44 lands exactly.
+//
+// Most boxes on the sheet have no SDK counterpart (`.mark`, `.acard`, `.drop`,
+// the tinted `.tile`s, the `.kbd`/`.ext` chips), and every clickable box is a
+// single hover/click target with its contents *painted* into it — a child widget
+// laid on top would shadow the box's own hover and eat its click. Those are
+// hand-painted from theme tokens; `Typography` carries the plain text flows.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::SystemTime;
+
 use eframe::egui;
+use egui::text::{LayoutJob, TextFormat, TextWrapping};
+use egui::{
+    Align2, Color32, FontId, Galley, Pos2, Rect, Sense, Stroke, StrokeKind, Vec2, pos2, vec2,
+};
 use egui_phosphor::regular as ph;
 use thoth_plugin_sdk::components::{Typography, TypographyVariant};
 
-use crate::theme::ThemeColors;
+use crate::theme::{
+    FONT_CAPTION, FONT_CONTROL, ICON_CONTROL, RADIUS_CHECK, RADIUS_CHIP, RADIUS_CONTROL,
+    RADIUS_PANEL, RADIUS_PILL, ThemeColors, edge_stroke, phosphor_font_id, semibold_font_id,
+    with_alpha,
+};
 
+// ── Alpha ladder — the sheet's `color-mix(in oklab, X N%, transparent)` ───────
+
+/// `.rrow:hover{background:text 5%}`.
+const A_05: u8 = 13;
+/// `.drop:hover{background:mauve 8%}`.
+const A_08: u8 = 20;
+/// The `.tile` / `.ic` tints (`t-mauve`/`t-blue`/`t-green`/`t-peach`, 16%).
+const A_16: u8 = 41;
+/// `.drop{background:surface0 30%}`.
+const A_30: u8 = 77;
+/// `.mark{box-shadow:… mauve 34%}`.
+const A_34: u8 = 87;
+/// `.drop{box-shadow:inset … surface1 55%}` and its mauve hover twin.
+const A_55: u8 = 140;
+/// The plugins card's `.kbd` carries `style="opacity:.35"` — no shortcut is
+/// bound to it yet, so the chip is present but dimmed.
+const A_35_OPACITY: u8 = 89;
+
+// ── Wrap — design `.wrap` ────────────────────────────────────────────────────
+
+/// `.wrap{max-width:980px}`. `box-sizing:border-box`, so the side padding below
+/// is *inside* this width.
+const WRAP_MAX_W: f32 = 980.0;
+/// `.wrap{padding:40px 44px}`.
+const WRAP_PAD_X: f32 = 44.0;
+const WRAP_PAD_Y: f32 = 40.0;
+
+// ── Hero — design `.hero` ────────────────────────────────────────────────────
+
+/// `.hero{gap:16px}` — between the mark, the text block, and the version pill.
+const HERO_GAP: f32 = 16.0;
+/// `.hero{margin-bottom:30px}`.
+const HERO_BOTTOM: f32 = 30.0;
+/// `.mark{width:52px;height:52px}`.
+const MARK: f32 = 52.0;
+/// `.mark{font-size:28px}`.
+const MARK_GLYPH: f32 = 28.0;
+/// `.mark{box-shadow:0 6px 18px color-mix(in oklab,var(--mauve) 34%,transparent)}`
+/// — hand-rolled rather than [`crate::theme::glow_shadow`], which is the
+/// primary button's tighter `0 3px 10px @38%`.
+const MARK_GLOW_OFFSET: i8 = 6;
+const MARK_GLOW_BLUR: u8 = 18;
+/// `.htext h1{font-size:26px;font-weight:700;line-height:1.1}`.
+const TITLE_FONT: f32 = 26.0;
+const TITLE_LINE: f32 = 1.1;
+/// `.htext .tag{font-size:13.5px}`.
+const TAG_FONT: f32 = 13.5;
+/// `.htext .tag{margin-top:4px}`.
+const TAG_TOP: f32 = 4.0;
+/// `.ver{font:600 11px/1 var(--mono)}`.
+const VER_FONT: f32 = FONT_CAPTION;
+/// `.ver{padding:5px 9px}`.
+const VER_PAD_X: f32 = 9.0;
+const VER_PAD_Y: f32 = 5.0;
+
+/// `.hero h1`.
+const TITLE: &str = "Welcome to Thoth";
+/// `.htext .tag` — two runs; the trailing sentence is the accented one
+/// (`<span style="color:var(--mauve)">`).
+const TAGLINE: &str = "A fast, keyboard-first viewer for JSON, NDJSON & data files. ";
+const TAGLINE_ACCENT: &str = "Wisdom for your JSON.";
+
+// ── Section label — design `.slabel` ─────────────────────────────────────────
+
+/// `.slabel{font-size:10.5px;font-weight:700;text-transform:uppercase}`. egui has
+/// no letter-spacing, so `letter-spacing:.09em` is dropped; the uppercasing and
+/// the weight are honoured.
+const SLABEL_FONT: f32 = 10.5;
+/// `.slabel{margin-bottom:10px}`.
+const SLABEL_BOTTOM: f32 = 10.0;
+/// `.slabel .a{font-weight:600;font-size:11px}` — the right-aligned action link.
+const SLABEL_ACTION_FONT: f32 = FONT_CAPTION;
+
+// ── Start actions — design `.actions` / `.acard` ─────────────────────────────
+
+/// `.actions{grid-template-columns:repeat(3,1fr);gap:10px}`.
+const ACTIONS_GAP: f32 = 10.0;
+/// `.actions{margin-bottom:12px}`.
+const ACTIONS_BOTTOM: f32 = 12.0;
+/// `.acard{padding:12px 13px}`.
+const ACARD_PAD_X: f32 = 13.0;
+const ACARD_PAD_Y: f32 = 12.0;
+/// `.acard{gap:12px}`.
+const ACARD_GAP: f32 = 12.0;
+/// `.acard .tile{width:38px;height:38px}` — the tallest child, so it sets the
+/// card's height together with the vertical padding.
+const ACARD_TILE: f32 = 38.0;
+/// `.acard .tile{font-size:20px}`.
+const ACARD_TILE_GLYPH: f32 = 20.0;
+/// `.acard .t{font-size:14px;font-weight:600}`.
+const ACARD_TITLE_FONT: f32 = 14.0;
+/// `.acard .s{font-size:11.5px}`.
+const ACARD_SUB_FONT: f32 = 11.5;
+/// `.acard .s{margin-top:2px}`.
+const ACARD_SUB_TOP: f32 = 2.0;
+
+// ── Key chip — design `.kbd` ─────────────────────────────────────────────────
+
+/// `.kbd{font-family:var(--mono);font-size:11px}`.
+const KBD_FONT: f32 = FONT_CAPTION;
+/// `.kbd{padding:3px 7px}`.
+const KBD_PAD_X: f32 = 7.0;
+const KBD_PAD_Y: f32 = 3.0;
+
+// ── Drop affordance — design `.drop` ─────────────────────────────────────────
+
+/// `.drop{height:52px}`.
+const DROP_H: f32 = 52.0;
+/// `.drop{gap:10px}`.
+const DROP_GAP: f32 = 10.0;
+/// `.drop{margin-bottom:28px}`.
+const DROP_BOTTOM: f32 = 28.0;
+/// `.drop{font-size:12.5px}`.
+const DROP_FONT: f32 = FONT_CONTROL;
+/// `.drop i{font-size:18px}`.
+const DROP_ICON: f32 = 18.0;
+/// `.drop{box-shadow:inset 0 0 0 1.5px …}` — an *inset* ring, so it is stroked
+/// inside the rect rather than centred on its edge.
+const DROP_BORDER: f32 = 1.5;
+/// `.drop .fmt{font-family:var(--mono);font-size:11px}`.
+const DROP_FMT_FONT: f32 = FONT_CAPTION;
+
+/// `.drop b`.
+const DROP_LABEL: &str = "Drop a file to open";
+/// `.drop .fmt`.
+const DROP_FORMATS: &str = "JSON · NDJSON · CSV · or paste with ⌘V";
+
+// ── Lower columns — design `.cols` ───────────────────────────────────────────
+
+/// `.cols{gap:34px}`.
+const COLS_GAP: f32 = 34.0;
+/// `.cols{grid-template-columns:1.1fr 1fr}` — the left (Recent) share.
+const COLS_LEFT_FR: f32 = 1.1;
+
+// ── Recent rows — design `.rrow` ─────────────────────────────────────────────
+
+/// `.recent{gap:2px}`.
+const RECENT_GAP: f32 = 2.0;
+/// `.rrow{padding:8px 10px}`.
+const RROW_PAD_X: f32 = 10.0;
+const RROW_PAD_Y: f32 = 8.0;
+/// `.rrow{gap:11px}`.
+const RROW_GAP: f32 = 11.0;
+/// `.rrow .ic{width:30px;height:30px}` — sets the row height with the padding.
+const RROW_TILE: f32 = 30.0;
+/// `.rrow .ic{font-size:15px}`.
+const RROW_TILE_GLYPH: f32 = ICON_CONTROL;
+/// `.rrow .fn{font-size:13px;font-family:var(--mono)}`.
+const RROW_NAME_FONT: f32 = 13.0;
+/// `.rrow .meta{font-size:11px}`.
+const RROW_META_FONT: f32 = FONT_CAPTION;
+/// `.rrow .meta{margin-top:1px}`.
+const RROW_META_TOP: f32 = 1.0;
+/// `.rrow .ext{font:600 9.5px/1 var(--mono)}`.
+const EXT_FONT: f32 = 9.5;
+/// `.rrow .ext{padding:3px 6px}`.
+const EXT_PAD_X: f32 = 6.0;
+const EXT_PAD_Y: f32 = 3.0;
+/// The sheet draws four `.rrow`s; five keeps the column in balance with the five
+/// tips beside it. The sidebar's Recent Files panel remains the full history.
+const RECENT_MAX: usize = 5;
+/// `.meta`'s separator.
+const META_SEP: &str = " · ";
+
+// ── Tips — design `.tips` / `.tip` ───────────────────────────────────────────
+
+/// `.tips{gap:9px}`.
+const TIPS_GAP: f32 = 9.0;
+/// `.tip{gap:11px}`.
+const TIP_GAP: f32 = 11.0;
+/// `.tip .bd{font-size:12.5px;line-height:1.45}`.
+const TIP_FONT: f32 = FONT_CONTROL;
+const TIP_LINE: f32 = 1.45;
+
+/// The sheet's five `.tip` rows: `.kbd` chip, then body. The shortcut glyphs are
+/// the sheet's own literals, matching the macOS bindings in `shortcut_handler`.
+const TIPS: [(&str, &str); 5] = [
+    (
+        "Drag → edge",
+        "Drop on the left, right, top or bottom of a pane to split it.",
+    ),
+    (
+        "Right-click tab",
+        "Pin, close others, split right / down — full menu.",
+    ),
+    (
+        "⌘W",
+        "Close the active tab. The last welcome tab closes the window.",
+    ),
+    ("⌘⌥ → / ←", "Cycle to the next or previous tab."),
+    ("⌘1 – ⌘9", "Jump to a tab by position."),
+];
+
+// ── Recent-file metadata cache ───────────────────────────────────────────────
+
+/// egui-memory key for the [`MetaCache`].
+const META_CACHE_ID: &str = "welcome_recent_meta";
+/// Seconds a cached stat is trusted for. `.meta`'s size and modified time need a
+/// `fs::metadata` syscall, which must not run per row per frame; five seconds
+/// keeps at most one stat per row per five seconds (five syscalls) while still
+/// reflecting a file that changed under us.
+const META_TTL: f64 = 5.0;
+
+/// A recent file's `fs::metadata`, as far as `.meta` needs it.
+#[derive(Clone, Copy)]
+struct FileMeta {
+    /// `.meta`'s size run.
+    size: u64,
+    /// `.meta`'s time run. The *string* is re-derived from this every frame, so a
+    /// cached entry never shows a stale “2m ago”.
+    modified: Option<SystemTime>,
+}
+
+/// One cache slot: when it was statted, and what came back (`None` = the stat
+/// failed, e.g. the file is gone — then `.meta` shows only the free parts).
+#[derive(Clone, Copy)]
+struct MetaEntry {
+    stat_at: f64,
+    meta: Option<FileMeta>,
+}
+
+type MetaCache = HashMap<PathBuf, MetaEntry>;
+
+/// One `.rrow`'s resolved content. Built once per frame, before layout, because
+/// the composition is measured and then drawn (see [`WelcomePanel::render`]).
+struct RecentEntry {
+    /// What clicking the row opens.
+    path: PathBuf,
+    /// `.fn` — the file's own name.
+    name: String,
+    /// `.meta` — `~/work/thoth · 4.2 KB · 2m ago`. The directory is free; the
+    /// size and time runs appear only when the stat succeeded, never faked.
+    meta: String,
+    /// `.ext` — the trailing chip, upper-cased.
+    ext: Option<String>,
+    /// `.ic`'s glyph and tint, by file type.
+    glyph: &'static str,
+    tint_role: TintRole,
+}
+
+/// Which palette role a `.rrow .ic` tint comes from — resolved against the live
+/// palette at paint time, so the entry list stays theme-independent.
+#[derive(Clone, Copy)]
+enum TintRole {
+    /// `t-mauve` — JSON.
+    Accent,
+    /// `t-blue` — NDJSON.
+    Info,
+    /// `t-peach` — CSV.
+    Peach,
+    /// Anything else: a muted glyph, no colour claim.
+    Muted,
+}
+
+impl TintRole {
+    fn color(self, c: &ThemeColors) -> Color32 {
+        match self {
+            Self::Accent => c.accent,
+            Self::Info => c.info,
+            Self::Peach => c.syntax_number,
+            Self::Muted => c.fg_muted,
+        }
+    }
+}
+
+/// What the user did on the welcome screen this frame.
 pub enum WelcomeEvent {
+    /// `.acard[data-od-id=action-open]`, and the `.drop` affordance.
     OpenFilePicker,
-    OpenRecentFile(std::path::PathBuf),
+    /// A `.rrow` was clicked.
+    OpenRecentFile(PathBuf),
+    /// `.acard[data-od-id=action-new-window]` (⌘N).
+    NewWindow,
+    /// `.acard[data-od-id=action-plugins]`.
+    BrowsePlugins,
+    /// The Recent `.slabel`'s `Clear` action.
+    ClearRecentFiles,
+}
+
+/// One `.acard`'s content.
+struct ActionCard<'a> {
+    /// `.tile`'s glyph.
+    glyph: &'a str,
+    /// `.tile`'s tint (`t-mauve` / `t-blue` / `t-green`).
+    tint: Color32,
+    /// `.acard .t`.
+    title: &'a str,
+    /// `.acard .s`.
+    subtitle: &'a str,
+    /// The trailing `.kbd` chip.
+    key: &'a str,
+    /// The chip is present but dimmed — the sheet's `style="opacity:.35"`.
+    dim_key: bool,
 }
 
 pub struct WelcomePanel;
@@ -28,253 +350,948 @@ impl WelcomePanel {
                 .unwrap_or_else(|| crate::theme::Theme::default().colors())
         });
 
-        // ── PluginShell header (title row + divider) ──────────────────────────
-        // padding: 20px 24px 16px  — top 20, sides 24, bottom 16
-        let header_padding = egui::Margin {
-            left: 24,
-            right: 24,
-            top: 20,
-            bottom: 16,
-        };
-        egui::Frame::NONE
-            .inner_margin(header_padding)
-            .show(ui, |ui| {
-                ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 12.0;
-                    // Title — --primary (mauve), --fs-2xl (20px), weight 700
-                    ui.add(
-                        Typography::builder()
-                            .text("Welcome to Thoth")
-                            .variant(TypographyVariant::Heading)
-                            .color(thoth_plugin_sdk::theme::color_to_hex(c.accent_secondary))
-                            .size(22.0)
-                            .bold(true)
-                            .build(),
-                    );
-                    // Subtitle — --overlay1, --fs-md (13px), baseline-aligned
-                    ui.add(
-                        Typography::builder()
-                            .text("Wisdom for your JSON.")
-                            .variant(TypographyVariant::Subtitle)
-                            .build(),
-                    );
-                });
-            });
+        // Resolved (and stat-cached) up front: the composition below is laid out
+        // twice per frame — once to measure, once to draw — and neither pass
+        // should touch the filesystem.
+        let recent = recent_entries(ui.ctx(), recent_files);
 
-        // Border-bottom: 1px solid --surface0
-        let sep_rect =
-            egui::Rect::from_min_size(ui.cursor().min, egui::vec2(ui.available_width(), 1.0));
-        ui.painter().rect_filled(sep_rect, 0.0, c.surface);
-        ui.advance_cursor_after_rect(sep_rect);
-
-        // ── Body — padding: 24px, scrollable ─────────────────────────────────
+        // `.welcome{overflow:auto;display:flex;flex-direction:column;
+        // justify-content:center}` — the panel scrolls, and while the content is
+        // shorter than the viewport it sits centred in it.
         egui::ScrollArea::vertical()
             .auto_shrink([false, false])
             .show(ui, |ui| {
-                let body_padding = egui::Margin::same(24);
-                egui::Frame::NONE
-                    .inner_margin(body_padding)
-                    .show(ui, |ui| {
-                        // Grid: 1fr 1fr, gap: 32, maxWidth: 880
-                        ui.set_max_width(880.0);
-                        ui.spacing_mut().item_spacing.y = 0.0;
+                let viewport_h = ui.available_height();
+                let avail_w = ui.available_width();
 
-                        ui.columns(2, |cols| {
-                            let col_gap = 16.0; // half of gap: 32
-                            cols[0].add_space(0.0);
+                // `.wrap{width:100%;max-width:980px;margin:0 auto;padding:40px 44px}`
+                let wrap_w = avail_w.min(WRAP_MAX_W);
+                let indent = ((avail_w - wrap_w) / 2.0).max(0.0) + WRAP_PAD_X;
+                let content_w = (wrap_w - WRAP_PAD_X * 2.0).max(0.0);
 
-                            // ── Left: Start + Recent ──────────────────────────
-                            {
-                                let ui = &mut cols[0];
-                                ui.set_max_width(ui.available_width() - col_gap);
+                // `justify-content:center` needs the block's height *before* it is
+                // placed. An invisible sizing pass measures it at the final width
+                // within this same frame (a height remembered from the last frame
+                // would lag, and the hero would visibly drift on resize). Its
+                // events are thrown away, and its widgets report no hover because
+                // the pass is disabled.
+                //
+                // `new_child`, not `scope_builder`: the latter allocates the child's
+                // min_rect in the parent, which would reserve the whole block's
+                // height as empty space and push the real content off the bottom.
+                let measured = {
+                    let mut probe = ui.new_child(
+                        egui::UiBuilder::new()
+                            .id_salt("welcome-sizing")
+                            .sizing_pass()
+                            .invisible()
+                            .max_rect(Rect::from_min_size(
+                                ui.cursor().min,
+                                vec2(content_w, viewport_h.max(1.0)),
+                            )),
+                    );
+                    wrap(&mut probe, &recent, &c, &mut Vec::new());
+                    probe.min_rect().height()
+                };
+                ui.add_space(((viewport_h - measured) / 2.0).max(0.0));
 
-                                t_section(ui, "Start", c);
-                                ui.add_space(8.0);
-
-                                if action_row(ui, ph::FOLDER_OPEN, "Open file…", Some("⌘O"), c) {
-                                    events.push(WelcomeEvent::OpenFilePicker);
-                                }
-                                if action_row(ui, ph::APP_WINDOW, "New window", Some("⌘N"), c) {
-                                    // handled by shortcut; no event needed
-                                }
-                                if action_row(ui, ph::PUZZLE_PIECE, "Browse plugins…", None, c) {
-                                    // future: open settings → plugins
-                                }
-
-                                ui.add_space(24.0);
-                                t_section(ui, "Recent", c);
-                                ui.add_space(8.0);
-
-                                if recent_files.is_empty() {
-                                    ui.add(
-                                        Typography::builder()
-                                            .text("No recent files")
-                                            .variant(TypographyVariant::BodyMuted)
-                                            .build(),
-                                    );
-                                } else {
-                                    for path_str in recent_files.iter().take(8) {
-                                        let path = std::path::PathBuf::from(path_str);
-                                        let name = path
-                                            .file_name()
-                                            .and_then(|n| n.to_str())
-                                            .unwrap_or(path_str.as_str())
-                                            .to_string();
-                                        let ext = path
-                                            .extension()
-                                            .and_then(|e| e.to_str())
-                                            .map(|e| e.to_uppercase());
-                                        if action_row(
-                                            ui,
-                                            ph::FILE_TEXT,
-                                            &name,
-                                            ext.as_deref(),
-                                            c,
-                                        ) {
-                                            events.push(WelcomeEvent::OpenRecentFile(path));
-                                        }
-                                    }
-                                }
-                            }
-
-                            // ── Right: Tips ───────────────────────────────────
-                            {
-                                let ui = &mut cols[1];
-                                ui.add_space(col_gap);
-
-                                t_section(ui, "Tips", c);
-                                ui.add_space(8.0);
-
-                                tip_row(ui, "Drag tab → edge", "Drop on the left, right, top, or bottom of any pane to split it.", c);
-                                tip_row(ui, "Drag tab → strip", "Move a tab between groups, or reorder within the same strip.", c);
-                                tip_row(ui, "Right-click tab", "Pin, close others, split right, split down — full VSCode-style menu.", c);
-                                tip_row(ui, "⌘W", "Close active tab. Last welcome tab closes the window.", c);
-                                tip_row(ui, "⌘⌥→ / ⌘⌥←", "Cycle to next or previous tab.", c);
-                                tip_row(ui, "⌘1 – ⌘9", "Jump to tab by position.", c);
-                            }
-                        });
+                // `ui.horizontal_top` (not `with_layout`, whose centred cross-align
+                // would claim the full remaining height) indents the wrap; the
+                // column inside it is pinned to the wrap's content width.
+                ui.horizontal_top(|ui| {
+                    ui.spacing_mut().item_spacing = Vec2::ZERO;
+                    ui.add_space(indent);
+                    ui.vertical(|ui| {
+                        ui.set_width(content_w);
+                        wrap(ui, &recent, &c, &mut events);
                     });
+                });
             });
 
         events
     }
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── Composition ───────────────────────────────────────────────────────────────
 
-/// `.t-section` — bold 12px content-area section label
-fn t_section(ui: &mut egui::Ui, text: &str, _c: ThemeColors) {
-    ui.add(
-        Typography::builder()
-            .text(text)
-            .variant(TypographyVariant::SectionHeader)
-            .build(),
+/// The `.wrap` block: every gap between its children is explicit, so the ui's own
+/// item spacing is zeroed first.
+fn wrap(
+    ui: &mut egui::Ui,
+    recent: &[RecentEntry],
+    c: &ThemeColors,
+    events: &mut Vec<WelcomeEvent>,
+) {
+    ui.spacing_mut().item_spacing = Vec2::ZERO;
+    let w = ui.available_width();
+
+    ui.add_space(WRAP_PAD_Y);
+
+    hero(ui, w, c);
+    ui.add_space(HERO_BOTTOM);
+
+    slabel(ui, w, "Start", None, c);
+    start_actions(ui, w, c, events);
+    ui.add_space(ACTIONS_BOTTOM);
+
+    if drop_zone(ui, w, c) {
+        // The sheet's drop affordance *teaches* the gesture; clicking it does what
+        // Open file… does. Real drag-and-drop lives in `drag_and_drop.rs`.
+        events.push(WelcomeEvent::OpenFilePicker);
+    }
+    ui.add_space(DROP_BOTTOM);
+
+    lower_columns(ui, w, recent, c, events);
+    ui.add_space(WRAP_PAD_Y);
+}
+
+/// `.hero`: the 52px `.mark`, the title + tagline block (both vertically centred
+/// — `align-items:center`), and the `.ver` pill pushed right and pinned to the
+/// top (`margin-left:auto;align-self:flex-start`).
+fn hero(ui: &mut egui::Ui, w: f32, c: &ThemeColors) {
+    // The pill is measured first: it keeps its natural width, and the text block
+    // gets whatever is left — the flex row's `margin-left:auto` in reverse.
+    let version = format!("v{}", env!("CARGO_PKG_VERSION"));
+    // No 600-weight mono face is registered (only the proportional 500/600 ones),
+    // so `.ver`'s `font:600 … var(--mono)` renders at the mono regular weight.
+    let ver = line(ui, &version, FontId::monospace(VER_FONT), c.fg_subtle());
+    let ver_size = ver.size() + vec2(VER_PAD_X * 2.0, VER_PAD_Y * 2.0);
+
+    let text_w = (w - MARK - HERO_GAP - HERO_GAP - ver_size.x).max(0.0);
+    // `font-weight:700` has no registered face; semibold (600) is the heaviest
+    // real one, and beats smearing a galley over itself.
+    let title = line_h(
+        ui,
+        TITLE,
+        semibold_font_id(ui.ctx(), TITLE_FONT),
+        c.fg,
+        TITLE_FONT * TITLE_LINE,
+    );
+    let tag = tagline(ui, text_w, c);
+
+    let text_h = title.size().y + TAG_TOP + tag.size().y;
+    let (rect, _) = ui.allocate_exact_size(vec2(w, MARK.max(text_h)), Sense::hover());
+    let p = ui.painter();
+
+    // `.mark` — gradient tile, mauve glow, 28px glyph in `--crust`.
+    let mark = Rect::from_min_size(
+        pos2(rect.left(), rect.center().y - MARK / 2.0),
+        Vec2::splat(MARK),
+    );
+    p.add(
+        egui::Shadow {
+            offset: [0, MARK_GLOW_OFFSET],
+            blur: MARK_GLOW_BLUR,
+            spread: 0,
+            color: with_alpha(c.accent, A_34),
+        }
+        .as_shape(mark, RADIUS_PANEL),
+    );
+    gradient_tile(p, mark, RADIUS_PANEL, c.accent, c.accent_secondary);
+    p.text(
+        mark.center(),
+        Align2::CENTER_CENTER,
+        ph::TREE_STRUCTURE,
+        phosphor_font_id(MARK_GLYPH),
+        c.bg_sunken,
+    );
+
+    let tx = mark.right() + HERO_GAP;
+    let ty = rect.center().y - text_h / 2.0;
+    p.galley(pos2(tx, ty), title.clone(), c.fg);
+    p.galley(pos2(tx, ty + title.size().y + TAG_TOP), tag, c.fg_muted);
+
+    // `.ver` — mono pill on `--surface0` with the shared hairline edge.
+    let ver_rect = Rect::from_min_size(pos2(rect.right() - ver_size.x, rect.top()), ver_size);
+    p.rect_filled(ver_rect, RADIUS_PILL, c.surface);
+    p.rect_stroke(ver_rect, RADIUS_PILL, edge_stroke(c), StrokeKind::Inside);
+    p.galley(
+        ver_rect.min + vec2(VER_PAD_X, VER_PAD_Y),
+        ver,
+        c.fg_subtle(),
     );
 }
 
-/// ActionRow — flex row, icon (16px --accent), label (13px --text, flex:1), optional hint (12px mono --overlay1)
-/// Hover: --surface0 bg, borderRadius 4
-fn action_row(
-    ui: &mut egui::Ui,
-    icon: &str,
-    label: &str,
-    hint: Option<&str>,
-    c: ThemeColors,
-) -> bool {
-    // padding: 8px 10px on each side — total height ~ 13 (font) + 16 (pad) = ~32
-    let row_h = 32.0;
-    let pad_x = 10.0;
-    let available_w = ui.available_width();
-    let (rect, response) =
-        ui.allocate_exact_size(egui::vec2(available_w, row_h), egui::Sense::click());
-
-    if ui.is_rect_visible(rect) {
-        // Hover bg
-        if response.hovered() {
-            ui.painter().rect_filled(rect, 4.0, c.surface);
-        }
-
-        // Icon: left-padded, 16px, --accent
-        let icon_x = rect.min.x + pad_x + 8.0; // 10px pad + ~8px to center
-        ui.painter().text(
-            egui::pos2(icon_x, rect.center().y),
-            egui::Align2::CENTER_CENTER,
-            icon,
-            egui::FontId::new(16.0, egui::FontFamily::Name("phosphor".into())),
-            c.accent,
-        );
-
-        // Hint (right-aligned, monospace 12px --overlay1) — layout first to reserve space
-        let hint_w = if let Some(h) = hint {
-            let g = ui.painter().layout_no_wrap(
-                h.to_string(),
-                egui::FontId::monospace(12.0),
-                c.fg_muted,
-            );
-            let gsize = g.size();
-            let hint_x = rect.max.x - pad_x - gsize.x;
-            ui.painter().galley(
-                egui::pos2(hint_x, rect.center().y - gsize.y / 2.0),
-                g,
-                c.fg_muted,
-            );
-            gsize.x + pad_x + 4.0
-        } else {
-            0.0
-        };
-
-        // Label (flex:1, 13px --text, single line)
-        let label_x = rect.min.x + pad_x + 8.0 + 10.0 + 6.0; // after icon + gap:10
-        let label_max_w = (rect.max.x - hint_w - label_x).max(0.0);
-        let lg = ui.painter().layout(
-            label.to_string(),
-            egui::FontId::proportional(13.0),
-            c.fg,
-            label_max_w,
-        );
-        ui.painter().galley(
-            egui::pos2(label_x, rect.center().y - lg.size().y / 2.0),
-            lg,
-            c.fg,
-        );
-    }
-
-    if response.hovered() {
-        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
-    }
-    response.clicked()
+/// `.htext .tag` — one wrapped paragraph in two runs: muted body, then the
+/// accented closing sentence.
+fn tagline(ui: &egui::Ui, max_w: f32, c: &ThemeColors) -> Arc<Galley> {
+    let font = FontId::proportional(TAG_FONT);
+    let mut job = LayoutJob {
+        wrap: TextWrapping::wrap_at_width(max_w),
+        ..Default::default()
+    };
+    job.append(
+        TAGLINE,
+        0.0,
+        TextFormat {
+            font_id: font.clone(),
+            color: c.fg_muted,
+            ..Default::default()
+        },
+    );
+    job.append(
+        TAGLINE_ACCENT,
+        0.0,
+        TextFormat {
+            font_id: font,
+            color: c.accent,
+            ..Default::default()
+        },
+    );
+    ui.painter().layout_job(job)
 }
 
-/// Tip row — badge (mono 12px, --surface0 bg, 2px/8px padding, --text) + body (13px --overlay1)
-fn tip_row(ui: &mut egui::Ui, kbd: &str, body: &str, c: ThemeColors) {
-    // padding: 8px 0 on the row
-    ui.add_space(4.0);
-    ui.horizontal_wrapped(|ui| {
-        ui.spacing_mut().item_spacing = egui::vec2(12.0, 4.0);
+/// `.slabel`: a bold upper-case label with an optional right-aligned action link
+/// (`.slabel .a`). Returns whether that link was clicked.
+fn slabel(ui: &mut egui::Ui, w: f32, text: &str, action: Option<&str>, c: &ThemeColors) -> bool {
+    let label = line(
+        ui,
+        &text.to_uppercase(),
+        semibold_font_id(ui.ctx(), SLABEL_FONT),
+        c.fg_muted,
+    );
+    let act = action.map(|a| {
+        line(
+            ui,
+            a,
+            semibold_font_id(ui.ctx(), SLABEL_ACTION_FONT),
+            c.fg_faint(),
+        )
+    });
+    let h = label.size().y.max(act.as_ref().map_or(0.0, |g| g.size().y));
+    let (rect, _) = ui.allocate_exact_size(vec2(w, h), Sense::hover());
 
-        // Badge: padding 2px 8px, borderRadius 4, bg --surface0, color --text
-        let badge_font = egui::FontId::monospace(12.0);
-        let badge_galley = ui
-            .painter()
-            .layout_no_wrap(kbd.to_string(), badge_font, c.fg);
-        let pad = egui::vec2(8.0, 2.0);
-        let badge_size = badge_galley.size() + pad * 2.0;
-        let (badge_rect, _) = ui.allocate_exact_size(badge_size, egui::Sense::hover());
-        if ui.is_rect_visible(badge_rect) {
-            ui.painter().rect_filled(badge_rect, 4.0, c.surface);
-            ui.painter()
-                .galley(badge_rect.min + pad, badge_galley, c.fg);
+    let mut clicked = false;
+    if let Some(act) = act {
+        // `.slabel .a{cursor:pointer}` — its own hit target, on top of the row.
+        let act_rect = Rect::from_min_size(
+            pos2(
+                rect.right() - act.size().x,
+                rect.center().y - act.size().y / 2.0,
+            ),
+            act.size(),
+        );
+        let resp = ui.interact(
+            act_rect,
+            ui.id().with(("slabel-action", text)),
+            Sense::click(),
+        );
+        if resp.hovered() && !ui.is_sizing_pass() {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
         }
+        // `.slabel .a:hover{color:var(--text)}`
+        let color = if resp.hovered() { c.fg } else { c.fg_faint() };
+        ui.painter().galley(act_rect.min, act, color);
+        clicked = resp.clicked();
+    }
+    ui.painter().galley(
+        pos2(rect.left(), rect.center().y - label.size().y / 2.0),
+        label,
+        c.fg_muted,
+    );
 
-        // Body: 13px --overlay1
+    ui.add_space(SLABEL_BOTTOM);
+    clicked
+}
+
+/// `.actions` — three equal `.acard` columns with a 10px gutter.
+fn start_actions(ui: &mut egui::Ui, w: f32, c: &ThemeColors, events: &mut Vec<WelcomeEvent>) {
+    let card_w = ((w - ACTIONS_GAP * 2.0) / 3.0).max(0.0);
+    ui.horizontal_top(|ui| {
+        ui.spacing_mut().item_spacing = Vec2::ZERO;
+
+        if acard(
+            ui,
+            card_w,
+            &ActionCard {
+                glyph: ph::FOLDER_OPEN,
+                tint: c.accent,
+                title: "Open file…",
+                subtitle: "JSON · NDJSON · CSV",
+                key: "⌘O",
+                dim_key: false,
+            },
+            c,
+        ) {
+            events.push(WelcomeEvent::OpenFilePicker);
+        }
+        ui.add_space(ACTIONS_GAP);
+
+        if acard(
+            ui,
+            card_w,
+            &ActionCard {
+                glyph: ph::APP_WINDOW,
+                tint: c.info,
+                title: "New window",
+                subtitle: "Fresh workspace",
+                key: "⌘N",
+                dim_key: false,
+            },
+            c,
+        ) {
+            events.push(WelcomeEvent::NewWindow);
+        }
+        ui.add_space(ACTIONS_GAP);
+
+        if acard(
+            ui,
+            card_w,
+            &ActionCard {
+                glyph: ph::PUZZLE_PIECE,
+                tint: c.success,
+                title: "Browse plugins…",
+                subtitle: "Databases · URLs · themes",
+                key: "↵",
+                dim_key: true,
+            },
+            c,
+        ) {
+            events.push(WelcomeEvent::BrowsePlugins);
+        }
+    });
+}
+
+/// One `.acard`: a hairline-edged base panel that washes to `--surface0` on
+/// hover, holding a tinted tile, a two-line label block, and a trailing chip.
+///
+/// Allocated as a single click target with its contents painted in, so nothing
+/// can shadow the card's hover or swallow its click.
+fn acard(ui: &mut egui::Ui, w: f32, card: &ActionCard<'_>, c: &ThemeColors) -> bool {
+    let h = ACARD_PAD_Y * 2.0 + ACARD_TILE;
+    let (rect, resp) = ui.allocate_exact_size(vec2(w, h), Sense::click());
+    let hovered = resp.hovered();
+    if hovered && !ui.is_sizing_pass() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+
+    // `.acard{background:var(--base);box-shadow:var(--edge)}`
+    // `.acard:hover{background:var(--surface0)}`
+    let p = ui.painter();
+    p.rect_filled(rect, RADIUS_PANEL, if hovered { c.surface } else { c.bg });
+    p.rect_stroke(rect, RADIUS_PANEL, edge_stroke(c), StrokeKind::Inside);
+
+    // `.acard .tile` — 38px tinted square, `RADIUS_CONTROL` for the sheet's 11px.
+    let tile = Rect::from_min_size(
+        pos2(
+            rect.left() + ACARD_PAD_X,
+            rect.center().y - ACARD_TILE / 2.0,
+        ),
+        Vec2::splat(ACARD_TILE),
+    );
+    tint_tile(
+        ui,
+        tile,
+        RADIUS_CONTROL,
+        card.glyph,
+        ACARD_TILE_GLYPH,
+        card.tint,
+    );
+
+    // `.kbd{margin-left:auto…}` — measured and placed first, so the label block
+    // takes what is left, exactly as the flex row does.
+    let chip = kbd_size(ui, card.key);
+    let chip_pos = pos2(
+        rect.right() - ACARD_PAD_X - chip.x,
+        rect.center().y - chip.y / 2.0,
+    );
+    kbd_chip(ui, chip_pos, card.key, card.dim_key, c);
+
+    // `.acard .l{flex:1;min-width:0}` with `.s{text-overflow:ellipsis}`.
+    let lx = tile.right() + ACARD_GAP;
+    let lw = (chip_pos.x - ACARD_GAP - lx).max(0.0);
+    let title = line_clipped(
+        ui,
+        card.title,
+        semibold_font_id(ui.ctx(), ACARD_TITLE_FONT),
+        c.fg,
+        lw,
+    );
+    let sub = line_clipped(
+        ui,
+        card.subtitle,
+        FontId::proportional(ACARD_SUB_FONT),
+        c.fg_muted,
+        lw,
+    );
+    let block_h = title.size().y + ACARD_SUB_TOP + sub.size().y;
+    let ly = rect.center().y - block_h / 2.0;
+    let p = ui.painter();
+    p.galley(pos2(lx, ly), title.clone(), c.fg);
+    p.galley(
+        pos2(lx, ly + title.size().y + ACARD_SUB_TOP),
+        sub,
+        c.fg_muted,
+    );
+
+    resp.clicked()
+}
+
+/// `.drop`: a 52px dashed-feeling well — `surface0@30%` behind a 1.5px inset
+/// `surface1@55%` ring — whose text, ring and fill all go mauve on hover.
+/// Returns whether it was clicked.
+fn drop_zone(ui: &mut egui::Ui, w: f32, c: &ThemeColors) -> bool {
+    let (rect, resp) = ui.allocate_exact_size(vec2(w, DROP_H), Sense::click());
+    let hovered = resp.hovered();
+    if hovered && !ui.is_sizing_pass() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+
+    let (fill, ring, fg) = if hovered {
+        (
+            with_alpha(c.accent, A_08),
+            with_alpha(c.accent, A_55),
+            c.accent,
+        )
+    } else {
+        (
+            with_alpha(c.surface, A_30),
+            with_alpha(c.surface_raised, A_55),
+            c.fg_muted,
+        )
+    };
+
+    // `.drop b{color:var(--subtext0)}` loses to `.drop:hover{color:var(--mauve)}`
+    // on specificity, so the bold run follows the hover; `.drop .fmt` ties and
+    // comes later, so the format hint keeps `--overlay0` throughout.
+    let icon = line(ui, ph::DOWNLOAD_SIMPLE, phosphor_font_id(DROP_ICON), fg);
+    let label = line(
+        ui,
+        DROP_LABEL,
+        semibold_font_id(ui.ctx(), DROP_FONT),
+        if hovered { c.accent } else { c.fg_subtle() },
+    );
+    let fmt = line(
+        ui,
+        DROP_FORMATS,
+        FontId::monospace(DROP_FMT_FONT),
+        c.fg_faint(),
+    );
+
+    let p = ui.painter();
+    p.rect_filled(rect, RADIUS_PANEL, fill);
+    p.rect_stroke(
+        rect,
+        RADIUS_PANEL,
+        Stroke::new(DROP_BORDER, ring),
+        StrokeKind::Inside,
+    );
+
+    // `justify-content:center` with a 10px gap between the three runs.
+    let total = icon.size().x + DROP_GAP + label.size().x + DROP_GAP + fmt.size().x;
+    let mut x = rect.center().x - total / 2.0;
+    for (galley, color) in [
+        (icon, fg),
+        (label, if hovered { c.accent } else { c.fg_subtle() }),
+        (fmt, c.fg_faint()),
+    ] {
+        let size = galley.size();
+        p.galley(pos2(x, rect.center().y - size.y / 2.0), galley, color);
+        x += size.x + DROP_GAP;
+    }
+
+    resp.clicked()
+}
+
+/// `.cols{grid-template-columns:1.1fr 1fr;gap:34px}` — Recent beside Tips, both
+/// starting at the same y.
+fn lower_columns(
+    ui: &mut egui::Ui,
+    w: f32,
+    recent: &[RecentEntry],
+    c: &ThemeColors,
+    events: &mut Vec<WelcomeEvent>,
+) {
+    let inner = (w - COLS_GAP).max(0.0);
+    let left_w = inner * COLS_LEFT_FR / (COLS_LEFT_FR + 1.0);
+    let right_w = inner - left_w;
+
+    ui.horizontal_top(|ui| {
+        ui.spacing_mut().item_spacing = Vec2::ZERO;
+
+        ui.vertical(|ui| {
+            ui.set_width(left_w);
+            recent_column(ui, left_w, recent, c, events);
+        });
+        ui.add_space(COLS_GAP);
+        ui.vertical(|ui| {
+            ui.set_width(right_w);
+            tips_column(ui, right_w, c);
+        });
+    });
+}
+
+/// The Recent column — `.slabel` with its `Clear` action over the `.recent` list.
+fn recent_column(
+    ui: &mut egui::Ui,
+    w: f32,
+    recent: &[RecentEntry],
+    c: &ThemeColors,
+    events: &mut Vec<WelcomeEvent>,
+) {
+    let clear = (!recent.is_empty()).then_some("Clear");
+    if slabel(ui, w, "Recent", clear, c) {
+        events.push(WelcomeEvent::ClearRecentFiles);
+    }
+
+    if recent.is_empty() {
         ui.add(
             Typography::builder()
-                .text(body)
+                .text("No recent files")
                 .variant(TypographyVariant::BodyMuted)
-                .color(thoth_plugin_sdk::theme::color_to_hex(c.fg_muted))
-                .size(13.0)
                 .build(),
         );
-    });
-    ui.add_space(4.0);
+        return;
+    }
+
+    for (i, entry) in recent.iter().enumerate() {
+        if i > 0 {
+            ui.add_space(RECENT_GAP);
+        }
+        if rrow(ui, w, entry, c) {
+            events.push(WelcomeEvent::OpenRecentFile(entry.path.clone()));
+        }
+    }
+}
+
+/// One `.rrow`: a tinted 30px type tile, the file name in mono, a metadata line,
+/// and the `.ext` chip — one click target with its contents painted in.
+fn rrow(ui: &mut egui::Ui, w: f32, entry: &RecentEntry, c: &ThemeColors) -> bool {
+    let h = RROW_PAD_Y * 2.0 + RROW_TILE;
+    let (rect, resp) = ui.allocate_exact_size(vec2(w, h), Sense::click());
+    let hovered = resp.hovered();
+    if hovered && !ui.is_sizing_pass() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+    if hovered {
+        // `.rrow:hover{background:color-mix(in oklab,var(--text) 5%,transparent)}`
+        ui.painter()
+            .rect_filled(rect, RADIUS_CONTROL, with_alpha(c.fg, A_05));
+    }
+
+    // `.rrow .ic` — the sheet's 9px corner sits on the control rung.
+    let tile = Rect::from_min_size(
+        pos2(rect.left() + RROW_PAD_X, rect.center().y - RROW_TILE / 2.0),
+        Vec2::splat(RROW_TILE),
+    );
+    tint_tile(
+        ui,
+        tile,
+        RADIUS_CONTROL,
+        entry.glyph,
+        RROW_TILE_GLYPH,
+        entry.tint_role.color(c),
+    );
+
+    // `.rrow .ext{flex:0 0 auto}` — placed from the right edge first.
+    let mut text_right = rect.right() - RROW_PAD_X;
+    if let Some(ext) = &entry.ext {
+        let ext_galley = line(ui, ext, FontId::monospace(EXT_FONT), c.fg_muted);
+        let size = ext_galley.size() + vec2(EXT_PAD_X * 2.0, EXT_PAD_Y * 2.0);
+        let ext_rect = Rect::from_min_size(
+            pos2(text_right - size.x, rect.center().y - size.y / 2.0),
+            size,
+        );
+        let p = ui.painter();
+        p.rect_filled(ext_rect, RADIUS_CHECK, c.surface);
+        p.galley(
+            ext_rect.min + vec2(EXT_PAD_X, EXT_PAD_Y),
+            ext_galley,
+            c.fg_muted,
+        );
+        text_right = ext_rect.left() - RROW_GAP;
+    }
+
+    // `.rrow .m{flex:1;min-width:0}`: the mono name ellipsises, the meta line
+    // below it does not (the sheet only clips `.fn`).
+    let tx = tile.right() + RROW_GAP;
+    let tw = (text_right - tx).max(0.0);
+    let name = line_clipped(ui, &entry.name, FontId::monospace(RROW_NAME_FONT), c.fg, tw);
+    let meta = line_clipped(
+        ui,
+        &entry.meta,
+        FontId::proportional(RROW_META_FONT),
+        c.fg_muted,
+        tw,
+    );
+    let block_h = name.size().y + RROW_META_TOP + meta.size().y;
+    let ty = rect.center().y - block_h / 2.0;
+    let p = ui.painter();
+    p.galley(pos2(tx, ty), name.clone(), c.fg);
+    p.galley(
+        pos2(tx, ty + name.size().y + RROW_META_TOP),
+        meta,
+        c.fg_muted,
+    );
+
+    resp.clicked()
+}
+
+/// The Tips column — `.slabel` over five `.tip` rows.
+fn tips_column(ui: &mut egui::Ui, w: f32, c: &ThemeColors) {
+    slabel(ui, w, "Tips · keyboard", None, c);
+    for (i, (keys, body)) in TIPS.iter().enumerate() {
+        if i > 0 {
+            ui.add_space(TIPS_GAP);
+        }
+        tip(ui, w, keys, body, c);
+    }
+}
+
+/// One `.tip`: a `.kbd` chip and a wrapped body, both aligned to the row's top
+/// (`align-items:flex-start`).
+fn tip(ui: &mut egui::Ui, w: f32, keys: &str, body: &str, c: &ThemeColors) {
+    let chip = kbd_size(ui, keys);
+    let body_w = (w - chip.x - TIP_GAP).max(0.0);
+    // `line-height:1.45` — `Typography` has no line-height control, so the body
+    // is laid out here with the design's leading.
+    let mut job = LayoutJob {
+        wrap: TextWrapping::wrap_at_width(body_w),
+        ..Default::default()
+    };
+    job.append(
+        body,
+        0.0,
+        TextFormat {
+            font_id: FontId::proportional(TIP_FONT),
+            color: c.fg_subtle(),
+            line_height: Some(TIP_FONT * TIP_LINE),
+            ..Default::default()
+        },
+    );
+    let text = ui.painter().layout_job(job);
+
+    let (rect, _) = ui.allocate_exact_size(vec2(w, chip.y.max(text.size().y)), Sense::hover());
+    kbd_chip(ui, rect.min, keys, false, c);
+    ui.painter().galley(
+        pos2(rect.left() + chip.x + TIP_GAP, rect.top()),
+        text,
+        c.fg_subtle(),
+    );
+}
+
+// ── Painted primitives ────────────────────────────────────────────────────────
+
+/// A tinted glyph tile — design `.acard .tile` / `.rrow .ic`, whose `t-*` classes
+/// are the same colour at 16% behind the glyph at full strength.
+fn tint_tile(ui: &egui::Ui, rect: Rect, radius: f32, glyph: &str, glyph_size: f32, tint: Color32) {
+    let p = ui.painter();
+    p.rect_filled(rect, radius, with_alpha(tint, A_16));
+    p.text(
+        rect.center(),
+        Align2::CENTER_CENTER,
+        glyph,
+        phosphor_font_id(glyph_size),
+        tint,
+    );
+}
+
+/// The size a [`kbd_chip`] will occupy — design `.kbd{padding:3px 7px}`.
+fn kbd_size(ui: &egui::Ui, text: &str) -> Vec2 {
+    let galley = line(ui, text, FontId::monospace(KBD_FONT), Color32::PLACEHOLDER);
+    galley.size() + vec2(KBD_PAD_X * 2.0, KBD_PAD_Y * 2.0)
+}
+
+/// A key chip — design `.kbd`: mono 11px `--subtext0` on `--surface0` with the
+/// shared hairline edge, at the chip rung (the sheet's 6px). `dim` reproduces the
+/// plugins card's `opacity:.35`.
+fn kbd_chip(ui: &egui::Ui, top_left: Pos2, text: &str, dim: bool, c: &ThemeColors) {
+    let fade = |color: Color32| {
+        if dim {
+            with_alpha(color, A_35_OPACITY)
+        } else {
+            color
+        }
+    };
+    let galley = line(ui, text, FontId::monospace(KBD_FONT), fade(c.fg_subtle()));
+    let rect = Rect::from_min_size(
+        top_left,
+        galley.size() + vec2(KBD_PAD_X * 2.0, KBD_PAD_Y * 2.0),
+    );
+    let p = ui.painter();
+    p.rect_filled(rect, RADIUS_CHIP, fade(c.surface));
+    let edge = edge_stroke(c);
+    p.rect_stroke(
+        rect,
+        RADIUS_CHIP,
+        Stroke::new(edge.width, fade(edge.color)),
+        StrokeKind::Inside,
+    );
+    p.galley(
+        rect.min + vec2(KBD_PAD_X, KBD_PAD_Y),
+        galley,
+        fade(c.fg_subtle()),
+    );
+}
+
+/// The `.mark` tile's `linear-gradient(150deg,var(--mauve),var(--lavender))`.
+///
+/// egui has no gradient shape, so the rounded rect's outline is tessellated and
+/// fanned into a mesh whose vertex colours are interpolated along the gradient
+/// axis (CSS `150deg` points 150° clockwise from “up”: mostly down, a little
+/// right). Mesh edges carry no feathering, so a hairline in the gradient's
+/// midpoint colour is stroked over the outline to keep the corners smooth.
+fn gradient_tile(p: &egui::Painter, rect: Rect, radius: f32, from: Color32, to: Color32) {
+    const ANGLE_DEG: f32 = 150.0;
+    let (sin, cos) = ANGLE_DEG.to_radians().sin_cos();
+    let dir = vec2(sin, -cos);
+    // How far the box extends along that axis, so `t` spans exactly 0…1 over it.
+    let span = ((rect.width() * dir.x).abs() + (rect.height() * dir.y).abs()).max(1.0);
+
+    let mut outline = Vec::new();
+    egui::epaint::tessellator::path::rounded_rectangle(
+        &mut outline,
+        rect,
+        egui::epaint::CornerRadiusF32::same(radius),
+    );
+
+    let center = rect.center();
+    let color_at = |pos: Pos2| lerp_color(from, to, 0.5 + (pos - center).dot(dir) / span);
+    let mut mesh = egui::Mesh::default();
+    mesh.colored_vertex(center, color_at(center));
+    for pos in &outline {
+        mesh.colored_vertex(*pos, color_at(*pos));
+    }
+    let n = outline.len() as u32;
+    for i in 0..n {
+        mesh.add_triangle(0, 1 + i, 1 + (i + 1) % n);
+    }
+    p.add(egui::Shape::mesh(mesh));
+    p.rect_stroke(
+        rect,
+        radius,
+        Stroke::new(1.0, lerp_color(from, to, 0.5)),
+        StrokeKind::Inside,
+    );
+}
+
+/// Channel-wise mix of two palette colours. The `.mark` gradient is the one place
+/// the design needs a colour that is not itself a token, and this keeps it a mix
+/// of `accent` and `accent_secondary` rather than a literal.
+fn lerp_color(a: Color32, b: Color32, t: f32) -> Color32 {
+    let t = t.clamp(0.0, 1.0);
+    let ch = |x: u8, y: u8| (f32::from(x) + (f32::from(y) - f32::from(x)) * t).round() as u8;
+    Color32::from_rgb(ch(a.r(), b.r()), ch(a.g(), b.g()), ch(a.b(), b.b()))
+}
+
+// ── Text helpers ──────────────────────────────────────────────────────────────
+
+/// One unwrapped line.
+fn line(ui: &egui::Ui, text: &str, font: FontId, color: Color32) -> Arc<Galley> {
+    ui.painter().layout_no_wrap(text.to_owned(), font, color)
+}
+
+/// One unwrapped line at an explicit `line-height`.
+fn line_h(ui: &egui::Ui, text: &str, font: FontId, color: Color32, height: f32) -> Arc<Galley> {
+    let mut job = LayoutJob::default();
+    job.append(
+        text,
+        0.0,
+        TextFormat {
+            font_id: font,
+            color,
+            line_height: Some(height),
+            ..Default::default()
+        },
+    );
+    ui.painter().layout_job(job)
+}
+
+/// One line, ellipsised at `max_w` — the design's
+/// `white-space:nowrap;overflow:hidden;text-overflow:ellipsis`. `Typography` has
+/// no truncating mode, so this is the same primitive the SDK's `List` rows use.
+fn line_clipped(
+    ui: &egui::Ui,
+    text: &str,
+    font: FontId,
+    color: Color32,
+    max_w: f32,
+) -> Arc<Galley> {
+    let mut job = LayoutJob::single_section(
+        text.to_owned(),
+        TextFormat {
+            font_id: font,
+            color,
+            ..Default::default()
+        },
+    );
+    job.wrap = TextWrapping::truncate_at_width(max_w);
+    ui.painter().layout_job(job)
+}
+
+// ── Recent-file resolution ────────────────────────────────────────────────────
+
+/// Resolve the recent list into `.rrow` content, statting each file at most once
+/// per [`META_TTL`] (see [`MetaEntry`]). The whole cache is read and written once
+/// per frame rather than per row, so a full pass costs one memory clone.
+fn recent_entries(ctx: &egui::Context, paths: &[String]) -> Vec<RecentEntry> {
+    let now = ctx.input(|i| i.time);
+    let id = egui::Id::new(META_CACHE_ID);
+    let mut cache: MetaCache = ctx.memory(|m| m.data.get_temp(id)).unwrap_or_default();
+    let mut dirty = false;
+
+    let entries = paths
+        .iter()
+        .take(RECENT_MAX)
+        .map(|raw| {
+            let path = PathBuf::from(raw);
+
+            let meta = match cache.get(&path) {
+                Some(hit) if now - hit.stat_at < META_TTL => hit.meta,
+                _ => {
+                    let meta = std::fs::metadata(&path).ok().map(|m| FileMeta {
+                        size: m.len(),
+                        modified: m.modified().ok(),
+                    });
+                    cache.insert(path.clone(), MetaEntry { stat_at: now, meta });
+                    dirty = true;
+                    meta
+                }
+            };
+
+            // `~/work/thoth · 4.2 KB · 2m ago` — the directory is free, the other
+            // two runs come from the stat and are simply absent without it.
+            let mut runs = Vec::new();
+            if let Some(dir) = path.parent().map(home_relative).filter(|d| !d.is_empty()) {
+                runs.push(dir);
+            }
+            if let Some(m) = meta {
+                runs.push(human_size(m.size));
+                if let Some(t) = m.modified {
+                    runs.push(relative_time(t));
+                }
+            }
+
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(str::to_uppercase);
+            let (glyph, tint_role) = file_type_icon(ext.as_deref());
+
+            RecentEntry {
+                name: path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(raw.as_str())
+                    .to_owned(),
+                meta: runs.join(META_SEP),
+                ext,
+                glyph,
+                tint_role,
+                path,
+            }
+        })
+        .collect();
+
+    if dirty {
+        // Drop cache slots for files no longer on the list, so the map cannot grow
+        // without bound over a long session.
+        cache.retain(|k, _| paths.iter().take(RECENT_MAX).any(|p| Path::new(p) == k));
+        ctx.memory_mut(|m| m.data.insert_temp(id, cache));
+    }
+
+    entries
+}
+
+/// `.rrow .ic`'s glyph and tint by file type — design's braces/mauve for JSON,
+/// dashed list/blue for NDJSON, and the CSV sheet in peach.
+fn file_type_icon(ext: Option<&str>) -> (&'static str, TintRole) {
+    match ext.unwrap_or_default() {
+        "JSON" | "JSON5" | "JSONC" => (ph::BRACKETS_CURLY, TintRole::Accent),
+        "NDJSON" | "JSONL" => (ph::LIST_DASHES, TintRole::Info),
+        "CSV" | "TSV" => (ph::FILE_CSV, TintRole::Peach),
+        _ => (ph::FILE_TEXT, TintRole::Muted),
+    }
+}
+
+/// `~/work/thoth` — a path under the user's home rendered home-relative, as the
+/// design's `.meta` does. Anything outside home is left as-is.
+fn home_relative(dir: &Path) -> String {
+    if let Some(home) = dirs::home_dir()
+        && let Ok(rest) = dir.strip_prefix(&home)
+    {
+        if rest.as_os_str().is_empty() {
+            return "~".to_owned();
+        }
+        return format!("~/{}", rest.display());
+    }
+    dir.display().to_string()
+}
+
+/// `4.2 KB` / `18 MB` — the design's `.meta` size run: decimal units, one
+/// decimal below ten of the unit and none above.
+fn human_size(bytes: u64) -> String {
+    const UNITS: [&str; 4] = ["KB", "MB", "GB", "TB"];
+    const STEP: f64 = 1000.0;
+
+    if bytes < STEP as u64 {
+        return format!("{bytes} B");
+    }
+    let mut value = bytes as f64 / STEP;
+    let mut unit = 0;
+    while value >= STEP && unit + 1 < UNITS.len() {
+        value /= STEP;
+        unit += 1;
+    }
+    if value < 10.0 {
+        format!("{value:.1} {}", UNITS[unit])
+    } else {
+        format!("{value:.0} {}", UNITS[unit])
+    }
+}
+
+/// `2m ago` / `yesterday` / `Mon` / `Aug 1` — the design's `.meta` time run,
+/// derived fresh from the cached mtime on every frame.
+fn relative_time(modified: SystemTime) -> String {
+    let when: chrono::DateTime<chrono::Local> = modified.into();
+    let now = chrono::Local::now();
+    let elapsed = now.signed_duration_since(when);
+
+    if elapsed.num_minutes() < 1 {
+        // Also covers a clock-skewed future mtime, which must never read as a
+        // negative age.
+        "just now".to_owned()
+    } else if elapsed.num_minutes() < 60 {
+        format!("{}m ago", elapsed.num_minutes())
+    } else if when.date_naive() == now.date_naive() {
+        format!("{}h ago", elapsed.num_hours().max(1))
+    } else if now.date_naive().pred_opt() == Some(when.date_naive()) {
+        "yesterday".to_owned()
+    } else if elapsed.num_days() < 7 {
+        when.format("%a").to_string()
+    } else {
+        when.format("%b %-d").to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{human_size, relative_time};
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn size_matches_the_design_samples() {
+        assert_eq!(human_size(4_200), "4.2 KB");
+        assert_eq!(human_size(18_000_000), "18 MB");
+        assert_eq!(human_size(512_000), "512 KB");
+        assert_eq!(human_size(2_100), "2.1 KB");
+        assert_eq!(human_size(812), "812 B");
+    }
+
+    #[test]
+    fn relative_time_ladder() {
+        let now = SystemTime::now();
+        assert_eq!(relative_time(now), "just now");
+        assert_eq!(
+            relative_time(now - Duration::from_secs(2 * 60)),
+            "2m ago",
+            "minutes are the design's `2m ago`"
+        );
+        // A week back is never a relative phrase — it is a calendar date.
+        let old = relative_time(now - Duration::from_secs(30 * 24 * 3600));
+        assert!(
+            !old.ends_with("ago") && old != "yesterday",
+            "old files show a date, got {old}"
+        );
+    }
 }

--- a/src/components/welcome.rs
+++ b/src/components/welcome.rs
@@ -58,9 +58,13 @@ const A_35_OPACITY: u8 = 89;
 
 /// `.wrap{max-width:980px}`. `box-sizing:border-box`, so the side padding below
 /// is *inside* this width.
-const WRAP_MAX_W: f32 = 980.0;
+///
+/// Public so the layout tests assert against the token rather than a copy of it.
+pub const WRAP_MAX_W: f32 = 980.0;
 /// `.wrap{padding:40px 44px}`.
-const WRAP_PAD_X: f32 = 44.0;
+///
+/// Public so the layout tests assert against the token rather than a copy of it.
+pub const WRAP_PAD_X: f32 = 44.0;
 const WRAP_PAD_Y: f32 = 40.0;
 
 // ── Hero — design `.hero` ────────────────────────────────────────────────────
@@ -77,7 +81,8 @@ const MARK_GLYPH: f32 = 28.0;
 /// — hand-rolled rather than [`crate::theme::glow_shadow`], which is the
 /// primary button's tighter `0 3px 10px @38%`.
 const MARK_GLOW_OFFSET: i8 = 6;
-const MARK_GLOW_BLUR: u8 = 18;
+/// Public so the layout tests can budget for the glow's bleed past the wrap edge.
+pub const MARK_GLOW_BLUR: u8 = 18;
 /// `.htext h1{font-size:26px;font-weight:700;line-height:1.1}`.
 const TITLE_FONT: f32 = 26.0;
 const TITLE_LINE: f32 = 1.1;

--- a/src/consent/modal.rs
+++ b/src/consent/modal.rs
@@ -1,14 +1,27 @@
-use eframe::egui::{self, Align2, Color32, CornerRadius, Frame, Layout, Margin, Stroke};
+use std::cell::Cell;
+
+use eframe::egui::{self, Align2, CornerRadius, Frame, Layout, Margin, Stroke, StrokeKind};
 
 use crate::{
     components::traits::ContextComponent,
-    theme::{ThemeColors, phosphor_font_id},
+    theme::{
+        RADIUS_CONTROL, RADIUS_PANEL, ThemeColors, edge_stroke, get_contrast_text_color,
+        phosphor_font_id,
+    },
 };
-use thoth_plugin_sdk::components::{
-    Button, ButtonColor, ButtonSize, ButtonType, Typography, TypographyVariant,
+use thoth_plugin_sdk::{
+    components::{
+        Badge, Button, ButtonColor, Checkbox, Icon, Modal, Separator, Size, Typography,
+        TypographyVariant,
+    },
+    theme::{FONT_CAPTION, FONT_CONTROL, RADIUS_PILL, color_to_hex, with_alpha},
 };
 
 use super::manager::{ConsentRequest, PermissionEntry};
+
+/// `.pill{font-size:9.5px}` — a rung below the caption scale, so it is pinned
+/// here rather than reached through a size preset.
+const PILL_FONT: f32 = 9.5;
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -45,45 +58,46 @@ impl ContextComponent for ConsentModal {
                 .unwrap_or_else(|| crate::theme::Theme::default().colors())
         });
 
-        let mut accepted = false;
-        let mut cancelled = false;
+        // The footer closure borrows these, so they must be passed by reference —
+        // `Cell::clone` would hand the footer detached copies and silently drop
+        // every click.
+        let remember = Cell::new(self.remember);
+        let accepted = Cell::new(false);
+        let cancelled = Cell::new(false);
 
-        let modal = egui::Modal::new(egui::Id::new("consent_modal"))
-            .backdrop_color(Color32::from_black_alpha(153));
+        // "Remember" only persists for domain-scoped (network) consents; hide it
+        // for one-off consents like dataset export, where it would be a no-op.
+        let show_remember = request.domain.is_some();
 
-        modal.show(ui.ctx(), |ui| {
-            ui.set_width(480.0);
+        // Design `.card.w480` — the base modal supplies the head, body and footer
+        // chrome, including the `.avatar` tile (the header's glyph-tile slot).
+        // Not dismissible: this dialog absorbs Escape and backdrop clicks and
+        // shows no ✕, so the user must make an explicit Allow/Cancel choice.
+        let modal = Modal::builder()
+            .id("consent_modal")
+            .title(request.title.as_str())
+            // `.grouplabel.warn` — the header's eyebrow, above the title.
+            .eyebrow("PERMISSION REQUESTED")
+            .eyebrow_color("warning")
+            .glyph(egui_phosphor::regular::PUZZLE_PIECE)
+            .glyph_color("accent")
+            .glyph_tile(true)
+            .dismissible(false)
+            .open(true)
+            .width(480.0)
+            .build();
 
-            Frame::new()
-                .fill(colors.bg)
-                .stroke(Stroke::new(1.0, colors.surface))
-                .corner_radius(CornerRadius::same(8))
-                .inner_margin(Margin::ZERO)
-                .show(ui, |ui| {
-                    render_header(ui, &request, &colors);
-                    ui.add(egui::Separator::default().spacing(0.0));
-                    render_body(ui, &request, &colors);
-                    ui.add(egui::Separator::default().spacing(0.0));
-                    render_footer(
-                        ui,
-                        &mut self.remember,
-                        // "Remember" only persists for domain-scoped (network)
-                        // consents; hide it for one-off consents like dataset
-                        // export, where it would be a no-op.
-                        request.domain.is_some(),
-                        &mut accepted,
-                        &mut cancelled,
-                        &colors,
-                    );
-                });
-        });
+        let _never_closes = modal.show_with_footer(
+            ui,
+            |ui| render_body(ui, &request, &colors),
+            |ui| render_footer(ui, show_remember, &remember, &accepted, &cancelled),
+        );
 
-        // Backdrop clicks are intentionally absorbed — the user must make an explicit choice.
-
-        if accepted {
+        self.remember = remember.get();
+        if accepted.get() {
             (props.on_accept)(self.remember);
             self.remember = false;
-        } else if cancelled {
+        } else if cancelled.get() {
             (props.on_cancel)();
             self.remember = false;
         }
@@ -92,244 +106,241 @@ impl ContextComponent for ConsentModal {
 
 // ── Section renderers ─────────────────────────────────────────────────────────
 
-fn render_header(ui: &mut egui::Ui, request: &ConsentRequest, colors: &ThemeColors) {
-    Frame::new()
-        .inner_margin(Margin {
-            left: 24,
-            right: 24,
-            top: 20,
-            bottom: 16,
-        })
-        .show(ui, |ui| {
-            ui.horizontal(|ui| {
-                // Plugin avatar with shield-warning badge
-                let avatar_size = egui::vec2(44.0, 44.0);
-                let (avatar_rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
-                ui.painter()
-                    .rect_filled(avatar_rect, CornerRadius::same(8), colors.surface);
-                ui.painter().text(
-                    avatar_rect.center(),
-                    Align2::CENTER_CENTER,
-                    egui_phosphor::regular::PUZZLE_PIECE,
-                    phosphor_font_id(22.0),
-                    colors.accent,
-                );
-
-                let badge_rect = egui::Rect::from_min_size(
-                    avatar_rect.max - egui::vec2(14.0, 14.0),
-                    egui::vec2(18.0, 18.0),
-                );
-                ui.painter()
-                    .rect_filled(badge_rect, CornerRadius::same(9), colors.warning);
-                ui.painter().rect_stroke(
-                    badge_rect,
-                    CornerRadius::same(9),
-                    Stroke::new(2.0, colors.bg),
-                    egui::StrokeKind::Outside,
-                );
-                ui.painter().text(
-                    badge_rect.center(),
-                    Align2::CENTER_CENTER,
-                    egui_phosphor::regular::SHIELD_WARNING,
-                    phosphor_font_id(10.0),
-                    colors.bg,
-                );
-
-                ui.add_space(12.0);
-                ui.vertical(|ui| {
-                    ui.add(
-                        Typography::builder()
-                            .text("PERMISSION REQUESTED")
-                            .variant(TypographyVariant::GroupLabel)
-                            .color(thoth_plugin_sdk::theme::color_to_hex(colors.warning))
-                            .build(),
-                    );
-                    ui.add_space(2.0);
-                    Typography::heading(ui, &request.title);
-                });
-            });
-        });
-}
-
 fn render_body(ui: &mut egui::Ui, request: &ConsentRequest, colors: &ThemeColors) {
+    // Every gap in this body is a design margin, so drive them all explicitly.
+    ui.spacing_mut().item_spacing = egui::Vec2::ZERO;
+
+    render_status_badge(ui, colors);
+
+    // Design `.sep` between head and body. The body inset already matches the
+    // rule's own `margin:0 20px`, so a full-width hairline lands exactly right.
+    ui.add(Separator::rule(color_to_hex(with_alpha(
+        colors.surface_raised,
+        77, // surface1@30%
+    ))));
+
+    // This dialog overrides the shared body padding with `padding-top:14px`.
+    ui.add_space(14.0);
+
+    if !request.message.is_empty() {
+        // `.m-body{font-size:13px;color:var(--subtext0)}`
+        ui.add(
+            Typography::builder()
+                .text(&request.message)
+                .variant(TypographyVariant::BodyLarge)
+                .color(color_to_hex(colors.fg_subtle()))
+                .build(),
+        );
+    }
+
+    // `.grouplabel{margin:14px 0 7px}`
+    ui.add_space(14.0);
+    ui.add(
+        Typography::builder()
+            .text("THIS WILL ALLOW THE PLUGIN TO")
+            .variant(TypographyVariant::GroupLabel)
+            .size(10.0)
+            .build(),
+    );
+    ui.add_space(7.0);
+
+    // `.permbox` — the crust-filled list container.
     Frame::new()
-        .inner_margin(Margin {
-            left: 24,
-            right: 24,
-            top: 16,
-            bottom: 12,
-        })
+        .fill(colors.bg_sunken)
+        .stroke(edge_stroke(colors))
+        .corner_radius(RADIUS_PANEL)
+        .inner_margin(Margin::same(5))
         .show(ui, |ui| {
-            if !request.message.is_empty() {
-                Typography::body_large(ui, &request.message);
-                ui.add_space(12.0);
+            // `.permbox` is a block element: it spans the body's full width rather
+            // than shrinking to the longest permission label.
+            ui.set_min_width(ui.available_width());
+            for (i, entry) in request.permissions.iter().enumerate() {
+                // `.perm+.perm` carries an inset top hairline.
+                render_permission_row(ui, entry, colors, i > 0);
             }
-
-            Typography::group_label(ui, "THIS WILL ALLOW THE PLUGIN TO");
-            ui.add_space(6.0);
-
-            Frame::new()
-                .fill(colors.bg_sunken)
-                .stroke(Stroke::new(1.0, colors.surface))
-                .corner_radius(CornerRadius::same(4))
-                .inner_margin(Margin::same(12))
-                .show(ui, |ui| {
-                    for (i, entry) in request.permissions.iter().enumerate() {
-                        if i > 0 {
-                            ui.add_space(8.0);
-                        }
-                        render_permission_row(ui, entry, colors);
-                    }
-                });
         });
 }
 
 fn render_footer(
     ui: &mut egui::Ui,
-    remember: &mut bool,
     show_remember: bool,
-    accepted: &mut bool,
-    cancelled: &mut bool,
-    colors: &ThemeColors,
+    remember: &Cell<bool>,
+    accepted: &Cell<bool>,
+    cancelled: &Cell<bool>,
 ) {
-    Frame::new()
-        .inner_margin(Margin {
-            left: 24,
-            right: 24,
-            top: 12,
-            bottom: 16,
-        })
-        .fill(colors.bg_panel)
-        .show(ui, |ui| {
-            ui.horizontal(|ui| {
-                if show_remember {
-                    // Custom checkbox — distinct from ToggleSwitch shape
-                    let cb_size = egui::vec2(14.0, 14.0);
-                    let (cb_rect, cb_resp) = ui.allocate_exact_size(cb_size, egui::Sense::click());
-                    if cb_resp.clicked() {
-                        *remember = !*remember;
-                    }
-                    cb_resp.on_hover_cursor(egui::CursorIcon::PointingHand);
-                    ui.painter().rect(
-                        cb_rect,
-                        CornerRadius::same(3),
-                        if *remember {
-                            colors.accent
-                        } else {
-                            Color32::TRANSPARENT
-                        },
-                        Stroke::new(
-                            1.0,
-                            if *remember {
-                                colors.accent
-                            } else {
-                                colors.surface_active
-                            },
-                        ),
-                        egui::StrokeKind::Outside,
-                    );
-                    if *remember {
-                        ui.painter().text(
-                            cb_rect.center(),
-                            Align2::CENTER_CENTER,
-                            egui_phosphor::regular::CHECK,
-                            phosphor_font_id(10.0),
-                            colors.bg,
-                        );
-                    }
-                    ui.add_space(6.0);
-                    ui.add(
-                        Typography::builder()
-                            .text("Remember this choice")
-                            .variant(TypographyVariant::Subtitle)
-                            .build(),
-                    );
-                }
+    // The footer lays out right-to-left, so the primary action goes first.
+    if ui
+        .add(
+            Button::builder()
+                .label("Allow")
+                .color(ButtonColor::Primary)
+                .build(),
+        )
+        .clicked()
+    {
+        accepted.set(true);
+    }
 
-                ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
-                    ui.spacing_mut().item_spacing.x = 8.0;
+    if ui
+        .add(
+            Button::builder()
+                .label("Cancel")
+                .color(ButtonColor::Default)
+                .build(),
+        )
+        .clicked()
+    {
+        cancelled.set(true);
+    }
 
-                    if ui
-                        .add(
-                            Button::builder()
-                                .label("Allow")
-                                .button_type(ButtonType::Elevated)
-                                .color(ButtonColor::Primary)
-                                .button_size(ButtonSize::Medium)
-                                .height(32.0)
-                                .width(100.0)
-                                .build(),
-                        )
-                        .clicked()
-                    {
-                        *accepted = true;
-                    }
-
-                    if ui
-                        .add(
-                            Button::builder()
-                                .label("Cancel")
-                                .button_type(ButtonType::Elevated)
-                                .color(ButtonColor::Default)
-                                .button_size(ButtonSize::Medium)
-                                .height(32.0)
-                                .width(100.0)
-                                .build(),
-                        )
-                        .clicked()
-                    {
-                        *cancelled = true;
-                    }
-                });
-            });
+    if show_remember {
+        // `.m-foot.split` — the remember toggle takes the remaining width and sits
+        // against the left edge, opposite the actions.
+        ui.with_layout(Layout::left_to_right(egui::Align::Center), |ui| {
+            let mut checkbox = Checkbox::builder()
+                .label("Remember this choice")
+                .checked(remember.get())
+                .build();
+            if checkbox.show(ui).changed() {
+                remember.set(checkbox.checked);
+            }
         });
+    }
 }
 
-fn render_permission_row(ui: &mut egui::Ui, entry: &PermissionEntry, colors: &ThemeColors) {
-    ui.horizontal(|ui| {
-        let icon_color = if entry.sensitive {
-            colors.warning
-        } else {
-            colors.accent
-        };
-        ui.label(
-            egui::RichText::new(entry.icon)
-                .font(phosphor_font_id(16.0))
-                .color(icon_color),
-        );
-        ui.add_space(8.0);
-        Typography::body_large(ui, &entry.label);
-        ui.add_space(6.0);
-        ui.add(
-            Typography::builder()
-                .text(&entry.scope)
-                .variant(TypographyVariant::Mono)
-                .size(11.0)
-                .color(thoth_plugin_sdk::theme::color_to_hex(colors.fg_muted))
-                .build(),
-        );
-        if entry.sensitive {
-            ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
-                Frame::new()
-                    .fill(Color32::from_rgba_premultiplied(249, 226, 175, 26))
-                    .corner_radius(CornerRadius::same(3))
-                    .inner_margin(Margin {
-                        left: 5,
-                        right: 5,
-                        top: 2,
-                        bottom: 2,
-                    })
-                    .show(ui, |ui| {
-                        ui.add(
-                            Typography::builder()
-                                .text("SENSITIVE")
-                                .variant(TypographyVariant::Label)
-                                .bold(true)
-                                .color(thoth_plugin_sdk::theme::color_to_hex(colors.warning))
-                                .build(),
-                        );
+/// The `.avatar .badge` status dot, painted over the bottom-right corner of the
+/// header's avatar tile.
+///
+/// The shared header owns the tile itself and hands back no geometry, so the
+/// corner is derived from the body: the body starts flush under the head, whose
+/// `padding-bottom` and matching 20px left inset fix where the 44px tile sits.
+fn render_status_badge(ui: &mut egui::Ui, colors: &ThemeColors) {
+    /// `.avatar{width:44px;height:44px}`
+    const TILE: f32 = 44.0;
+    /// `.m-head{padding:18px 20px 14px}` — the gap under the tile.
+    const HEAD_BOTTOM: f32 = 14.0;
+
+    let tile_corner = egui::pos2(
+        ui.max_rect().left() + TILE,
+        ui.max_rect().top() - HEAD_BOTTOM,
+    );
+    // `.badge{right:-4px;bottom:-4px;width:20px;border-radius:50%}` — a round
+    // warning dot hanging off the corner, ringed in the card fill so it detaches.
+    // `RADIUS_PILL` saturates to `u8::MAX`; the tessellator clamps it to a circle.
+    let badge = egui::Rect::from_min_size(
+        tile_corner - egui::vec2(16.0, 16.0),
+        egui::Vec2::splat(20.0),
+    );
+    let round = CornerRadius::same(RADIUS_PILL as u8);
+    ui.painter().rect_filled(badge, round, colors.warning);
+    ui.painter().rect_stroke(
+        badge,
+        round,
+        Stroke::new(2.0, colors.bg),
+        StrokeKind::Outside,
+    );
+    ui.painter().text(
+        badge.center(),
+        Align2::CENTER_CENTER,
+        egui_phosphor::regular::SHIELD_WARNING,
+        phosphor_font_id(12.0),
+        get_contrast_text_color(colors.warning),
+    );
+}
+
+/// One `.perm` row: glyph, stacked label + scope, and a `.pill` for sensitive
+/// permissions. `divided` draws the inset hairline rows after the first carry.
+fn render_permission_row(
+    ui: &mut egui::Ui,
+    entry: &PermissionEntry,
+    colors: &ThemeColors,
+    divided: bool,
+) {
+    // `.perm{padding:8px 9px;border-radius:8px}` — the row itself is unfilled, so
+    // the radius only matters if it ever gains a hover wash.
+    let row = Frame::new()
+        .corner_radius(RADIUS_CONTROL)
+        .inner_margin(Margin {
+            left: 9,
+            right: 9,
+            top: 8,
+            bottom: 8,
+        })
+        .show(ui, |ui| {
+            // Full-width too, so the inter-row hairline spans the box and a future
+            // hover wash would cover the whole row.
+            ui.set_min_width(ui.available_width());
+            ui.spacing_mut().item_spacing.x = 10.0; // `.perm{gap:10px}`
+            ui.horizontal(|ui| {
+                // `.perm i` — warn-tinted for a sensitive permission (`.sens`).
+                ui.add(
+                    Icon::builder()
+                        .glyph(entry.icon)
+                        .size(17.0)
+                        .color(color_to_hex(if entry.sensitive {
+                            colors.warning
+                        } else {
+                            colors.accent
+                        }))
+                        .build(),
+                );
+                ui.vertical(|ui| {
+                    // The two lines are adjacent blocks in the design; a hair of
+                    // leading stands in for its 1.5 line-height.
+                    ui.spacing_mut().item_spacing.y = 2.0;
+                    // `.pl` — 12.5px in the primary foreground (the variant default).
+                    ui.add(
+                        Typography::builder()
+                            .text(&entry.label)
+                            .variant(TypographyVariant::Body)
+                            .size(FONT_CONTROL)
+                            .build(),
+                    );
+                    // `.ps` — monospace scope hint.
+                    ui.add(
+                        Typography::builder()
+                            .text(&entry.scope)
+                            .variant(TypographyVariant::Mono)
+                            .size(FONT_CAPTION)
+                            .color(color_to_hex(colors.fg_muted))
+                            .build(),
+                    );
+                });
+                if entry.sensitive {
+                    // `.pill{margin-left:auto}`
+                    ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
+                        render_sensitive_pill(ui, colors);
                     });
+                }
             });
-        }
-    });
+        });
+
+    if divided {
+        // `.perm+.perm{box-shadow:inset 0 1px 0 surface1@24%}` — painted rather
+        // than added, so it rides the row's own top edge instead of pushing it.
+        Separator::rule(color_to_hex(with_alpha(colors.surface_raised, 61))).paint_at(
+            ui,
+            row.response.rect.x_range(),
+            row.response.rect.top() + 0.5,
+        );
+    }
+}
+
+/// The `.pill` tag on a sensitive permission — a fully round warning wash behind
+/// 9.5px bold proportional text, i.e. the shared soft [`Badge`] at a pill radius.
+fn render_sensitive_pill(ui: &mut egui::Ui, colors: &ThemeColors) {
+    ui.add(
+        Badge::builder()
+            .label("SENSITIVE")
+            .color(color_to_hex(colors.warning))
+            .soft(true)
+            .pill(true)
+            // `.pill{font-weight:700}` in the body family, not a code token.
+            .mono(false)
+            .bold(true)
+            // `.pill{padding:2px 7px}` — the medium preset's horizontal padding.
+            .size(Size::Medium)
+            .font_size(PILL_FONT)
+            .build(),
+    );
 }

--- a/src/notification/notification_dropdown.rs
+++ b/src/notification/notification_dropdown.rs
@@ -1,17 +1,19 @@
-use eframe::egui::{self, Align2, Color32, CornerRadius, Frame, Layout, Margin, RichText, Stroke};
+use eframe::egui::{
+    self, Align, Align2, Color32, CornerRadius, Frame, Layout, Margin, RichText, Sense,
+};
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use thoth_plugin_sdk::components::{
-    Button, ButtonColor, ButtonGroupItem, ButtonGroups, ButtonSize, ButtonType, IconButton, List,
-    ListEvent, ListItem, ListItemPostfix, ListItemPrefix, Typography, TypographyVariant,
+    Button, ButtonColor, ButtonGroupItem, ButtonGroups, ButtonSize, ButtonType, IconButton,
+    IconButtonSelectedStyle, Typography, TypographyVariant,
 };
-use thoth_plugin_sdk::theme::color_to_hex;
+use thoth_plugin_sdk::theme::{FONT_CONTROL, RADIUS_POPOVER, color_to_hex, with_alpha};
 
 use crate::{
     components::traits::ContextComponent,
     notification::{NotificationKind, NotificationManager, NotificationStatus},
-    theme::{ThemeColors, phosphor_font_id},
+    theme::{RADIUS_CHIP, ThemeColors, edge_stroke, phosphor_font_id, popover_shadow},
 };
 
 type NotifAction = Arc<dyn Fn() + Send + Sync + 'static>;
@@ -28,6 +30,126 @@ type NotifRow = (
     i64,
     bool,
 );
+
+// ── Design metrics ────────────────────────────────────────────────────────────
+//
+// Radii come from the ladder (`RADIUS_*`), never from the CSS pixel values.
+
+/// Bell trigger. `overlays.html` draws `.bell` at 28px, but that is the floating
+/// `.bellbar` context; here the trigger lives in the 26px status bar, whose items
+/// are 22px `.chip`s (app-mockup.html). At 28px it would overflow the bar's clip
+/// rect and lose a pixel off each corner, so it is chip-sized instead.
+const BELL_SIZE: f32 = 22.0;
+/// …with a glyph scaled to match (the design's 16px on a 28px box).
+const BELL_GLYPH: f32 = 14.0;
+/// Unread dot — design `.bell .bd{width:8px;height:8px}`…
+const BELL_DOT: f32 = 8.0;
+/// …tucked 3px in from the top-right corner (the component's own dot overhangs
+/// the corner instead).
+const BELL_DOT_INSET: f32 = 3.0;
+
+/// Panel width — design `.npanel{width:380px}`.
+const PANEL_W: f32 = 380.0;
+
+/// Header padding — design `.nhead{padding:12px 12px 10px 16px}`.
+const HEAD_MARGIN: Margin = Margin {
+    left: 16,
+    right: 12,
+    top: 12,
+    bottom: 10,
+};
+/// Gap between the header's title and its unread count — design `.nhead{gap:8px}`.
+const HEAD_GAP: f32 = 8.0;
+/// Unread count — design `.nhead .u{font-size:11.5px}`.
+const HEAD_COUNT_FONT: f32 = 11.5;
+/// Header actions — design `.nhead .ib{width:24px;height:24px}`…
+const HEAD_ACTION: f32 = 24.0;
+/// …with a 14px glyph…
+const HEAD_ACTION_GLYPH: f32 = 14.0;
+/// …spaced tightly — design `.nhead .acts{gap:2px}`.
+const HEAD_ACTION_GAP: f32 = 2.0;
+
+/// Filter tabs sit inset from the panel edges — design `.tabs{margin:0 16px 6px}`.
+const TABS_MARGIN: Margin = Margin {
+    left: 16,
+    right: 16,
+    top: 0,
+    bottom: 6,
+};
+
+/// The list scrolls past this height — design `.nlist{max-height:300px}`.
+const LIST_MAX_H: f32 = 300.0;
+/// …and is inset from the panel edges — design `.nlist{padding:0 8px}`.
+const LIST_MARGIN: Margin = Margin {
+    left: 8,
+    right: 8,
+    top: 0,
+    bottom: 0,
+};
+
+/// Date separator padding — design `.ndate{padding:9px 8px 5px}`.
+const DATE_MARGIN: Margin = Margin {
+    left: 8,
+    right: 8,
+    top: 9,
+    bottom: 5,
+};
+/// …and its type — design `.ndate{font-size:10px;font-weight:700}`.
+const DATE_FONT: f32 = 10.0;
+
+/// Row padding — design `.nrow{padding:9px 8px}`.
+const ROW_MARGIN: Margin = Margin {
+    left: 8,
+    right: 8,
+    top: 9,
+    bottom: 9,
+};
+/// Gap between a row's glyph, body, and dismiss — design `.nrow{gap:10px}`.
+const ROW_GAP: f32 = 10.0;
+/// Gap *after* every row, so the chip-radius cards read as separate cards rather
+/// than one packed column, and so the last row is not flush against `.nfoot`.
+///
+/// `.nrow` itself declares no margin, but it is the same construct as
+/// app-mockup's `.card` — a wash-filled, 3px-striped card in a scrolling stack
+/// (`.card::before{top:9px;bottom:9px}` against `.nrow.unread::before{top:10px;
+/// bottom:10px}`) — so its stack rule carries over: `.card{margin-bottom:6px}`.
+const ROW_STACK_GAP: f32 = 6.0;
+/// Hover wash — design `.nrow:hover{background:text@5%}`.
+const ROW_HOVER_ALPHA: u8 = 13; // 5% of 255
+/// Unread wash — design `.nrow.unread{background:mauve@7%}`.
+const ROW_UNREAD_ALPHA: u8 = 18; // 7% of 255
+/// Unread stripe — design `.nrow.unread::before{width:3px}`…
+const STRIPE_W: f32 = 3.0;
+/// …inset this far from the row's top and bottom edges…
+const STRIPE_INSET_Y: f32 = 10.0;
+/// …with its own tiny radius, below the ladder's smallest rung.
+const STRIPE_RADIUS: f32 = 3.0;
+/// Leading kind glyph — design `.nrow>i{font-size:17px}`…
+const KIND_GLYPH: f32 = 17.0;
+/// …nudged down off the row's top edge — design `.nrow>i{margin-top:1px}`.
+const KIND_GLYPH_DROP: f32 = 1.0;
+/// Message line — design `.nrow .nm{font-size:11.5px}`…
+const MESSAGE_FONT: f32 = 11.5;
+/// …just under the title — design `.nm{margin-top:1px}`.
+const MESSAGE_GAP: f32 = 1.0;
+/// Timestamp — design `.nrow .tm{font-size:10.5px}`…
+const TIME_FONT: f32 = 10.5;
+/// …below the message — design `.tm{margin-top:2px}`.
+const TIME_GAP: f32 = 2.0;
+/// Dismiss button — design `.nrow .dismiss{width:22px;height:22px}`…
+const DISMISS_SIZE: f32 = 22.0;
+/// …with a 13px glyph.
+const DISMISS_GLYPH: f32 = 13.0;
+
+/// Footer padding — design `.nfoot{padding:8px 12px}`. The footer already carries
+/// its own 8px top padding, so the gap above "Clear all" is bought on the list
+/// side (see [`ROW_STACK_GAP`]), not here.
+const FOOT_MARGIN: Margin = Margin {
+    left: 12,
+    right: 12,
+    top: 8,
+    bottom: 8,
+};
 
 // ── Filter ────────────────────────────────────────────────────────────────────
 
@@ -58,6 +180,15 @@ impl Filter {
             _ => Filter::All,
         }
     }
+}
+
+/// What the user did to one `.nrow` this frame.
+enum RowEvent {
+    /// The row (or a pinned row's action button) was clicked — fire its primary
+    /// action.
+    Activate,
+    /// The row's dismiss button was clicked.
+    Dismiss,
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -98,17 +229,23 @@ impl ContextComponent for NotificationDropdown {
             egui_phosphor::regular::BELL
         };
 
+        // Design `.bell`: a ghost square that takes a 14% accent wash while its
+        // panel is open, keeps its `--text` glyph in every state, and carries an
+        // 8px unread dot ringed in the bar it sits on.
         let btn = ui.add(
             IconButton::builder()
                 .icon(bell_icon)
                 .tooltip("Notifications")
                 .frame(false)
-                .maybe_badge_color(if unread_count > 0 {
-                    Some(color_to_hex(colors.error))
-                } else {
-                    None
-                })
+                .size_px(BELL_SIZE)
+                .icon_size(BELL_GLYPH)
                 .selected(self.state.is_open)
+                .selected_style(IconButtonSelectedStyle::Wash)
+                .glyph_color("fg")
+                .maybe_badge_color((unread_count > 0).then(|| color_to_hex(colors.error)))
+                .badge_size(BELL_DOT)
+                .badge_inset(BELL_DOT_INSET)
+                .badge_ring_color(color_to_hex(colors.bg_panel))
                 .build(),
         );
 
@@ -134,104 +271,105 @@ impl NotificationDropdown {
             .collapsible(false)
             .movable(false)
             .anchor(Align2::RIGHT_BOTTOM, egui::vec2(-4.0, -28.0))
-            .fixed_size(egui::vec2(380.0, 520.0))
+            // Design `.npanel{width:380px}` — pinned width, height hugs content.
+            .min_width(PANEL_W)
+            .max_width(PANEL_W)
             .frame(
+                // Design `.npanel`: a mantle popover lifted by the menu shadow over
+                // a hairline edge.
                 Frame::new()
                     .fill(colors.bg_panel)
-                    .stroke(Stroke::new(1.0, colors.surface))
-                    .corner_radius(CornerRadius::same(8)),
+                    .stroke(edge_stroke(colors))
+                    .corner_radius(RADIUS_POPOVER)
+                    .shadow(popover_shadow(ui.visuals().dark_mode)),
             )
             .show(ui.ctx(), |ui| {
-                ui.set_min_width(380.0);
-                ui.set_max_width(380.0);
+                // A flex column: each band carries its own padding, so there is no
+                // spacing between them.
+                ui.spacing_mut().item_spacing.y = 0.0;
 
                 // ── Header ────────────────────────────────────────────────────
-                Frame::new()
-                    .inner_margin(Margin {
-                        left: 16,
-                        right: 12,
-                        top: 12,
-                        bottom: 10,
-                    })
-                    .show(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            Typography::title(ui, "Notifications");
-                            if unread_count > 0 {
-                                ui.add_space(6.0);
-                                Typography::caption(ui, &format!("{unread_count} unread"));
+                Frame::new().inner_margin(HEAD_MARGIN).show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = HEAD_GAP;
+                        Typography::title(ui, "Notifications");
+                        if unread_count > 0 {
+                            ui.add(
+                                Typography::builder()
+                                    .text(format!("{unread_count} unread"))
+                                    .variant(TypographyVariant::Caption)
+                                    .size(HEAD_COUNT_FONT)
+                                    .build(),
+                            );
+                        }
+                        // Design `.nhead .acts{margin-left:auto;gap:2px}` — ghost
+                        // `.ib`s, in sheet order (checks, then close) once the
+                        // right-to-left layout reverses them.
+                        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                            ui.spacing_mut().item_spacing.x = HEAD_ACTION_GAP;
+                            if ui
+                                .add(
+                                    IconButton::builder()
+                                        .icon(egui_phosphor::regular::X)
+                                        .tooltip("Close")
+                                        .frame(false)
+                                        .size_px(HEAD_ACTION)
+                                        .icon_size(HEAD_ACTION_GLYPH)
+                                        .build(),
+                                )
+                                .clicked()
+                            {
+                                close_panel = true;
                             }
-                            ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
-                                if ui
-                                    .add(
-                                        IconButton::builder()
-                                            .icon(egui_phosphor::regular::X)
-                                            .tooltip("Close")
-                                            .frame(false)
-                                            .size_px(20.0)
-                                            .icon_size(13.0)
-                                            .build(),
-                                    )
-                                    .clicked()
-                                {
-                                    close_panel = true;
-                                }
-                                ui.add_space(4.0);
-                                if ui
-                                    .add(
-                                        IconButton::builder()
-                                            .icon(egui_phosphor::regular::CHECKS)
-                                            .tooltip("Mark all as read")
-                                            .frame(false)
-                                            .size_px(20.0)
-                                            .icon_size(13.0)
-                                            .disabled(unread_count == 0)
-                                            .build(),
-                                    )
-                                    .clicked()
-                                    && let Some(m) = crate::NOTIFICATION_MANAGER.get()
-                                    && let Ok(mut nm) = m.lock()
-                                {
-                                    nm.mark_all_read();
-                                }
-                            });
+                            if ui
+                                .add(
+                                    IconButton::builder()
+                                        .icon(egui_phosphor::regular::CHECKS)
+                                        .tooltip("Mark all as read")
+                                        .frame(false)
+                                        .size_px(HEAD_ACTION)
+                                        .icon_size(HEAD_ACTION_GLYPH)
+                                        .disabled(unread_count == 0)
+                                        .build(),
+                                )
+                                .clicked()
+                                && let Some(m) = crate::NOTIFICATION_MANAGER.get()
+                                && let Ok(mut nm) = m.lock()
+                            {
+                                nm.mark_all_read();
+                            }
                         });
                     });
-
-                ui.add(egui::Separator::default().spacing(0.0));
+                });
 
                 // ── Filter tabs ───────────────────────────────────────────────
-                Frame::new()
-                    .inner_margin(Margin {
-                        left: 12,
-                        right: 12,
-                        top: 8,
-                        bottom: 8,
-                    })
-                    .show(ui, |ui| {
-                        let selected = ButtonGroups::builder()
-                            .items(vec![
-                                ButtonGroupItem::builder().value("all").label("All").build(),
-                                ButtonGroupItem::builder()
-                                    .value("unread")
-                                    .label("Unread")
-                                    .build(),
-                                ButtonGroupItem::builder()
-                                    .value("plugins")
-                                    .label("Plugins")
-                                    .build(),
-                                ButtonGroupItem::builder()
-                                    .value("errors")
-                                    .label("Errors")
-                                    .build(),
-                            ])
-                            .active(new_filter.as_str())
-                            .build()
-                            .show(ui)
-                            .inner;
-                        if let Some(v) = selected {
-                            new_filter = Filter::from_str(&v);
-                        }
-                    });
+                // Design `.tabs`: a segmented control on a crust track, sized to
+                // its segments rather than the panel width.
+                Frame::new().inner_margin(TABS_MARGIN).show(ui, |ui| {
+                    let selected = ButtonGroups::builder()
+                        .items(vec![
+                            ButtonGroupItem::builder().value("all").label("All").build(),
+                            ButtonGroupItem::builder()
+                                .value("unread")
+                                .label("Unread")
+                                .build(),
+                            ButtonGroupItem::builder()
+                                .value("plugins")
+                                .label("Plugins")
+                                .build(),
+                            ButtonGroupItem::builder()
+                                .value("errors")
+                                .label("Errors")
+                                .build(),
+                        ])
+                        .active(new_filter.as_str())
+                        .build()
+                        .show(ui)
+                        .inner;
+                    if let Some(v) = selected {
+                        new_filter = Filter::from_str(&v);
+                    }
+                });
 
                 // ── Notification list ─────────────────────────────────────────
                 let notifications: Vec<NotifRow> = crate::NOTIFICATION_MANAGER
@@ -277,153 +415,69 @@ impl NotificationDropdown {
                     .collect();
 
                 egui::ScrollArea::vertical()
-                    .max_height(380.0)
-                    .auto_shrink([false, false])
+                    .max_height(LIST_MAX_H)
+                    .auto_shrink([false, true])
                     .show(ui, |ui| {
-                        if visible.is_empty() {
-                            render_empty_state(ui, new_filter);
-                        } else {
-                            for bucket_label in ["Today", "Yesterday", "Earlier"] {
-                                // Rows for this date bucket
-                                let bucket: Vec<&NotifRow> = visible
-                                    .iter()
-                                    .copied()
-                                    .filter(|row| date_bucket(row.7) == bucket_label)
-                                    .collect();
+                        Frame::new().inner_margin(LIST_MARGIN).show(ui, |ui| {
+                            ui.spacing_mut().item_spacing.y = 0.0;
+                            if visible.is_empty() {
+                                render_empty_state(ui, new_filter);
+                            } else {
+                                for bucket_label in ["Today", "Yesterday", "Earlier"] {
+                                    // Rows for this date bucket
+                                    let bucket: Vec<&NotifRow> = visible
+                                        .iter()
+                                        .copied()
+                                        .filter(|row| date_bucket(row.7) == bucket_label)
+                                        .collect();
 
-                                if bucket.is_empty() {
-                                    continue;
-                                }
+                                    if bucket.is_empty() {
+                                        continue;
+                                    }
 
-                                Frame::new()
-                                    .inner_margin(Margin {
-                                        left: 16,
-                                        right: 16,
-                                        top: 8,
-                                        bottom: 8,
-                                    })
-                                    .show(ui, |ui| {
-                                        Typography::group_label(ui, &bucket_label.to_uppercase());
-                                    });
+                                    render_date_separator(ui, bucket_label, colors);
 
-                                // Pre-build descriptions (formatted Strings that
-                                // must outlive the ListItem borrows below).
-                                let descs: Vec<String> = bucket
-                                    .iter()
-                                    .map(|row| {
-                                        let ts = relative_time(row.7);
-                                        if row.2.is_empty() {
-                                            ts
-                                        } else {
-                                            format!("{}\n{ts}", row.2)
-                                        }
-                                    })
-                                    .collect();
-
-                                // Pre-build action labels for pinned rows (must own the Strings).
-                                let action_labels: Vec<Option<String>> = bucket
-                                    .iter()
-                                    .map(|row| {
-                                        if row.8 {
-                                            row.6.first().map(|(label, _)| label.clone())
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .collect();
-
-                                let list_items: Vec<ListItem> = bucket
-                                    .iter()
-                                    .zip(descs.iter())
-                                    .zip(action_labels.iter())
-                                    .map(
-                                        |(
-                                            ((_, title, _, _, kind, unread, _, _, pinned), desc),
-                                            action_label,
-                                        )| {
-                                            let (icon, icon_color) = kind_icon(*kind, colors);
-                                            let postfix = if *pinned {
-                                                action_label.as_deref().map(|label| {
-                                                    ListItemPostfix::Button(
-                                                        Button::builder()
-                                                            .label(label)
-                                                            .button_type(ButtonType::Elevated)
-                                                            .color(ButtonColor::Primary)
-                                                            .button_size(ButtonSize::Small)
-                                                            .build(),
-                                                    )
-                                                })
-                                            } else {
-                                                Some(ListItemPostfix::IconButton(
-                                                    IconButton::builder()
-                                                        .icon(egui_phosphor::regular::X)
-                                                        .tooltip("Dismiss")
-                                                        .frame(false)
-                                                        .size_px(18.0)
-                                                        .icon_size(11.0)
-                                                        .build(),
-                                                ))
-                                            };
-                                            ListItem::builder()
-                                                .title(title.clone())
-                                                .description(desc.clone())
-                                                .prefix(ListItemPrefix::Icon {
-                                                    glyph: icon.to_string(),
-                                                    color: Some(color_to_hex(icon_color)),
-                                                })
-                                                .maybe_accent(
-                                                    (*unread).then(|| color_to_hex(icon_color)),
-                                                )
-                                                .maybe_postfix(postfix)
-                                                .build()
-                                        },
-                                    )
-                                    .collect();
-
-                                let list_event = List::builder()
-                                    .items(list_items)
-                                    .shrink_to_fit(true)
-                                    .build()
-                                    .show(ui);
-
-                                match list_event {
-                                    Some(ListEvent::PostfixClicked(idx)) => {
-                                        if let Some(row) = bucket.get(idx) {
-                                            if row.8 {
-                                                // Pinned row: postfix is an action button — fire it.
+                                    for row in bucket {
+                                        let event = render_row(ui, row, colors);
+                                        // `.card{margin-bottom:6px}` semantics: the
+                                        // gap trails *every* row, so the last one
+                                        // also supplies the bottom inset that
+                                        // `.nlist{padding:0 8px}` leaves at zero.
+                                        ui.add_space(ROW_STACK_GAP);
+                                        match event {
+                                            // Clicking a row fires the primary
+                                            // (first) action only.
+                                            Some(RowEvent::Activate) => {
                                                 if let Some((_, cb)) = row.6.first() {
                                                     cb();
                                                 }
-                                            } else {
+                                            }
+                                            Some(RowEvent::Dismiss) => {
                                                 to_dismiss = Some(row.0.clone());
                                             }
+                                            None => {}
                                         }
                                     }
-                                    // Clicking a row fires the primary (first) action only.
-                                    Some(ListEvent::ItemClicked(idx)) => {
-                                        if let Some(row) = bucket.get(idx)
-                                            && let Some((_, cb)) = row.6.first()
-                                        {
-                                            cb();
-                                        }
-                                    }
-                                    _ => {}
                                 }
                             }
-                        }
+                        });
                     });
 
                 // ── Footer ────────────────────────────────────────────────────
-                ui.add(egui::Separator::default().spacing(0.0));
                 Frame::new()
-                    .inner_margin(Margin {
-                        left: 14,
-                        right: 14,
-                        top: 8,
-                        bottom: 8,
-                    })
+                    .inner_margin(FOOT_MARGIN)
                     .fill(colors.bg_sunken)
+                    // Design `.npanel{overflow:hidden}` — the footer is the only
+                    // filled band touching the panel edge, so it carries the
+                    // bottom corners itself.
+                    .corner_radius(CornerRadius {
+                        nw: 0,
+                        ne: 0,
+                        sw: RADIUS_POPOVER as u8,
+                        se: RADIUS_POPOVER as u8,
+                    })
                     .show(ui, |ui| {
+                        // Design `.nfoot .btn{margin:0 auto 0 0}` — left-aligned.
                         ui.horizontal(|ui| {
                             if ui
                                 .add(
@@ -455,6 +509,221 @@ impl NotificationDropdown {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Design `.ndate`: a tiny bold upper-case bucket label.
+fn render_date_separator(ui: &mut egui::Ui, label: &str, colors: &ThemeColors) {
+    Frame::new().inner_margin(DATE_MARGIN).show(ui, |ui| {
+        ui.add(
+            Typography::builder()
+                .text(label.to_uppercase())
+                .variant(TypographyVariant::Label)
+                .size(DATE_FONT)
+                .bold(true)
+                .color(color_to_hex(colors.fg_faint()))
+                .build(),
+        );
+    });
+}
+
+/// Design `.nrow`: kind glyph, text block, and a hover-revealed dismiss, over a
+/// chip-radius wash with an unread stripe on its left edge.
+///
+/// Hand-built rather than an SDK `List`: `.li` is a fixed-height row with one
+/// 12px title and one 11px muted description, where `.nrow` grows with its
+/// content and carries three distinct type tiers plus a 3px kind-coloured
+/// stripe.
+fn render_row(ui: &mut egui::Ui, row: &NotifRow, colors: &ThemeColors) -> Option<RowEvent> {
+    let (id, title, message, _, kind, unread, actions, created_at, pinned) = row;
+    let (glyph, kind_color) = kind_icon(*kind, colors);
+
+    let row_id = ui.make_persistent_id(("notification_row", id));
+    // `.dismiss{opacity:0}` is revealed by the row's `:hover`, but a row's rect is
+    // only known once it has laid out — so reveal on last frame's hover, as the
+    // SDK's `List` does for its trailing actions.
+    let was_hovered = ui
+        .ctx()
+        .memory(|m| m.data.get_temp::<bool>(row_id).unwrap_or(false));
+
+    let mut event = None;
+
+    // Reserve a paint slot before the content so the wash draws behind the glyph
+    // and text.
+    let bg_slot = ui.painter().add(egui::Shape::Noop);
+
+    let response = ui
+        .push_id(row_id, |ui| {
+            Frame::new()
+                .inner_margin(ROW_MARGIN)
+                .show(ui, |ui| {
+                    ui.horizontal_top(|ui| {
+                        ui.set_min_width(ui.available_width());
+                        // Every gap inside a row is explicit.
+                        ui.spacing_mut().item_spacing.x = 0.0;
+
+                        // Design `.nrow>i` — the kind glyph, 1px down from the top.
+                        let galley = ui.painter().layout_no_wrap(
+                            glyph.to_string(),
+                            phosphor_font_id(KIND_GLYPH),
+                            kind_color,
+                        );
+                        let (glyph_rect, _) = ui.allocate_exact_size(
+                            galley.size() + egui::vec2(0.0, KIND_GLYPH_DROP),
+                            Sense::hover(),
+                        );
+                        ui.painter().galley(
+                            glyph_rect.min + egui::vec2(0.0, KIND_GLYPH_DROP),
+                            galley,
+                            kind_color,
+                        );
+                        ui.add_space(ROW_GAP);
+
+                        ui.with_layout(Layout::right_to_left(Align::Min), |ui| {
+                            if *pinned {
+                                // A pinned row keeps its primary action in place of
+                                // the dismiss — it can't be swiped away.
+                                if let Some((label, _)) = actions.first()
+                                    && ui
+                                        .add(
+                                            Button::builder()
+                                                .label(label.as_str())
+                                                .button_type(ButtonType::Elevated)
+                                                .color(ButtonColor::Primary)
+                                                .button_size(ButtonSize::Small)
+                                                .build(),
+                                        )
+                                        .clicked()
+                                {
+                                    event = Some(RowEvent::Activate);
+                                }
+                            } else if was_hovered {
+                                if ui
+                                    .add(
+                                        IconButton::builder()
+                                            .icon(egui_phosphor::regular::X)
+                                            .tooltip("Dismiss")
+                                            .frame(false)
+                                            .size_px(DISMISS_SIZE)
+                                            .icon_size(DISMISS_GLYPH)
+                                            .build(),
+                                    )
+                                    .clicked()
+                                {
+                                    event = Some(RowEvent::Dismiss);
+                                }
+                            } else {
+                                // The space stays reserved either way so the text
+                                // doesn't reflow when the pointer arrives.
+                                ui.allocate_exact_size(
+                                    egui::Vec2::splat(DISMISS_SIZE),
+                                    Sense::hover(),
+                                );
+                            }
+                            ui.add_space(ROW_GAP);
+                            render_row_body(ui, title, message, *created_at, colors);
+                        });
+                    });
+                })
+                .response
+        })
+        .inner;
+
+    let hovered = ui.rect_contains_pointer(response.rect);
+    if hovered {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+    ui.ctx().memory_mut(|m| m.data.insert_temp(row_id, hovered));
+
+    // `.nrow.unread` comes after `.nrow:hover` at equal specificity, so the
+    // unread wash wins while the pointer is over an unread row.
+    let fill = if *unread {
+        Some(with_alpha(colors.accent, ROW_UNREAD_ALPHA))
+    } else if hovered || was_hovered {
+        Some(with_alpha(colors.fg, ROW_HOVER_ALPHA))
+    } else {
+        None
+    };
+    if let Some(fill) = fill {
+        ui.painter().set(
+            bg_slot,
+            egui::Shape::rect_filled(response.rect, RADIUS_CHIP, fill),
+        );
+    }
+
+    // Design `.nrow.unread::before` — a kind-coloured bar on the left edge,
+    // inset from the row's top and bottom.
+    if *unread {
+        let stripe = egui::Rect::from_min_size(
+            egui::pos2(response.rect.left(), response.rect.top() + STRIPE_INSET_Y),
+            egui::vec2(
+                STRIPE_W,
+                (response.rect.height() - STRIPE_INSET_Y * 2.0).max(0.0),
+            ),
+        );
+        ui.painter().rect_filled(stripe, STRIPE_RADIUS, kind_color);
+    }
+
+    if event.is_none() && hovered && ui.input(|i| i.pointer.primary_clicked()) {
+        event = Some(RowEvent::Activate);
+    }
+
+    event
+}
+
+/// Design `.nrow .body`: the title, the one-line message, and the timestamp, as
+/// one tight block against the row's top edge.
+fn render_row_body(
+    ui: &mut egui::Ui,
+    title: &str,
+    message: &str,
+    created_at: i64,
+    colors: &ThemeColors,
+) {
+    let width = ui.available_width();
+    ui.allocate_ui_with_layout(
+        egui::vec2(width, 0.0),
+        Layout::top_down(Align::LEFT),
+        |ui| {
+            // Every offset in the block is explicit — design `.nm{margin-top:1px}`
+            // and `.tm{margin-top:2px}`.
+            ui.spacing_mut().item_spacing.y = 0.0;
+
+            // `.nt` — 12.5px semibold.
+            ui.add(
+                Typography::builder()
+                    .text(title)
+                    .size(FONT_CONTROL)
+                    .bold(true)
+                    .build(),
+            );
+
+            if !message.is_empty() {
+                ui.add_space(MESSAGE_GAP);
+                // `.nm` is a single ellipsised line; `Typography` has no
+                // truncating mode, so this line is a plain label on the same
+                // size/colour tokens.
+                ui.add(
+                    egui::Label::new(
+                        RichText::new(message)
+                            .size(MESSAGE_FONT)
+                            .color(colors.fg_subtle()),
+                    )
+                    .truncate(),
+                );
+            }
+
+            // `.tm` — the relative timestamp.
+            ui.add_space(TIME_GAP);
+            ui.add(
+                Typography::builder()
+                    .text(relative_time(created_at))
+                    .variant(TypographyVariant::Label)
+                    .size(TIME_FONT)
+                    .color(color_to_hex(colors.fg_faint()))
+                    .build(),
+            );
+        },
+    );
+}
 
 fn render_empty_state(ui: &mut egui::Ui, filter: Filter) {
     let (icon, title, body) = match filter {

--- a/src/notification/notification_dropdown.rs
+++ b/src/notification/notification_dropdown.rs
@@ -546,6 +546,21 @@ fn render_row(ui: &mut egui::Ui, row: &NotifRow, colors: &ThemeColors) -> Option
 
     let mut event = None;
 
+    // The row's own click target. Registered *before* the children so egui stacks
+    // the dismiss / pinned-action buttons on top of it, and so activation needs a
+    // press **and** release on the row rather than a bare pointer test. Its rect
+    // is only known after layout, hence last frame's — the same one-frame trick
+    // as `was_hovered`, and harmless because a row's rect is stable.
+    let hit_id = row_id.with("hit");
+    let hit_rect = ui
+        .ctx()
+        .memory(|m| m.data.get_temp::<egui::Rect>(hit_id))
+        .unwrap_or(egui::Rect::NOTHING);
+    let row_resp = ui.interact(hit_rect, hit_id, Sense::click());
+    // Gives the row a focusable widget with a label, so Tab + Enter/Space and
+    // AccessKit clients can activate a notification.
+    row_resp.widget_info(|| egui::WidgetInfo::labeled(egui::WidgetType::Button, true, title));
+
     // Reserve a paint slot before the content so the wash draws behind the glyph
     // and text.
     let bg_slot = ui.painter().add(egui::Shape::Noop);
@@ -627,7 +642,12 @@ fn render_row(ui: &mut egui::Ui, row: &NotifRow, colors: &ThemeColors) -> Option
         })
         .inner;
 
-    let hovered = ui.rect_contains_pointer(response.rect);
+    ui.ctx()
+        .memory_mut(|m| m.data.insert_temp(hit_id, response.rect));
+
+    // `contains_pointer`, not `hovered`: the pointer sitting on the dismiss button
+    // is still inside the row, and the row's wash and revealed dismiss must stay.
+    let hovered = row_resp.contains_pointer();
     if hovered {
         ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
     }
@@ -662,7 +682,7 @@ fn render_row(ui: &mut egui::Ui, row: &NotifRow, colors: &ThemeColors) -> Option
         ui.painter().rect_filled(stripe, STRIPE_RADIUS, kind_color);
     }
 
-    if event.is_none() && hovered && ui.input(|i| i.pointer.primary_clicked()) {
+    if event.is_none() && row_resp.clicked() {
         event = Some(RowEvent::Activate);
     }
 

--- a/src/platform/fonts.rs
+++ b/src/platform/fonts.rs
@@ -32,16 +32,52 @@ pub fn list_system_font_families() -> Vec<String> {
 /// Return the raw bytes for the first face whose family name matches `family`.
 /// Returns `None` if the font is not installed or its file cannot be read.
 pub fn find_font_bytes(family: &str) -> Option<Vec<u8>> {
+    find_font_bytes_weighted(family, fontdb::Weight::NORMAL)
+}
+
+/// Return the raw bytes for the face of `family` closest to `weight`.
+///
+/// egui has no weight axis: a `FontId` names a *family*, so rendering text at
+/// weight 500 or 600 means registering that weight as its own named family. This
+/// picks the nearest available face by absolute weight distance, so asking for
+/// Medium on a family that ships only Regular and Bold yields Regular rather
+/// than nothing.
+pub fn find_font_bytes_weighted(family: &str, weight: fontdb::Weight) -> Option<Vec<u8>> {
     let db = font_db();
-    let face = db.faces().find(|f| {
-        f.families
-            .iter()
-            .any(|(name, _)| name.eq_ignore_ascii_case(family))
-    })?;
+    let face = db
+        .faces()
+        .filter(|f| {
+            f.families
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case(family))
+        })
+        // Prefer upright faces so a Medium *Italic* never wins on weight alone.
+        .min_by_key(|f| {
+            let dw = f.weight.0.abs_diff(weight.0) as u32;
+            let italic = u32::from(f.style != fontdb::Style::Normal);
+            (italic, dw)
+        })?;
 
     match &face.source {
         fontdb::Source::File(path) => std::fs::read(path).ok(),
         fontdb::Source::Binary(data) => Some(data.as_ref().as_ref().to_vec()),
         fontdb::Source::SharedFile(_, data) => Some(data.as_ref().as_ref().to_vec()),
     }
+}
+
+/// Whether `family` actually ships a face at (or very near) `weight`.
+///
+/// [`find_font_bytes_weighted`] always falls back to the nearest face, so callers
+/// that only want to register a real Medium/SemiBold family — rather than a
+/// duplicate of Regular — check this first.
+pub fn has_weight(family: &str, weight: fontdb::Weight) -> bool {
+    const TOLERANCE: u16 = 25;
+    font_db()
+        .faces()
+        .filter(|f| {
+            f.families
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case(family))
+        })
+        .any(|f| f.style == fontdb::Style::Normal && f.weight.0.abs_diff(weight.0) <= TOLERANCE)
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -26,5 +26,5 @@ pub mod path_registry;
 pub use archive::get_extractor_for_file;
 pub use file_io::FileIO;
 pub use file_open_channel::{drain_open_requests, enqueue_open_request};
-pub use fonts::{find_font_bytes, list_system_font_families};
+pub use fonts::{find_font_bytes, find_font_bytes_weighted, has_weight, list_system_font_families};
 pub use fs::get_fs_ops;

--- a/src/plugin/marketplace/mod.rs
+++ b/src/plugin/marketplace/mod.rs
@@ -23,9 +23,43 @@ pub enum PluginInstallProgress {
     Downloading(u8), // 0–99
     Complete,
     Failed(String),
+    /// The UI asked for the install to stop. The worker polls for this between
+    /// download chunks and archive entries, undoes any partial extraction, and
+    /// leaves the slot in this state.
+    Cancelled,
 }
 
 pub type InstallSlot = Arc<Mutex<PluginInstallProgress>>;
+
+/// Ask an in-flight install to stop.
+///
+/// Dropping the [`InstallSlot`] is not enough on its own: the worker thread owns
+/// its own clone, so it would keep downloading and keep writing files into the
+/// plugin directory. Callers should signal here *and* forget the slot.
+pub fn cancel_install(slot: &InstallSlot) {
+    if let Ok(mut guard) = slot.lock() {
+        // Only a running install can be cancelled — don't clobber a terminal
+        // state, or a completed install would report as cancelled.
+        if matches!(*guard, PluginInstallProgress::Downloading(_)) {
+            *guard = PluginInstallProgress::Cancelled;
+        }
+    }
+}
+
+/// Whether [`cancel_install`] has been called for this slot.
+fn is_cancelled(slot: &InstallSlot) -> bool {
+    slot.lock()
+        .is_ok_and(|g| matches!(*g, PluginInstallProgress::Cancelled))
+}
+
+/// How an install worker finished — reported so the caller can tell "stopped
+/// early" from "ran all the way through", which a bare `Ok(())` cannot.
+enum InstallOutcome {
+    /// Extraction finished; the plugin is on disk.
+    Completed,
+    /// A cancel was observed at a checkpoint and any partial tree was removed.
+    Stopped,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MarketPlacePlugin {
@@ -166,10 +200,21 @@ impl MarketPlacePlugin {
 
         thread::spawn(move || {
             let result = Self::perform_install(&url, &sha256, &id, &slot_clone, &ctx);
-            *slot_clone.lock().unwrap() = match result {
-                Ok(()) => PluginInstallProgress::Complete,
-                Err(e) => PluginInstallProgress::Failed(e.to_string()),
-            };
+            if let Ok(mut guard) = slot_clone.lock() {
+                match result {
+                    // Extraction finished, so the plugin *is* installed — report
+                    // that even if a cancel landed after the last checkpoint.
+                    // Anything else would leave the row saying "not installed"
+                    // with the files on disk.
+                    Ok(InstallOutcome::Completed) => {
+                        *guard = PluginInstallProgress::Complete;
+                    }
+                    // Stopped at a checkpoint: the partial tree is already gone,
+                    // and the slot is left in its `Cancelled` state.
+                    Ok(InstallOutcome::Stopped) => {}
+                    Err(e) => *guard = PluginInstallProgress::Failed(e.to_string()),
+                }
+            }
             ctx.request_repaint();
         });
 
@@ -182,7 +227,7 @@ impl MarketPlacePlugin {
         plugin_id: &str,
         slot: &InstallSlot,
         ctx: &egui::Context,
-    ) -> Result<()> {
+    ) -> Result<InstallOutcome> {
         use sha2::{Digest, Sha256};
 
         let client = reqwest::blocking::Client::builder()
@@ -211,6 +256,12 @@ impl MarketPlacePlugin {
         let mut buf = vec![0u8; 8192];
 
         loop {
+            // Checked per chunk so Cancel stops a large download promptly rather
+            // than at the next phase boundary. Nothing has been written to disk
+            // yet at this point, so there's nothing to undo.
+            if is_cancelled(slot) {
+                return Ok(InstallOutcome::Stopped);
+            }
             let n = response.read(&mut buf)?;
             if n == 0 {
                 break;
@@ -218,7 +269,13 @@ impl MarketPlacePlugin {
             data.extend_from_slice(&buf[..n]);
             if total_size > 0 {
                 let pct = ((data.len() as f64 / total_size as f64) * 85.0) as u8;
-                *slot.lock().unwrap() = PluginInstallProgress::Downloading(pct);
+                // Don't resurrect a `Downloading` state over a `Cancelled` one
+                // set between the check above and here.
+                if let Ok(mut guard) = slot.lock()
+                    && matches!(*guard, PluginInstallProgress::Downloading(_))
+                {
+                    *guard = PluginInstallProgress::Downloading(pct);
+                }
                 ctx.request_repaint();
             }
         }
@@ -284,6 +341,13 @@ impl MarketPlacePlugin {
         };
 
         for i in 0..len {
+            // From here on the worker is writing into `dest`, so a cancellation
+            // has to take the partial tree with it — a half-extracted plugin
+            // directory would be picked up as installed on the next launch.
+            if is_cancelled(slot) {
+                let _ = fs::remove_dir_all(&dest);
+                return Ok(InstallOutcome::Stopped);
+            }
             let mut entry = archive
                 .by_index(i)
                 .map_err(|e| ThothError::PluginDownloadError {
@@ -343,10 +407,16 @@ impl MarketPlacePlugin {
             }
 
             let pct = (90 + ((i + 1) as f64 / len as f64 * 9.0) as u8).min(99);
-            *slot.lock().unwrap() = PluginInstallProgress::Downloading(pct);
+            // As in the download loop: never write progress over a `Cancelled`
+            // state set since the checkpoint at the top of this iteration.
+            if let Ok(mut guard) = slot.lock()
+                && matches!(*guard, PluginInstallProgress::Downloading(_))
+            {
+                *guard = PluginInstallProgress::Downloading(pct);
+            }
             ctx.request_repaint();
         }
 
-        Ok(())
+        Ok(InstallOutcome::Completed)
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -63,7 +63,7 @@ impl Default for WindowState {
             sidebar: components::sidebar::Sidebar::default(),
             toolbar: components::toolbar::Toolbar::default(),
             status_bar: components::status_bar::StatusBar::default(),
-            error_modal: components::error_modal::ErrorModal,
+            error_modal: components::error_modal::ErrorModal::default(),
         }
     }
 }

--- a/src/theme/constants.rs
+++ b/src/theme/constants.rs
@@ -5,16 +5,24 @@ pub const SPACING_SMALL: f32 = GRID_UNIT; // 4px
 pub const SPACING_MEDIUM: f32 = 2.0 * GRID_UNIT; // 8px
 pub const SPACING_LARGE: f32 = 4.0 * GRID_UNIT; // 16px
 pub const TREE_INDENT: f32 = SPACING_LARGE;
-pub const ROW_HEIGHT: f32 = 22.0;
+// ROW_HEIGHT is the SDK's (same 22px) — re-exported from `super`, so tree/data
+// rows in host chrome and in SDK widgets can't drift apart.
 
-pub const ROW_PADDING_H: f32 = 24.0; // outer left/right margin for section header and group title
-pub const ROW_INNER_H: f32 = 16.0; // horizontal padding INSIDE card rows (matches design 16px)
-pub const ROW_PADDING_V: f32 = 14.0; // vertical padding inside card rows (matches design 14px)
+pub const ROW_PADDING_H: f32 = 24.0;
+pub const ROW_INNER_H: f32 = 16.0;
+pub const ROW_PADDING_V: f32 = 14.0;
 pub const GROUP_SPACING: f32 = 20.0;
-pub const CARD_OUTER_H: f32 = 24.0; // card indented from panel edges
+pub const CARD_OUTER_H: f32 = 24.0;
 pub const CARD_RADIUS: f32 = 8.0;
 pub const CONTROL_WIDTH: f32 = 220.0;
 pub const DIRTY_DOT_RADIUS: f32 = 3.0;
+
+// ── Squircle redesign — radius ladder + floating-panel chrome ────────────────
+// Owned by the SDK so host chrome and plugin/SDK widgets round identically;
+// re-exported here so `crate::theme::RADIUS_PANEL` keeps resolving.
+pub use thoth_plugin_sdk::theme::{
+    GUTTER_GAP, RADIUS_CHIP, RADIUS_CONTROL, RADIUS_PANEL, RADIUS_WINDOW,
+};
 
 impl Theme {
     pub fn mocha() -> Self {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -345,40 +345,49 @@ impl ThemeColorsExt for ThemeColors {
         // gives the two tab surfaces different vocabularies (`.etabs .tab` here,
         // `.rtabs .rtab` there). An outline box around the active tab, which is
         // what this used to draw, is neither.
-        // A *real* pill is half the tab's height. `RADIUS_PILL as u8` saturates to
-        // 255, which egui clamps when filling — so it still looks round — but
-        // egui_dock also derives its "connect the tab to the body" hline from the
-        // raw corner radius (`min.x + sw ..= max.x - se`). At 255 that range
-        // inverts on any normal-width tab and paints a stray 2px line.
-        let pill = egui::CornerRadius::same((TAB_H / 2.0) as u8);
-        // Design `.tab.active{box-shadow:var(--edge)}` — a hairline, *not* an
-        // accent ring. egui_dock's `from_egui_*` defaults derive `outline_color`
-        // from `widgets.hovered.bg_stroke`, which this theme sets to the accent,
-        // so every state has to be set explicitly or a mauve ring leaks through.
-        let edge = with_alpha(self.surface_raised, 87); // surface1@34%
+        // Safari's tab shape rather than the sheet's `--r-pill`: a rounded
+        // *rectangle*, not a lozenge. A full pill on a 30pt tab needs a 15pt
+        // radius, which rounds the short ends so hard that a two-word title reads
+        // as a capsule floating in the strip; Safari keeps the ends square enough
+        // that the tab still reads as a rectangular surface you could stack.
+        //
+        // Also note `RADIUS_PILL as u8` saturates to 255, and egui_dock derives its
+        // "connect the tab to the body" hline from the *raw* corner radius
+        // (`min.x + sw ..= max.x - se`) — at 255 that range inverts on any normal
+        // tab and paints a stray 2px line. Staying on the ladder avoids that.
+        let tab_radius = egui::CornerRadius::same(RADIUS_PANEL as u8);
+        // The design's `.tab.active{box-shadow:var(--edge)}` hairline, carried a
+        // little brighter than `edge_stroke`'s 34% so the active tab reads as a
+        // raised surface the way Safari's does. egui_dock has no shadow field on a
+        // tab, so the border is the only elevation cue available.
+        //
+        // It must be set on *every* state explicitly: egui_dock's `from_egui_*`
+        // defaults derive `outline_color` from `widgets.hovered.bg_stroke`, which
+        // this theme sets to the accent, so a mauve ring leaks through otherwise.
+        let edge = with_alpha(self.surface_raised, 130); // surface1@51%
 
-        // ── Active / focused tab: filled pill with a hairline edge ────────────
+        // ── Active / focused tab: filled rounded rect with a hairline edge ─────
         style.tab.active.bg_fill = self.surface;
         style.tab.active.text_color = self.fg;
         style.tab.active.outline_color = edge;
-        style.tab.active.corner_radius = pill;
+        style.tab.active.corner_radius = tab_radius;
 
         style.tab.focused.bg_fill = self.surface;
         style.tab.focused.text_color = self.fg;
         style.tab.focused.outline_color = edge;
-        style.tab.focused.corner_radius = pill;
+        style.tab.focused.corner_radius = tab_radius;
 
         // ── Inactive tab: bare label on the strip, no chrome at all ───────────
         style.tab.inactive.bg_fill = Color32::TRANSPARENT;
         style.tab.inactive.text_color = self.fg_muted;
         style.tab.inactive.outline_color = Color32::TRANSPARENT;
-        style.tab.inactive.corner_radius = pill;
+        style.tab.inactive.corner_radius = tab_radius;
 
         // ── Hovered tab ───────────────────────────────────────────────────────
         style.tab.hovered.bg_fill = with_alpha(self.fg, 20); // text@8%
         style.tab.hovered.text_color = self.fg;
         style.tab.hovered.outline_color = Color32::TRANSPARENT;
-        style.tab.hovered.corner_radius = pill;
+        style.tab.hovered.corner_radius = tab_radius;
 
         style.tab.inactive_with_kb_focus = style.tab.inactive.clone();
         style.tab.active_with_kb_focus = style.tab.active.clone();
@@ -476,7 +485,18 @@ pub fn apply_fonts(ctx: &egui::Context, settings: &Settings) {
                     key.clone(),
                     std::sync::Arc::new(egui::FontData::from_owned(bytes)),
                 );
-                vec![key]
+                // The weighted face covers only its own glyph set, and egui walks a
+                // family's entries in order for missing glyphs — so keep the normal
+                // stack behind it or emoji/CJK/icons render as tofu.
+                let mut stack = vec![key];
+                stack.extend(
+                    fonts
+                        .families
+                        .get(&egui::FontFamily::Proportional)
+                        .cloned()
+                        .unwrap_or_default(),
+                );
+                stack
             }
             // No real face at this weight — alias the family to the normal stack so
             // callers degrade to regular text rather than to a missing font.

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -14,9 +14,29 @@ use crate::{
 // Pure colour/font helpers are owned by the plugin SDK so host-native and
 // SDK-provided widgets share one implementation. Re-exported so existing
 // `crate::theme::{get_contrast_text_color, phosphor_font_id}` paths keep working.
-pub use thoth_plugin_sdk::theme::{get_contrast_text_color, phosphor_font_id};
+pub use thoth_plugin_sdk::theme::{
+    FAMILY_MEDIUM, FAMILY_SEMIBOLD, color_to_hex, get_contrast_text_color, hover_text,
+    medium_font_id, phosphor_font_id, resolve_color, semibold_font_id, with_alpha,
+};
 
-// ── Design-system constants ───────────────────────────────────────────────────
+// Floating-panel chrome (`--edge`, `--shadow-panel`, `--shadow-menu`,
+// `--shadow-dialog`) also lives in the SDK, so a plugin's panels and the host's
+// pick up identical elevation. Re-exported for `crate::theme::edge_stroke` etc.
+pub use thoth_plugin_sdk::theme::{
+    dialog_shadow, edge_stroke, focus_stroke, glow_shadow, panel_shadow, popover_shadow,
+    slider_thumb_shadow, thumb_shadow,
+};
+
+// Type/metric tokens, so host chrome sizes controls from the same scale the SDK
+// widgets do rather than re-deriving the numbers.
+pub use thoth_plugin_sdk::theme::{
+    FIELD_HEIGHT, FONT_BODY, FONT_CAPTION, FONT_CONTROL, ICON_CONTROL, RADIUS_CHECK, RADIUS_PILL,
+    RADIUS_POPOVER, ROW_HEIGHT,
+};
+
+/// Document-tab height — design `.etabs .tab{height:30px}`. Also drives the pill
+/// radius, which is exactly half of it.
+const TAB_H: f32 = 30.0;
 
 // ── Theme (serialisable hex-string form) ──────────────────────────────────────
 
@@ -291,47 +311,74 @@ impl ThemeColorsExt for ThemeColors {
 
     fn dock_style(&self, egui_style: &egui::Style) -> egui_dock::Style {
         let mut style = egui_dock::Style::from_egui(egui_style);
-        let zero_rounding = egui::CornerRadius::ZERO;
 
-        // ── Tab bar ───────────────────────────────────────────────────────────
-        style.tab_bar.bg_fill = self.bg_sunken;
-        style.tab_bar.height = 28.0;
-        // Side padding on the tab bar strip itself.
+        // ── Tab bar — strip floats on the panel background ───────────────────
+        style.tab_bar.bg_fill = self.bg_panel;
+        style.tab_bar.height = TAB_H;
+        // The strip's fill differs from the dock panel's, so its top corners must
+        // match the panel radius exactly or a sliver of panel fill shows through.
+        style.tab_bar.corner_radius = egui::CornerRadius {
+            nw: RADIUS_PANEL as u8,
+            ne: RADIUS_PANEL as u8,
+            sw: 0,
+            se: 0,
+        };
         style.tab_bar.inner_margin = egui::Margin {
             left: 12,
             right: 12,
             top: 0,
             bottom: 0,
         };
-        style.tab_bar.hline_color = self.surface;
+        // No rule under the strip: design `.etabs` carries no border or shadow —
+        // the editor/dock panel is one unbroken card, and the active tab's own
+        // pill is what separates the strip from the body.
+        style.tab_bar.hline_color = Color32::TRANSPARENT;
 
         // ── Tab body ──────────────────────────────────────────────────────────
         style.tab.tab_body.bg_fill = self.bg;
         style.tab.tab_body.inner_margin = egui::Margin::ZERO;
         style.tab.tab_body.stroke = egui::Stroke::NONE;
 
-        // ── Active / focused tab: top+side accent (bottom covered by egui_dock) ─
-        style.tab.active.bg_fill = self.bg;
+        // Document tabs are *pills* — design `.etabs .tab{border-radius:--r-pill}`,
+        // active filled `surface0` with a hairline edge. This is deliberately not
+        // the underline treatment the in-pane `Tabs` component uses: app-mockup
+        // gives the two tab surfaces different vocabularies (`.etabs .tab` here,
+        // `.rtabs .rtab` there). An outline box around the active tab, which is
+        // what this used to draw, is neither.
+        // A *real* pill is half the tab's height. `RADIUS_PILL as u8` saturates to
+        // 255, which egui clamps when filling — so it still looks round — but
+        // egui_dock also derives its "connect the tab to the body" hline from the
+        // raw corner radius (`min.x + sw ..= max.x - se`). At 255 that range
+        // inverts on any normal-width tab and paints a stray 2px line.
+        let pill = egui::CornerRadius::same((TAB_H / 2.0) as u8);
+        // Design `.tab.active{box-shadow:var(--edge)}` — a hairline, *not* an
+        // accent ring. egui_dock's `from_egui_*` defaults derive `outline_color`
+        // from `widgets.hovered.bg_stroke`, which this theme sets to the accent,
+        // so every state has to be set explicitly or a mauve ring leaks through.
+        let edge = with_alpha(self.surface_raised, 87); // surface1@34%
+
+        // ── Active / focused tab: filled pill with a hairline edge ────────────
+        style.tab.active.bg_fill = self.surface;
         style.tab.active.text_color = self.fg;
-        style.tab.active.outline_color = self.accent;
-        style.tab.active.corner_radius = zero_rounding;
+        style.tab.active.outline_color = edge;
+        style.tab.active.corner_radius = pill;
 
-        style.tab.focused.bg_fill = self.bg;
+        style.tab.focused.bg_fill = self.surface;
         style.tab.focused.text_color = self.fg;
-        style.tab.focused.outline_color = self.accent;
-        style.tab.focused.corner_radius = zero_rounding;
+        style.tab.focused.outline_color = edge;
+        style.tab.focused.corner_radius = pill;
 
-        // ── Inactive tab: no visible border ───────────────────────────────────
-        style.tab.inactive.bg_fill = self.bg_sunken;
+        // ── Inactive tab: bare label on the strip, no chrome at all ───────────
+        style.tab.inactive.bg_fill = Color32::TRANSPARENT;
         style.tab.inactive.text_color = self.fg_muted;
         style.tab.inactive.outline_color = Color32::TRANSPARENT;
-        style.tab.inactive.corner_radius = zero_rounding;
+        style.tab.inactive.corner_radius = pill;
 
         // ── Hovered tab ───────────────────────────────────────────────────────
-        style.tab.hovered.bg_fill = self.surface;
+        style.tab.hovered.bg_fill = with_alpha(self.fg, 20); // text@8%
         style.tab.hovered.text_color = self.fg;
         style.tab.hovered.outline_color = Color32::TRANSPARENT;
-        style.tab.hovered.corner_radius = zero_rounding;
+        style.tab.hovered.corner_radius = pill;
 
         style.tab.inactive_with_kb_focus = style.tab.inactive.clone();
         style.tab.active_with_kb_focus = style.tab.active.clone();
@@ -401,6 +448,47 @@ pub fn apply_fonts(ctx: &egui::Context, settings: &Settings) {
                 list.insert(0, family.clone());
             }
         }
+    }
+
+    // ── Real weight axes ─────────────────────────────────────────────────────
+    // egui resolves a `FontId` to a *family*, with no weight axis, so the design's
+    // `font-weight: 500` / `600` can only be honoured by registering those faces as
+    // named families. Everything that wanted a weight previously faked it by
+    // painting the galley twice a fraction of a pixel apart, which smears at small
+    // sizes and reads heavier than intended.
+    //
+    // The UI face is Inter per the design; a user-chosen `font_family` overrides it.
+    // Each named family always resolves — it falls back to the Proportional stack —
+    // so `medium_font_id`/`semibold_font_id` are safe to call regardless of what is
+    // installed.
+    let ui_family = settings.font_family.as_deref().unwrap_or("Inter");
+    for (name, weight) in [
+        (crate::theme::FAMILY_MEDIUM, fontdb::Weight::MEDIUM),
+        (crate::theme::FAMILY_SEMIBOLD, fontdb::Weight::SEMIBOLD),
+    ] {
+        let stack = match crate::platform::has_weight(ui_family, weight)
+            .then(|| crate::platform::find_font_bytes_weighted(ui_family, weight))
+            .flatten()
+        {
+            Some(bytes) => {
+                let key = format!("{ui_family}-{}", weight.0);
+                fonts.font_data.insert(
+                    key.clone(),
+                    std::sync::Arc::new(egui::FontData::from_owned(bytes)),
+                );
+                vec![key]
+            }
+            // No real face at this weight — alias the family to the normal stack so
+            // callers degrade to regular text rather than to a missing font.
+            None => fonts
+                .families
+                .get(&egui::FontFamily::Proportional)
+                .cloned()
+                .unwrap_or_default(),
+        };
+        fonts
+            .families
+            .insert(egui::FontFamily::Name(name.into()), stack);
     }
 
     ctx.set_fonts(fonts);
@@ -499,6 +587,10 @@ fn build_visuals(dark_mode: bool, c: &ThemeColors) -> egui::Visuals {
 
     // ── Backgrounds ──────────────────────────────────────────────────────────
     v.override_text_color = Some(c.fg);
+    // Content background for `Frame::central_panel` (used inside each dock tab),
+    // so it blends with the floating dock panel's fill. NOT the root canvas —
+    // that is crust and comes from `App::clear_color`; using bg_sunken here would
+    // paint a square crust rect over the dock panel's rounded corners.
     v.panel_fill = c.bg;
     v.window_fill = c.bg_panel; // modal / popup backgrounds
     v.extreme_bg_color = c.surface; // TextEdit / ComboBox text-area background
@@ -537,9 +629,9 @@ fn build_visuals(dark_mode: bool, c: &ThemeColors) -> egui::Visuals {
     v.widgets.active.bg_stroke = egui::Stroke::new(1.0, c.accent);
 
     // ── Windows / popups ─────────────────────────────────────────────────────
-    v.window_stroke = egui::Stroke::new(1.0, c.surface_raised);
-    v.popup_shadow = egui::Shadow::NONE;
-    v.window_shadow = egui::Shadow::NONE;
+    v.window_stroke = edge_stroke(c);
+    v.popup_shadow = dialog_shadow(dark_mode);
+    v.window_shadow = dialog_shadow(dark_mode);
 
     // ── Selection & links ────────────────────────────────────────────────────
     v.selection.bg_fill =

--- a/tests/file_association_tests.rs
+++ b/tests/file_association_tests.rs
@@ -153,9 +153,8 @@ fn thoth_app_picks_up_os_dispatched_file() {
     let _guard = test_guard();
     reset();
 
-    // Launch app with no file (simulates Finder-launched empty window).
-    // Session restore may reopen previously-open tabs, so we don't assert a blank
-    // initial state — that is legitimate behaviour.
+    // Launch app with no file (simulates Finder-launched empty window). A blank
+    // persistent state keeps the test independent of any session on disk.
     let mut app =
         ThothApp::with_persistent_state(Settings::default(), None, PersistentState::blank());
 

--- a/tests/file_association_tests.rs
+++ b/tests/file_association_tests.rs
@@ -136,6 +136,7 @@ fn multiple_drains_only_return_new_items() {
 // ---------------------------------------------------------------------------
 
 use thoth::app::ThothApp;
+use thoth::app::persistent_state::PersistentState;
 use thoth::settings::Settings;
 
 /// Helper: create a temporary JSON file and return its path.
@@ -155,7 +156,8 @@ fn thoth_app_picks_up_os_dispatched_file() {
     // Launch app with no file (simulates Finder-launched empty window).
     // Session restore may reopen previously-open tabs, so we don't assert a blank
     // initial state — that is legitimate behaviour.
-    let mut app = ThothApp::new(Settings::default(), None);
+    let mut app =
+        ThothApp::with_persistent_state(Settings::default(), None, PersistentState::blank());
 
     // Simulate macOS dispatching a file via Apple Event
     let path = make_temp_json_file("os_dispatch.json");
@@ -179,7 +181,11 @@ fn argv_path_still_loads_on_construction() {
     let _guard = test_guard();
     // This guards against regressions: the existing CLI flow must keep working.
     let path = make_temp_json_file("argv_test.json");
-    let mut app = ThothApp::new(Settings::default(), Some(path.clone()));
+    let mut app = ThothApp::with_persistent_state(
+        Settings::default(),
+        Some(path.clone()),
+        PersistentState::blank(),
+    );
     assert_eq!(
         app.window_state
             .tab_manager
@@ -199,7 +205,11 @@ fn second_os_dispatch_replaces_current_file() {
     let p2 = make_temp_json_file("second_file.json");
 
     // App launched with first file via argv
-    let mut app = ThothApp::new(Settings::default(), Some(p1.clone()));
+    let mut app = ThothApp::with_persistent_state(
+        Settings::default(),
+        Some(p1.clone()),
+        PersistentState::blank(),
+    );
     assert!(
         app.window_state
             .tab_manager
@@ -227,7 +237,8 @@ fn os_dispatch_clears_previous_error() {
     let _guard = test_guard();
     reset();
 
-    let mut app = ThothApp::new(Settings::default(), None);
+    let mut app =
+        ThothApp::with_persistent_state(Settings::default(), None, PersistentState::blank());
     // Simulate an error state on the active tab
     if let Some(tab) = app.window_state.tab_manager.active_tab_mut() {
         tab.error = Some(thoth::error::ThothError::Unknown {

--- a/tests/welcome_layout_tests.rs
+++ b/tests/welcome_layout_tests.rs
@@ -1,7 +1,13 @@
 use eframe::egui;
-use thoth::components::welcome::WelcomePanel;
+use thoth::components::welcome::{MARK_GLOW_BLUR, WRAP_MAX_W, WRAP_PAD_X, WelcomePanel};
 
-fn run(size: egui::Vec2, recent: &[String]) -> (Vec<egui::Rect>, egui::Rect) {
+/// `.wrap{max-width:WRAP_MAX_W;margin:0 auto;padding:… WRAP_PAD_X}` — how far the
+/// wrap's content sits from the pane's edge at a given pane width.
+fn wrap_inset(pane_w: f32) -> f32 {
+    (pane_w - pane_w.min(WRAP_MAX_W)) / 2.0 + WRAP_PAD_X
+}
+
+fn run(size: egui::Vec2, recent: &[String]) -> egui::Rect {
     let ctx = egui::Context::default();
     let mut fonts = egui::FontDefinitions::default();
     egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
@@ -11,19 +17,16 @@ fn run(size: egui::Vec2, recent: &[String]) -> (Vec<egui::Rect>, egui::Rect) {
     );
     ctx.set_fonts(fonts);
     let mut shapes_rect = egui::Rect::NOTHING;
-    let mut rects = Vec::new();
     for _ in 0..3 {
         let input = egui::RawInput {
             screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, size)),
             ..Default::default()
         };
-        rects.clear();
         let out = ctx.run_ui(input, |ctx| {
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show_inside(ctx, |ui| {
                     let _ = WelcomePanel::render(ui, recent, None);
-                    rects.push(ui.min_rect());
                 });
         });
         // egui reports an id clash by painting a "🔥 …" debug label.
@@ -48,7 +51,7 @@ fn run(size: egui::Vec2, recent: &[String]) -> (Vec<egui::Rect>, egui::Rect) {
         }
         shapes_rect = union;
     }
-    (rects.clone(), shapes_rect)
+    shapes_rect
 }
 
 #[test]
@@ -59,24 +62,25 @@ fn tall_viewport_centres_the_block() {
         "/tmp/revenue.csv".into(),
     ];
     let size = egui::vec2(1200.0, 900.0);
-    let (_, painted) = run(size, &recent);
-    println!("tall painted = {painted:?}");
+    let painted = run(size, &recent);
     let top_gap = painted.top();
     let bottom_gap = size.y - painted.bottom();
     assert!(
         (top_gap - bottom_gap).abs() < 24.0,
         "block should be vertically centred: top {top_gap} vs bottom {bottom_gap}"
     );
-    // 980-wide wrap centred in a 1200 pane: content starts at 110+44 = 154, and
-    // the mark's 18px glow blur bleeds ~9px to the left of it.
+    // The wrap is centred in the pane; the tolerance is the mark's glow, which
+    // bleeds outwards by up to its blur radius.
+    let inset = wrap_inset(size.x);
+    let tol = f32::from(MARK_GLOW_BLUR);
     assert!(
-        (painted.left() - 154.0).abs() < 12.0,
-        "wrap should be centred horizontally, got left {}",
+        (painted.left() - inset).abs() < tol,
+        "wrap should be centred horizontally at WRAP_MAX_W/WRAP_PAD_X inset {inset}, got left {}",
         painted.left()
     );
     assert!(
-        ((1200.0 - painted.right()) - 154.0).abs() < 12.0,
-        "wrap right edge should mirror the left, got right {}",
+        ((size.x - painted.right()) - inset).abs() < tol,
+        "wrap right edge should mirror the left inset {inset}, got right {}",
         painted.right()
     );
 }
@@ -85,8 +89,7 @@ fn tall_viewport_centres_the_block() {
 fn short_viewport_scrolls_from_the_top() {
     let recent: Vec<String> = vec!["/tmp/a.json".into()];
     let size = egui::vec2(900.0, 320.0);
-    let (_, painted) = run(size, &recent);
-    println!("short painted = {painted:?}");
+    let painted = run(size, &recent);
     assert!(
         painted.top() >= -1.0 && painted.top() < 45.0,
         "content must start at the top when it overflows, got {}",
@@ -96,7 +99,6 @@ fn short_viewport_scrolls_from_the_top() {
 
 #[test]
 fn empty_recent_list_is_fine() {
-    let (_, painted) = run(egui::vec2(700.0, 600.0), &[]);
-    println!("narrow painted = {painted:?}");
+    let painted = run(egui::vec2(700.0, 600.0), &[]);
     assert!(painted.is_positive());
 }

--- a/tests/welcome_layout_tests.rs
+++ b/tests/welcome_layout_tests.rs
@@ -1,0 +1,102 @@
+use eframe::egui;
+use thoth::components::welcome::WelcomePanel;
+
+fn run(size: egui::Vec2, recent: &[String]) -> (Vec<egui::Rect>, egui::Rect) {
+    let ctx = egui::Context::default();
+    let mut fonts = egui::FontDefinitions::default();
+    egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
+    fonts.families.insert(
+        egui::FontFamily::Name("phosphor".into()),
+        vec!["phosphor".into()],
+    );
+    ctx.set_fonts(fonts);
+    let mut shapes_rect = egui::Rect::NOTHING;
+    let mut rects = Vec::new();
+    for _ in 0..3 {
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, size)),
+            ..Default::default()
+        };
+        rects.clear();
+        let out = ctx.run_ui(input, |ctx| {
+            egui::CentralPanel::default()
+                .frame(egui::Frame::NONE)
+                .show_inside(ctx, |ui| {
+                    let _ = WelcomePanel::render(ui, recent, None);
+                    rects.push(ui.min_rect());
+                });
+        });
+        // egui reports an id clash by painting a "🔥 …" debug label.
+        for clipped in &out.shapes {
+            if let egui::Shape::Text(t) = &clipped.shape {
+                assert!(
+                    !t.galley.text().starts_with('🔥'),
+                    "egui debug error painted: {}",
+                    t.galley.text()
+                );
+            }
+        }
+
+        // Union of every painted shape, to see where content actually landed.
+        let mut union = egui::Rect::NOTHING;
+        for prim in ctx.tessellate(out.shapes, out.pixels_per_point) {
+            let bounds = match &prim.primitive {
+                egui::epaint::Primitive::Mesh(m) => m.calc_bounds(),
+                egui::epaint::Primitive::Callback(cb) => cb.rect,
+            };
+            union = union.union(prim.clip_rect.intersect(bounds));
+        }
+        shapes_rect = union;
+    }
+    (rects.clone(), shapes_rect)
+}
+
+#[test]
+fn tall_viewport_centres_the_block() {
+    let recent: Vec<String> = vec![
+        "/tmp/os_dispatch.json".into(),
+        "/tmp/users.ndjson".into(),
+        "/tmp/revenue.csv".into(),
+    ];
+    let size = egui::vec2(1200.0, 900.0);
+    let (_, painted) = run(size, &recent);
+    println!("tall painted = {painted:?}");
+    let top_gap = painted.top();
+    let bottom_gap = size.y - painted.bottom();
+    assert!(
+        (top_gap - bottom_gap).abs() < 24.0,
+        "block should be vertically centred: top {top_gap} vs bottom {bottom_gap}"
+    );
+    // 980-wide wrap centred in a 1200 pane: content starts at 110+44 = 154, and
+    // the mark's 18px glow blur bleeds ~9px to the left of it.
+    assert!(
+        (painted.left() - 154.0).abs() < 12.0,
+        "wrap should be centred horizontally, got left {}",
+        painted.left()
+    );
+    assert!(
+        ((1200.0 - painted.right()) - 154.0).abs() < 12.0,
+        "wrap right edge should mirror the left, got right {}",
+        painted.right()
+    );
+}
+
+#[test]
+fn short_viewport_scrolls_from_the_top() {
+    let recent: Vec<String> = vec!["/tmp/a.json".into()];
+    let size = egui::vec2(900.0, 320.0);
+    let (_, painted) = run(size, &recent);
+    println!("short painted = {painted:?}");
+    assert!(
+        painted.top() >= -1.0 && painted.top() < 45.0,
+        "content must start at the top when it overflows, got {}",
+        painted.top()
+    );
+}
+
+#[test]
+fn empty_recent_list_is_fine() {
+    let (_, painted) = run(egui::vec2(700.0, 600.0), &[]);
+    println!("narrow painted = {painted:?}");
+    assert!(painted.is_positive());
+}

--- a/thoth-plugin-sdk/examples/gallery.rs
+++ b/thoth-plugin-sdk/examples/gallery.rs
@@ -375,9 +375,9 @@ impl Gallery {
                     &[
                         (ButtonColor::Default, "Default"),
                         (ButtonColor::Primary, "Primary"),
-                        (ButtonColor::Secondary, "Secondary"),
                         (ButtonColor::Danger, "Danger"),
                         (ButtonColor::Success, "Success"),
+                        (ButtonColor::Warning, "Warning"),
                     ],
                 );
                 ui.end_row();
@@ -443,9 +443,9 @@ impl Gallery {
             for (c, name) in [
                 (ButtonColor::Default, "Default"),
                 (ButtonColor::Primary, "Primary"),
-                (ButtonColor::Secondary, "Secondary"),
                 (ButtonColor::Danger, "Danger"),
                 (ButtonColor::Success, "Success"),
+                (ButtonColor::Warning, "Warning"),
             ] {
                 ui.add(
                     Button::builder()

--- a/thoth-plugin-sdk/src/components/badge/mod.rs
+++ b/thoth-plugin-sdk/src/components/badge/mod.rs
@@ -166,15 +166,17 @@ impl egui::Widget for Badge {
         };
         let font = self.font_size.unwrap_or(size_font);
         let margin = egui::Margin::symmetric(pad_x, pad_y);
+        // `pill` overrides every variant's own corner; otherwise the soft chip is
+        // the squircle 8px and the filled/outlined ones the tighter 3px.
+        let radius = match (self.pill, self.soft) {
+            (true, _) => RADIUS_PILL,
+            (false, true) => RADIUS_BADGE_SOFT,
+            (false, false) => RADIUS_BADGE,
+        };
 
         if self.soft {
             // A faint tint of the colour behind coloured text (the chip look) —
             // design `.badge.soft`.
-            let radius = if self.pill {
-                RADIUS_PILL
-            } else {
-                RADIUS_BADGE_SOFT
-            };
             egui::Frame::new()
                 .fill(with_alpha(color, SOFT_TINT_ALPHA))
                 .corner_radius(radius)
@@ -184,7 +186,6 @@ impl egui::Widget for Badge {
         } else if self.outlined {
             // Transparent fill, coloured border + coloured monospace text — the
             // schema/structure constraint-tag style (design `.badge.outlined`).
-            let radius = if self.pill { RADIUS_PILL } else { RADIUS_BADGE };
             egui::Frame::new()
                 .stroke(egui::Stroke::new(1.0, color))
                 .corner_radius(radius)
@@ -194,7 +195,6 @@ impl egui::Widget for Badge {
         } else {
             // Design `.badge.filled`: solid fill, auto-contrast text.
             let fg = get_contrast_text_color(color);
-            let radius = if self.pill { RADIUS_PILL } else { RADIUS_BADGE };
             egui::Frame::new()
                 .fill(color)
                 .corner_radius(radius)

--- a/thoth-plugin-sdk/src/components/badge/mod.rs
+++ b/thoth-plugin-sdk/src/components/badge/mod.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::components::Size;
 
+fn default_true() -> bool {
+    true
+}
+
 /// A small colored pill label (e.g. an HTTP method or status tag).
 ///
 /// ```
@@ -34,16 +38,117 @@ pub struct Badge {
     #[builder(default = Size::Small)]
     #[serde(default = "default_badge_size")]
     pub size: Size,
+    /// Optional leading Phosphor glyph, drawn at the label's size with the
+    /// label's colour — design `.dt-badge{gap:5px}` with its `<i class="ph …">`.
+    /// `None` (the default) draws the label alone.
+    #[serde(default)]
+    pub icon: Option<String>,
+    /// Draw the chip fully round ([`RADIUS_PILL`]) instead of the variant's own
+    /// radius — design `.pill`/`.dt-badge{border-radius:999px}`. Defaults to
+    /// `false`, which keeps the filled/outlined 3px and soft 8px corners.
+    ///
+    /// [`RADIUS_PILL`]: crate::theme::RADIUS_PILL
+    #[builder(default)]
+    #[serde(default)]
+    pub pill: bool,
+    /// Render the label in the monospace family. Defaults to `true` — design
+    /// `.badge{font-family:var(--mono)}`. Set `false` for the proportional chips
+    /// (`.pill`, `.dt-badge`), which carry prose rather than a code token.
+    #[builder(default = true)]
+    #[serde(default = "default_true")]
+    pub mono: bool,
+    /// Thicken the label's strokes, standing in for design `.pill`'s
+    /// `font-weight:700`. Defaults to `false`: the base chip's 600 is drawn as
+    /// plain weight, as it always has been.
+    #[builder(default)]
+    #[serde(default)]
+    pub bold: bool,
+    /// Font size override in points; derived from [`size`](Badge::size) when
+    /// unset. Padding still comes from the size preset.
+    #[serde(default, rename = "font-size")]
+    pub font_size: Option<f32>,
 }
 
 fn default_badge_size() -> Size {
     Size::Small
 }
 
+/// Filled and outlined chips — design `.badge.filled`/`.badge.outlined`
+/// (`border-radius:3px`). Below the radius ladder's smallest rung, so the
+/// handoff pins them as raw values.
+#[cfg(feature = "egui")]
+const RADIUS_BADGE: f32 = 3.0;
+/// Soft chips — design `.badge.soft{border-radius:8px}`, the squircle pill.
+#[cfg(feature = "egui")]
+const RADIUS_BADGE_SOFT: f32 = 8.0;
+/// Soft fill tint — design `.badge.soft{background:currentColor@18%}`.
+#[cfg(feature = "egui")]
+const SOFT_TINT_ALPHA: u8 = 46; // 18% of 255
+/// Gap between a leading glyph and the label — design `.dt-badge{gap:5px}`.
+#[cfg(feature = "egui")]
+const ICON_GAP: f32 = 5.0;
+
+#[cfg(feature = "egui")]
+impl Badge {
+    /// The label (and any leading glyph) in `color`, laid out as the chip's
+    /// content. A glyph-less badge is a bare label, exactly as before.
+    fn content(&self, ui: &mut egui::Ui, font: f32, color: egui::Color32) {
+        match self.icon.as_deref().filter(|g| !g.is_empty()) {
+            Some(glyph) => {
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = ICON_GAP;
+                    ui.label(
+                        egui::RichText::new(glyph)
+                            .font(crate::theme::phosphor_font_id(font))
+                            .color(color),
+                    );
+                    self.label(ui, font, color);
+                });
+            }
+            None => self.label(ui, font, color),
+        }
+    }
+
+    /// One run of label text. `bold` thickens it with a second 0.5px-offset
+    /// pass, the same faux-weight trick [`Typography`] uses — egui has no bold
+    /// face to switch to.
+    ///
+    /// [`Typography`]: crate::components::Typography
+    fn label(&self, ui: &mut egui::Ui, font: f32, color: egui::Color32) {
+        let font_id = if self.mono {
+            egui::FontId::monospace(font)
+        } else {
+            egui::FontId::proportional(font)
+        };
+        if self.bold {
+            let galley = ui
+                .painter()
+                .layout_no_wrap(self.label.clone(), font_id, color);
+            let (rect, _) = ui.allocate_exact_size(galley.size(), egui::Sense::hover());
+            if ui.is_rect_visible(rect) {
+                ui.painter()
+                    .galley(rect.min + egui::vec2(0.5, 0.0), galley.clone(), color);
+                ui.painter().galley(rect.min, galley, color);
+            }
+        } else {
+            // `.strong()` is kept for the mono chips that have always carried it,
+            // so their rendering is untouched.
+            ui.label(
+                egui::RichText::new(&self.label)
+                    .font(font_id)
+                    .strong()
+                    .color(color),
+            );
+        }
+    }
+}
+
 #[cfg(feature = "egui")]
 impl egui::Widget for Badge {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
-        use crate::theme::{ThemeColors, get_contrast_text_color, resolve_color};
+        use crate::theme::{
+            RADIUS_PILL, ThemeColors, get_contrast_text_color, resolve_color, with_alpha,
+        };
         let colors = ThemeColors::from_ctx(ui.ctx());
         let color = self
             .color
@@ -54,56 +159,98 @@ impl egui::Widget for Badge {
         // Slim by default; padding + font scale with the size. Vertical padding
         // is 0 at the small size so the pill hugs the text (matches the handoff's
         // 1px-tall enum chip).
-        let (font, pad_x, pad_y): (f32, i8, i8) = match self.size {
+        let (size_font, pad_x, pad_y): (f32, i8, i8) = match self.size {
             Size::Small => (9.0, 6, 0),
             Size::Medium => (10.0, 7, 1),
             Size::Large => (12.0, 9, 2),
         };
+        let font = self.font_size.unwrap_or(size_font);
         let margin = egui::Margin::symmetric(pad_x, pad_y);
 
         if self.soft {
             // A faint tint of the colour behind coloured text (the chip look) —
-            // ~0.18 alpha, matching the handoff.
-            let bg = egui::Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), 46);
+            // design `.badge.soft`.
+            let radius = if self.pill {
+                RADIUS_PILL
+            } else {
+                RADIUS_BADGE_SOFT
+            };
             egui::Frame::new()
-                .fill(bg)
-                .corner_radius(8.0)
+                .fill(with_alpha(color, SOFT_TINT_ALPHA))
+                .corner_radius(radius)
                 .inner_margin(margin)
-                .show(ui, |ui| {
-                    ui.label(
-                        egui::RichText::new(&self.label)
-                            .monospace()
-                            .size(font)
-                            .color(color),
-                    );
-                })
+                .show(ui, |ui| self.content(ui, font, color))
                 .response
         } else if self.outlined {
             // Transparent fill, coloured border + coloured monospace text — the
-            // schema/structure constraint-tag style.
+            // schema/structure constraint-tag style (design `.badge.outlined`).
+            let radius = if self.pill { RADIUS_PILL } else { RADIUS_BADGE };
             egui::Frame::new()
                 .stroke(egui::Stroke::new(1.0, color))
-                .corner_radius(3.0)
+                .corner_radius(radius)
                 .inner_margin(margin)
-                .show(ui, |ui| {
-                    ui.label(
-                        egui::RichText::new(&self.label)
-                            .monospace()
-                            .size(font)
-                            .color(color),
-                    );
-                })
+                .show(ui, |ui| self.content(ui, font, color))
                 .response
         } else {
+            // Design `.badge.filled`: solid fill, auto-contrast text.
             let fg = get_contrast_text_color(color);
+            let radius = if self.pill { RADIUS_PILL } else { RADIUS_BADGE };
             egui::Frame::new()
                 .fill(color)
-                .corner_radius(3.0)
+                .corner_radius(radius)
                 .inner_margin(margin)
-                .show(ui, |ui| {
-                    ui.label(egui::RichText::new(&self.label).size(font).color(fg));
-                })
+                .show(ui, |ui| self.content(ui, font, fg))
                 .response
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Badge;
+    use crate::components::Size;
+    use serde_json::json;
+
+    #[test]
+    fn new_props_default_to_the_original_rendering() {
+        let b = Badge::builder().label("GET").build();
+        assert!(b.icon.is_none(), "no leading glyph by default");
+        assert!(!b.pill, "the 3px/8px corners are still the default");
+        assert!(b.mono, "design pins the badge to the mono family");
+        assert!(!b.bold, "the base chip keeps its plain weight");
+        assert!(b.font_size.is_none(), "font size derives from `size`");
+        assert_eq!(b.size, Size::Small);
+    }
+
+    #[test]
+    fn builder_sets_the_new_props() {
+        let b = Badge::builder()
+            .label("SENSITIVE")
+            .pill(true)
+            .mono(false)
+            .bold(true)
+            .font_size(9.5)
+            .icon("\u{e182}")
+            .build();
+        assert!(b.pill && !b.mono && b.bold);
+        assert_eq!(b.font_size, Some(9.5));
+        assert_eq!(b.icon.as_deref(), Some("\u{e182}"));
+    }
+
+    #[test]
+    fn deserialises_without_the_new_props() {
+        // A plugin built against the older schema must still round-trip.
+        let b: Badge = serde_json::from_value(json!({ "label": "POST" })).unwrap();
+        assert_eq!(b.label, "POST");
+        assert!(b.mono, "the mono default has to survive a missing field");
+        assert!(!b.pill);
+        assert!(b.icon.is_none());
+    }
+
+    #[test]
+    fn font_size_serialises_kebab_case() {
+        let b = Badge::builder().label("x").font_size(9.5).build();
+        let v = serde_json::to_value(&b).unwrap();
+        assert_eq!(v["font-size"], 9.5);
     }
 }

--- a/thoth-plugin-sdk/src/components/breadcrumbs/ui.rs
+++ b/thoth-plugin-sdk/src/components/breadcrumbs/ui.rs
@@ -1,10 +1,65 @@
 use egui::{CursorIcon, RichText};
 
-use crate::theme::ThemeColors;
+use crate::theme::{RADIUS_CHECK, ThemeColors, with_alpha};
 
 use super::Breadcrumbs;
 
+/// Row height — design `.crumbs{height:26px}`.
+const ROW_HEIGHT: f32 = 26.0;
+/// Gap between segments and separators — design `.crumbs{gap:5px}`.
+const GAP: f32 = 5.0;
+/// Horizontal padding of the trail — design `.crumbs{padding:0 8px}`.
+const PADDING_X: i8 = 8;
+/// Segment text size — design `.crumbs{font-size:12px}`.
+const FONT_SIZE: f32 = 12.0;
+/// Separator glyph size — design `.crumbs .sepc{font-size:10px}`.
+const SEPARATOR_SIZE: f32 = 10.0;
+/// Padding inside a segment's hit area — design `.crumbs a{padding:1px 5px}`.
+const SEGMENT_PADDING: egui::Vec2 = egui::vec2(5.0, 1.0);
+/// Hover wash behind a clickable segment — design `text 8%`.
+const HOVER_ALPHA: u8 = 20;
+
 impl Breadcrumbs {
+    /// Paint one segment: `label` inside a small chip-shaped hit area. Clickable
+    /// segments fill on hover (design `.crumbs a:hover`); the `current` one — the
+    /// last — is bold and inert (design `.crumbs .cur`).
+    fn segment(
+        ui: &mut egui::Ui,
+        label: &str,
+        current: bool,
+        colors: &ThemeColors,
+    ) -> egui::Response {
+        let galley = ui.painter().layout_no_wrap(
+            label.to_owned(),
+            egui::FontId::proportional(FONT_SIZE),
+            colors.fg,
+        );
+        let size = galley.size() + SEGMENT_PADDING * 2.0;
+        let sense = if current {
+            egui::Sense::hover()
+        } else {
+            egui::Sense::click()
+        };
+        let (rect, response) = ui.allocate_exact_size(size, sense);
+
+        if ui.is_rect_visible(rect) {
+            if !current && response.hovered() {
+                ui.painter()
+                    .rect_filled(rect, RADIUS_CHECK, with_alpha(colors.fg, HOVER_ALPHA));
+            }
+            let pos = rect.center() - galley.rect.center().to_vec2();
+            if current {
+                // Faux bold (design `.cur{font-weight:700}`): a second pass shifted
+                // half a pixel right thickens the vertical strokes.
+                ui.painter()
+                    .galley(pos + egui::vec2(0.5, 0.0), galley.clone(), colors.fg);
+            }
+            ui.painter().galley(pos, galley, colors.fg);
+        }
+
+        response
+    }
+
     /// Render the breadcrumb trail and report navigation.
     ///
     /// The returned [`egui::InnerResponse::inner`] is `Some(path)` when the user
@@ -18,67 +73,71 @@ impl Breadcrumbs {
         let delim = self.separator.as_deref().unwrap_or(".");
         let mut selected: Option<String> = None;
 
-        let inner = ui.horizontal(|ui| {
-            ui.add_space(8.0);
-            match self.path.as_deref() {
-                None => {
-                    ui.label(
-                        RichText::new("No selection")
-                            .size(12.0)
-                            .color(colors.fg_muted),
-                    );
-                }
-                Some("") => {
-                    ui.label(RichText::new("Root").size(12.0).color(colors.fg));
-                }
-                Some(p) => {
-                    let segments = Self::parse_path(p, delim);
-
-                    // Root is always clickable.
-                    if ui
-                        .link(RichText::new("Root").size(12.0).color(colors.fg))
-                        .on_hover_cursor(CursorIcon::PointingHand)
-                        .clicked()
-                    {
-                        selected = Some(String::new());
-                    }
-
-                    let last = segments.len().saturating_sub(1);
-                    for (i, segment) in segments.iter().enumerate() {
-                        ui.label(
-                            RichText::new(egui_phosphor::regular::CARET_RIGHT)
-                                .size(10.0)
-                                .color(colors.fg_muted),
-                        );
-                        if i == last {
+        let inner = egui::Frame::new()
+            .inner_margin(egui::Margin {
+                left: PADDING_X,
+                right: PADDING_X,
+                top: 0,
+                bottom: 0,
+            })
+            .show(ui, |ui| {
+                ui.set_min_height(ROW_HEIGHT);
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = GAP;
+                    match self.path.as_deref() {
+                        None => {
                             ui.label(
-                                RichText::new(&segment.display)
-                                    .size(12.0)
-                                    .color(colors.fg)
-                                    .strong(),
+                                RichText::new("No selection")
+                                    .size(FONT_SIZE)
+                                    .color(colors.fg_muted),
                             );
-                        } else {
-                            // Navigation emits the RAW path so it round-trips
-                            // with `Breadcrumbs::path`, not the bracketed display.
-                            let path = segments[..=i]
-                                .iter()
-                                .map(|s| s.raw.as_str())
-                                .collect::<Vec<_>>()
-                                .join(delim);
-                            let resp = ui
-                                .link(RichText::new(&segment.display).size(12.0).color(colors.fg))
-                                .on_hover_cursor(CursorIcon::PointingHand);
-                            let resp =
-                                crate::theme::hover_text(resp, format!("Navigate to {path}"));
-                            if resp.clicked() {
-                                selected = Some(path);
+                        }
+                        Some("") => {
+                            Self::segment(ui, "Root", true, &colors);
+                        }
+                        Some(p) => {
+                            let segments = Self::parse_path(p, delim);
+
+                            // Root is always clickable.
+                            if Self::segment(ui, "Root", false, &colors)
+                                .on_hover_cursor(CursorIcon::PointingHand)
+                                .clicked()
+                            {
+                                selected = Some(String::new());
+                            }
+
+                            let last = segments.len().saturating_sub(1);
+                            for (i, segment) in segments.iter().enumerate() {
+                                ui.label(
+                                    RichText::new(egui_phosphor::regular::CARET_RIGHT)
+                                        .size(SEPARATOR_SIZE)
+                                        .color(colors.fg_muted),
+                                );
+                                if i == last {
+                                    Self::segment(ui, &segment.display, true, &colors);
+                                } else {
+                                    // Navigation emits the RAW path so it round-trips
+                                    // with `Breadcrumbs::path`, not the bracketed display.
+                                    let path = segments[..=i]
+                                        .iter()
+                                        .map(|s| s.raw.as_str())
+                                        .collect::<Vec<_>>()
+                                        .join(delim);
+                                    let resp = Self::segment(ui, &segment.display, false, &colors)
+                                        .on_hover_cursor(CursorIcon::PointingHand);
+                                    let resp = crate::theme::hover_text(
+                                        resp,
+                                        format!("Navigate to {path}"),
+                                    );
+                                    if resp.clicked() {
+                                        selected = Some(path);
+                                    }
+                                }
                             }
                         }
                     }
-                    ui.add_space(8.0);
-                }
-            }
-        });
+                });
+            });
 
         egui::InnerResponse::new(selected, inner.response)
     }

--- a/thoth-plugin-sdk/src/components/breadcrumbs/ui.rs
+++ b/thoth-plugin-sdk/src/components/breadcrumbs/ui.rs
@@ -29,10 +29,12 @@ impl Breadcrumbs {
         current: bool,
         colors: &ThemeColors,
     ) -> egui::Response {
+        // `PLACEHOLDER` leaves the colour to the `Painter::galley` calls below —
+        // baking one in here would make that argument a no-op.
         let galley = ui.painter().layout_no_wrap(
             label.to_owned(),
             egui::FontId::proportional(FONT_SIZE),
-            colors.fg,
+            egui::Color32::PLACEHOLDER,
         );
         let size = galley.size() + SEGMENT_PADDING * 2.0;
         let sense = if current {

--- a/thoth-plugin-sdk/src/components/button/mod.rs
+++ b/thoth-plugin-sdk/src/components/button/mod.rs
@@ -13,6 +13,11 @@ pub enum ButtonType {
     Elevated,
     /// Borderless text-only button — for low-emphasis / inline actions.
     Text,
+    /// Tinted button: the semantic colour washes the surface at low opacity and
+    /// carries the label, instead of filling the button solid. Design `.btn.dsoft`
+    /// (a soft [`ButtonColor::Danger`]) — quieter than [`Elevated`](Self::Elevated)
+    /// but still unmistakably coloured.
+    Soft,
 }
 
 /// Preset size of a [`Button`] — an alias of the shared [`Size`](crate::components::Size)
@@ -30,12 +35,23 @@ pub enum ButtonColor {
     Default,
     /// Primary accent — the main call to action.
     Primary,
-    /// Secondary accent — complementary emphasis.
+    /// Legacy alias of [`Primary`](ButtonColor::Primary) — **prefer `Primary`**.
+    ///
+    /// The design system has one accent action colour (lavender) and one neutral
+    /// button (surface + hairline, which is [`Default`](ButtonColor::Default) here,
+    /// and what the sheets call `.btn.secondary`). That leaves this variant with no
+    /// distinct appearance: it resolves to the same lavender as `Primary`.
+    ///
+    /// Kept because `ButtonColor` is serialised in the plugin DSL, so an installed
+    /// plugin may still send `"Secondary"`; removing it would break those.
     Secondary,
     /// Destructive action (delete, discard).
     Danger,
     /// Positive / confirming action.
     Success,
+    /// Cautionary action — reversible but consequential (disable, revoke), where
+    /// [`Danger`](ButtonColor::Danger) would overstate it.
+    Warning,
 }
 
 /// A clickable button.
@@ -160,17 +176,17 @@ mod tests {
 
     #[test]
     fn button_size_small_metrics() {
-        assert_eq!(ButtonSize::Small.metrics(), (11.0, 24.0));
+        assert_eq!(ButtonSize::Small.metrics(), (11.5, 22.0));
     }
 
     #[test]
     fn button_size_medium_metrics() {
-        assert_eq!(ButtonSize::Medium.metrics(), (13.0, 28.0));
+        assert_eq!(ButtonSize::Medium.metrics(), (12.5, 26.0));
     }
 
     #[test]
     fn button_size_large_metrics() {
-        assert_eq!(ButtonSize::Large.metrics(), (15.0, 32.0));
+        assert_eq!(ButtonSize::Large.metrics(), (14.0, 30.0));
     }
 
     // ── serialisation ─────────────────────────────────────────────────────────
@@ -185,6 +201,12 @@ mod tests {
     fn button_type_text_serialises() {
         let s = serde_json::to_string(&ButtonType::Text).unwrap();
         assert_eq!(s, r#""Text""#);
+    }
+
+    #[test]
+    fn button_type_soft_serialises() {
+        let s = serde_json::to_string(&ButtonType::Soft).unwrap();
+        assert_eq!(s, r#""Soft""#);
     }
 
     #[test]

--- a/thoth-plugin-sdk/src/components/button/ui.rs
+++ b/thoth-plugin-sdk/src/components/button/ui.rs
@@ -48,6 +48,21 @@ impl Fill {
     }
 }
 
+/// The theme hue a [`ButtonColor`] role resolves to, or `None` for
+/// [`ButtonColor::Default`], which has no semantic hue: it *is* the neutral
+/// surface button. Shared by the filled and text paths so the two can't drift.
+fn semantic_color(color: ButtonColor, colors: &ThemeColors) -> Option<Color32> {
+    match color {
+        ButtonColor::Default => None,
+        // The design's primary button is lavender, not mauve; `Secondary` shares
+        // it so text buttons keep their lavender label colour.
+        ButtonColor::Primary | ButtonColor::Secondary => Some(colors.accent_secondary),
+        ButtonColor::Danger => Some(colors.error),
+        ButtonColor::Success => Some(colors.success),
+        ButtonColor::Warning => Some(colors.warning),
+    }
+}
+
 /// Everything needed to paint one filled button, resolved from the palette.
 struct Visual {
     fill: Fill,
@@ -61,18 +76,7 @@ struct Visual {
 impl Visual {
     /// Paint recipe for `color`, either solid or as a soft tint over the surface.
     fn resolve(color: ButtonColor, soft: bool, colors: &ThemeColors) -> Self {
-        // `Default` has no semantic hue: it *is* the neutral surface button.
-        let semantic = match color {
-            ButtonColor::Default => None,
-            // The design's primary button is lavender, not mauve; `Secondary`
-            // shares it so text buttons keep their lavender label colour.
-            ButtonColor::Primary | ButtonColor::Secondary => Some(colors.accent_secondary),
-            ButtonColor::Danger => Some(colors.error),
-            ButtonColor::Success => Some(colors.success),
-            ButtonColor::Warning => Some(colors.warning),
-        };
-
-        match (semantic, soft) {
+        match (semantic_color(color, colors), soft) {
             // `.btn.dsoft` — the hue reads in the label, the fill only hints at it.
             (Some(hue), true) => Self {
                 fill: Fill::surface(colors),
@@ -298,16 +302,8 @@ impl egui::Widget for Button {
                         // Text buttons paint with their semantic color; preserve it on
                         // hover — brightened by the same step as a solid fill — instead
                         // of falling back to the default foreground.
-                        let semantic = match self.color {
-                            ButtonColor::Default => None,
-                            ButtonColor::Primary | ButtonColor::Secondary => {
-                                Some(colors.accent_secondary)
-                            }
-                            ButtonColor::Danger => Some(colors.error),
-                            ButtonColor::Success => Some(colors.success),
-                            ButtonColor::Warning => Some(colors.warning),
-                        };
-                        let (normal_color, hover_color) = match semantic {
+                        let (normal_color, hover_color) = match semantic_color(self.color, &colors)
+                        {
                             Some(hue) => (hue, hue.gamma_multiply(HOVER_BRIGHTEN)),
                             None => (colors.fg_muted, colors.fg),
                         };

--- a/thoth-plugin-sdk/src/components/button/ui.rs
+++ b/thoth-plugin-sdk/src/components/button/ui.rs
@@ -1,10 +1,115 @@
-use super::{Button, ButtonColor, ButtonType};
-use crate::theme::{ThemeColors, get_contrast_text_color, phosphor_font_id};
-use egui::{Color32, TextFormat, text::LayoutJob};
+use super::{Button, ButtonColor, ButtonSize, ButtonType};
+use crate::theme::{
+    RADIUS_CONTROL, ThemeColors, edge_stroke, get_contrast_text_color, glow_shadow,
+    phosphor_font_id, with_alpha,
+};
+use egui::{Color32, Shadow, Stroke, TextFormat, text::LayoutJob};
+
+/// Gap between a leading icon and the label — design `.btn{gap:6px}`.
+const ICON_GAP: f32 = 6.0;
+/// Horizontal padding inside a button — design `.btn{padding:0 11px}`.
+const PADDING_X: f32 = 11.0;
+/// …and its compact variant — design `.btn.sm{padding:0 9px}`.
+const PADDING_X_SMALL: f32 = 9.0;
+/// Solid fills brighten on hover — design `.btn.primary:hover{filter:brightness(1.06)}`.
+const HOVER_BRIGHTEN: f32 = 1.06;
+/// …and dim by the same step while held.
+const PRESSED_DIM: f32 = 0.94;
+/// Disabled buttons drop to 42% opacity — design `.btn.disabled{opacity:.42}`.
+const DISABLED_OPACITY: f32 = 0.42;
+/// A soft fill lays 18% of its semantic colour over the resting surface — design
+/// `.btn.dsoft{background:color-mix(in oklab,var(--red) 18%,var(--surface0))}`.
+const SOFT_TINT_ALPHA: u8 = 46; // 18% of 255
+
+/// Background fill of a filled button in each interaction state.
+struct Fill {
+    resting: Color32,
+    hovered: Color32,
+    pressed: Color32,
+}
+
+impl Fill {
+    /// The neutral surface ladder — design `.btn.secondary` and its `:hover`.
+    fn surface(colors: &ThemeColors) -> Self {
+        Self {
+            resting: colors.surface,
+            hovered: colors.surface_raised,
+            pressed: colors.surface_active,
+        }
+    }
+
+    /// A solid semantic fill, brightened on hover and dimmed while pressed.
+    fn solid(color: Color32) -> Self {
+        Self {
+            resting: color,
+            hovered: color.gamma_multiply(HOVER_BRIGHTEN),
+            pressed: color.gamma_multiply(PRESSED_DIM),
+        }
+    }
+}
+
+/// Everything needed to paint one filled button, resolved from the palette.
+struct Visual {
+    fill: Fill,
+    /// Translucent wash laid over `fill` — soft variants only.
+    tint: Option<Color32>,
+    text: Color32,
+    stroke: Stroke,
+    shadow: Option<Shadow>,
+}
+
+impl Visual {
+    /// Paint recipe for `color`, either solid or as a soft tint over the surface.
+    fn resolve(color: ButtonColor, soft: bool, colors: &ThemeColors) -> Self {
+        // `Default` has no semantic hue: it *is* the neutral surface button.
+        let semantic = match color {
+            ButtonColor::Default => None,
+            // The design's primary button is lavender, not mauve; `Secondary`
+            // shares it so text buttons keep their lavender label colour.
+            ButtonColor::Primary | ButtonColor::Secondary => Some(colors.accent_secondary),
+            ButtonColor::Danger => Some(colors.error),
+            ButtonColor::Success => Some(colors.success),
+            ButtonColor::Warning => Some(colors.warning),
+        };
+
+        match (semantic, soft) {
+            // `.btn.dsoft` — the hue reads in the label, the fill only hints at it.
+            (Some(hue), true) => Self {
+                fill: Fill::surface(colors),
+                tint: Some(with_alpha(hue, SOFT_TINT_ALPHA)),
+                text: hue,
+                stroke: Stroke::NONE,
+                shadow: None,
+            },
+            // Solid semantic fill with a matching glow — `.btn.primary` et al.
+            (Some(hue), false) => Self {
+                fill: Fill::solid(hue),
+                tint: None,
+                text: get_contrast_text_color(hue),
+                stroke: Stroke::NONE,
+                shadow: Some(glow_shadow(hue)),
+            },
+            // `.btn.secondary` — surface fill, hairline edge, no glow. A soft
+            // neutral button is the same thing minus the edge.
+            (None, soft) => Self {
+                fill: Fill::surface(colors),
+                tint: None,
+                text: colors.fg,
+                stroke: if soft {
+                    Stroke::NONE
+                } else {
+                    edge_stroke(colors)
+                },
+                shadow: None,
+            },
+        }
+    }
+}
 
 impl Button {
     fn make_layout_job(icon: Option<&str>, label: &str, size: f32, color: Color32) -> LayoutJob {
         let mut job = LayoutJob::default();
+        let mut gap = 0.0;
         if let Some(ic) = icon {
             job.append(
                 ic,
@@ -16,20 +121,12 @@ impl Button {
                     ..Default::default()
                 },
             );
-            job.append(
-                " ",
-                0.0,
-                TextFormat {
-                    font_id: egui::FontId::proportional(size),
-                    color,
-                    valign: egui::Align::Center,
-                    ..Default::default()
-                },
-            );
+            // Design `.btn{gap:6px}` — a real gap, not a space glyph.
+            gap = ICON_GAP;
         }
         job.append(
             label,
-            0.0,
+            gap,
             TextFormat {
                 font_id: egui::FontId::proportional(size),
                 color,
@@ -40,38 +137,61 @@ impl Button {
         job
     }
 
-    fn elevated_button(
+    /// Paint a filled button: optional glow, fill (+ tint), inset edge, label.
+    ///
+    /// `job` must be laid out with [`Color32::PLACEHOLDER`] so the final text
+    /// colour — which depends on the enabled state — can be applied at paint time.
+    fn filled_button(
         ui: &mut egui::Ui,
         job: LayoutJob,
-        bg_color: Color32,
+        visual: Visual,
+        padding_x: f32,
         width: Option<f32>,
         height: Option<f32>,
     ) -> egui::Response {
         let galley = ui.painter().layout_job(job);
         let desired = egui::vec2(
-            width.unwrap_or(galley.size().x + 20.0),
+            width.unwrap_or(galley.size().x + padding_x * 2.0),
             height.unwrap_or(galley.size().y + 10.0),
         );
         let (rect, response) = ui.allocate_exact_size(desired, egui::Sense::click());
 
         if ui.is_rect_visible(rect) {
-            let bg = if !ui.is_enabled() {
-                bg_color.linear_multiply(0.35)
+            let enabled = ui.is_enabled();
+            let fill = if !enabled {
+                visual.fill.resting
             } else if response.is_pointer_button_down_on() {
-                bg_color.linear_multiply(0.75)
+                visual.fill.pressed
             } else if response.hovered() {
-                bg_color.linear_multiply(0.85)
+                visual.fill.hovered
             } else {
-                bg_color
+                visual.fill.resting
             };
-            ui.painter().rect_filled(rect, 4.0, bg);
 
-            let text_color = get_contrast_text_color(bg_color);
+            // Design `.btn.disabled{box-shadow:none}` — the glow drops out; the
+            // 42% fade itself is applied by egui through `disabled_alpha`.
+            if let Some(shadow) = visual.shadow.filter(|_| enabled) {
+                ui.painter().add(shadow.as_shape(rect, RADIUS_CONTROL));
+            }
+            ui.painter().rect_filled(rect, RADIUS_CONTROL, fill);
+            if let Some(tint) = visual.tint {
+                ui.painter().rect_filled(rect, RADIUS_CONTROL, tint);
+            }
+            if visual.stroke != Stroke::NONE {
+                ui.painter().rect_stroke(
+                    rect,
+                    RADIUS_CONTROL,
+                    visual.stroke,
+                    egui::StrokeKind::Inside,
+                );
+            }
+
             let pos = rect.center() - galley.rect.center().to_vec2();
-            // Faux bold: second pass shifted 0.5 px right thickens vertical strokes.
+            // Faux semibold (design `font-weight:600`): a second pass shifted
+            // 0.5 px right thickens vertical strokes.
             ui.painter()
-                .galley(pos + egui::vec2(0.5, 0.0), galley.clone(), text_color);
-            ui.painter().galley(pos, galley, text_color);
+                .galley(pos + egui::vec2(0.5, 0.0), galley.clone(), visual.text);
+            ui.painter().galley(pos, galley, visual.text);
         }
 
         response.on_hover_cursor(egui::CursorIcon::PointingHand)
@@ -143,6 +263,11 @@ impl egui::Widget for Button {
         let size = self.size.unwrap_or(default_font);
         let height = Some(self.height.unwrap_or(default_h));
         let icon = self.icon.as_deref();
+        // Design `.btn.sm` tightens its horizontal padding along with its height.
+        let padding_x = match self.button_size {
+            ButtonSize::Small => PADDING_X_SMALL,
+            _ => PADDING_X,
+        };
         // Full-width buttons stretch to the container's available width.
         let width = if self.full_width {
             Some(ui.available_width())
@@ -150,44 +275,55 @@ impl egui::Widget for Button {
             self.width
         };
 
-        let bg_color = match self.color {
-            ButtonColor::Default => colors.surface_active,
-            ButtonColor::Primary => colors.accent,
-            ButtonColor::Danger => colors.error,
-            ButtonColor::Success => colors.success,
-            ButtonColor::Secondary => colors.accent_secondary,
-        };
-
         let mut response = ui
-            .add_enabled_ui(self.enabled, |ui| match self.button_type {
-                ButtonType::Elevated => {
-                    let text_color = get_contrast_text_color(bg_color);
-                    Self::elevated_button(
-                        ui,
-                        Self::make_layout_job(icon, &self.label, size, text_color),
-                        bg_color,
-                        width,
-                        height,
-                    )
-                }
-                ButtonType::Text => {
-                    // Text buttons paint with their semantic color; preserve it on
-                    // hover instead of falling back to the default foreground.
-                    let hover_color = match self.color {
-                        ButtonColor::Default => colors.fg,
-                        _ => bg_color,
-                    };
-                    Self::text_button(
-                        ui,
-                        &self.label,
-                        icon,
-                        size,
-                        bg_color,
-                        hover_color,
-                        width,
-                        height,
-                    )
-                }
+            .scope(|ui| {
+                // Design `.btn.disabled{opacity:.42}`. egui fades disabled widgets
+                // by `disabled_alpha`, so set the design value here instead of
+                // dimming a second time by hand.
+                ui.visuals_mut().disabled_alpha = DISABLED_OPACITY;
+                ui.add_enabled_ui(self.enabled, |ui| match self.button_type {
+                    ButtonType::Elevated | ButtonType::Soft => {
+                        let soft = self.button_type == ButtonType::Soft;
+                        Self::filled_button(
+                            ui,
+                            // Colour is applied at paint time, not baked in.
+                            Self::make_layout_job(icon, &self.label, size, Color32::PLACEHOLDER),
+                            Visual::resolve(self.color, soft, &colors),
+                            padding_x,
+                            width,
+                            height,
+                        )
+                    }
+                    ButtonType::Text => {
+                        // Text buttons paint with their semantic color; preserve it on
+                        // hover — brightened by the same step as a solid fill — instead
+                        // of falling back to the default foreground.
+                        let semantic = match self.color {
+                            ButtonColor::Default => None,
+                            ButtonColor::Primary | ButtonColor::Secondary => {
+                                Some(colors.accent_secondary)
+                            }
+                            ButtonColor::Danger => Some(colors.error),
+                            ButtonColor::Success => Some(colors.success),
+                            ButtonColor::Warning => Some(colors.warning),
+                        };
+                        let (normal_color, hover_color) = match semantic {
+                            Some(hue) => (hue, hue.gamma_multiply(HOVER_BRIGHTEN)),
+                            None => (colors.fg_muted, colors.fg),
+                        };
+                        Self::text_button(
+                            ui,
+                            &self.label,
+                            icon,
+                            size,
+                            normal_color,
+                            hover_color,
+                            width,
+                            height,
+                        )
+                    }
+                })
+                .inner
             })
             .inner;
 

--- a/thoth-plugin-sdk/src/components/button_group/mod.rs
+++ b/thoth-plugin-sdk/src/components/button_group/mod.rs
@@ -13,12 +13,17 @@ pub struct ButtonGroupItem {
     pub value: String,
     /// The label shown on the segment.
     pub label: String,
+    /// Optional leading icon — a Phosphor glyph drawn 6px before the label,
+    /// per design `.seg .s{gap:6px}`.
+    #[serde(default)]
+    pub icon: Option<String>,
 }
 
 /// A pill-style segmented control — one selection at a time.
 ///
-/// The active segment is filled with `surface_active`; inactive segments are
-/// transparent and highlight on hover. [`ButtonGroups::show`](Self::show) reports
+/// The track is `bg_sunken`; the active segment is a `surface`-filled thumb
+/// lifted off it by a tight shadow, and inactive segments carry muted text that
+/// brightens on hover. [`ButtonGroups::show`](Self::show) reports
 /// the newly-selected value; the plain `egui::Widget` impl discards it.
 ///
 /// ```

--- a/thoth-plugin-sdk/src/components/button_group/ui.rs
+++ b/thoth-plugin-sdk/src/components/button_group/ui.rs
@@ -1,8 +1,22 @@
-use egui::{Align2, Color32, CursorIcon, FontId, Margin, Sense, Widget};
+use egui::{Color32, CursorIcon, Margin, Sense, TextFormat, Widget, text::LayoutJob};
 
-use crate::theme::ThemeColors;
+use crate::theme::{FONT_CONTROL, RADIUS_CHIP, ThemeColors, phosphor_font_id, thumb_shadow};
 
 use super::ButtonGroups;
+
+/// Corner radius of the outer track — design `.seg{border-radius:9px}`. One step
+/// above the segment radius so the selected thumb nests inside it.
+const TRACK_RADIUS: u8 = 9;
+/// Inset between the track and its segments — design `.seg{padding:2px}`.
+const TRACK_PADDING: i8 = 2;
+/// Gap between segments — design `.seg{gap:2px}`.
+const SEGMENT_GAP: f32 = 2.0;
+/// Segment height — design `.seg .s{height:23px}`.
+const SEGMENT_HEIGHT: f32 = 23.0;
+/// Segment horizontal padding — design `.seg .s{padding:0 11px}`.
+const SEGMENT_PADDING_X: f32 = 11.0;
+/// Gap between a segment's icon and its label — design `.seg .s{gap:6px}`.
+const ICON_GAP: f32 = 6.0;
 
 impl ButtonGroups {
     /// Render the segmented control and report the user's selection.
@@ -15,16 +29,18 @@ impl ButtonGroups {
         let colors = ThemeColors::from_ctx(ui.ctx());
         let mut selected: Option<String> = None;
 
+        // Design `.seg` — the track is the deepest background, so the selected
+        // segment reads as a raised thumb sitting in a groove.
         let frame = egui::Frame::new()
-            .fill(colors.bg_panel)
-            .corner_radius(6)
-            .inner_margin(Margin::same(2))
+            .fill(colors.bg_sunken)
+            .corner_radius(TRACK_RADIUS)
+            .inner_margin(Margin::same(TRACK_PADDING))
             .show(ui, |ui| {
-                ui.spacing_mut().item_spacing.x = 2.0;
+                ui.spacing_mut().item_spacing.x = SEGMENT_GAP;
                 ui.horizontal(|ui| {
                     for item in &self.items {
                         let is_active = item.value == self.active;
-                        let response = render_segment(ui, &item.label, is_active, &colors);
+                        let response = render_segment(ui, item, is_active, &colors);
                         if response.clicked() && !is_active {
                             selected = Some(item.value.clone());
                         }
@@ -38,32 +54,49 @@ impl ButtonGroups {
 
 fn render_segment(
     ui: &mut egui::Ui,
-    label: &str,
+    item: &super::ButtonGroupItem,
     is_active: bool,
     colors: &ThemeColors,
 ) -> egui::Response {
-    let font_size = 12.5_f32;
-    let padding = egui::vec2(10.0, 4.0);
-    // Approximate width: proportional fonts average ~0.6× font_size per char.
-    let text_w = label.len() as f32 * font_size * 0.6;
-    let desired = egui::vec2(text_w + padding.x * 2.0, font_size + padding.y * 2.0);
+    // Lay the label out with a placeholder colour so the real one — which depends
+    // on hover, only known after allocation — can be applied at paint time.
+    let mut job = LayoutJob::default();
+    let mut gap = 0.0;
+    if let Some(icon) = item.icon.as_deref() {
+        job.append(
+            icon,
+            0.0,
+            TextFormat {
+                font_id: phosphor_font_id(FONT_CONTROL),
+                color: Color32::PLACEHOLDER,
+                valign: egui::Align::Center,
+                ..Default::default()
+            },
+        );
+        gap = ICON_GAP;
+    }
+    job.append(
+        &item.label,
+        gap,
+        TextFormat {
+            // Design `.seg .s{font-weight:500}` — a real medium face. egui has no
+            // weight axis, so the host registers weight 500 as its own family.
+            font_id: crate::theme::medium_font_id(ui.ctx(), FONT_CONTROL),
+            color: Color32::PLACEHOLDER,
+            valign: egui::Align::Center,
+            ..Default::default()
+        },
+    );
+    let galley = ui.painter().layout_job(job);
 
+    let desired = egui::vec2(galley.size().x + SEGMENT_PADDING_X * 2.0, SEGMENT_HEIGHT);
     let (rect, response) = ui.allocate_exact_size(desired, Sense::click());
 
     if ui.is_rect_visible(rect) {
+        // Design `.seg .s.on` — surface fill lifted off the track by a tight shadow.
         if is_active {
-            ui.painter().rect_filled(rect, 4.0, colors.surface_active);
-        } else if response.hovered() {
-            ui.painter().rect_filled(
-                rect,
-                4.0,
-                Color32::from_rgba_premultiplied(
-                    colors.surface_raised.r(),
-                    colors.surface_raised.g(),
-                    colors.surface_raised.b(),
-                    60,
-                ),
-            );
+            ui.painter().add(thumb_shadow().as_shape(rect, RADIUS_CHIP));
+            ui.painter().rect_filled(rect, RADIUS_CHIP, colors.surface);
         }
 
         let text_color = if is_active || response.hovered() {
@@ -71,13 +104,8 @@ fn render_segment(
         } else {
             colors.fg_muted
         };
-        ui.painter().text(
-            rect.center(),
-            Align2::CENTER_CENTER,
-            label,
-            FontId::proportional(font_size),
-            text_color,
-        );
+        let pos = rect.center() - galley.rect.center().to_vec2();
+        ui.painter().galley(pos, galley, text_color);
     }
 
     if response.hovered() {

--- a/thoth-plugin-sdk/src/components/card/ui.rs
+++ b/thoth-plugin-sdk/src/components/card/ui.rs
@@ -70,9 +70,16 @@ impl Card {
                 ui.horizontal(|ui| {
                     // ── Leading icon ─────────────────────────────────────────
                     if let Some(icon) = &self.icon {
+                        // Zero spacing only *around the tile*, so `ICON_GAP` is the
+                        // whole icon↔content gap. Restored straight after: the row
+                        // and everything nested in it (the title/toggle line, the
+                        // body node) must keep the default gap whether or not this
+                        // card has an icon.
+                        let spacing = ui.spacing().item_spacing.x;
                         ui.spacing_mut().item_spacing.x = 0.0;
                         Self::icon_tile(ui, icon, &colors);
                         ui.add_space(ICON_GAP);
+                        ui.spacing_mut().item_spacing.x = spacing;
                     }
 
                     ui.vertical(|ui| {

--- a/thoth-plugin-sdk/src/components/card/ui.rs
+++ b/thoth-plugin-sdk/src/components/card/ui.rs
@@ -1,9 +1,42 @@
-use egui::{CornerRadius, Layout, RichText};
+use egui::{Align2, CornerRadius, Layout, RichText, Sense};
 
-use crate::components::{Button, ButtonColor, ButtonType, Icon, ToggleSwitch};
-use crate::theme::ThemeColors;
+use crate::components::{
+    Button, ButtonColor, ButtonType, ToggleSwitch, Typography, TypographyVariant,
+};
+use crate::theme::{
+    FONT_BODY, FONT_CAPTION, RADIUS_CONTROL, RADIUS_PANEL, ThemeColors, edge_stroke,
+    phosphor_font_id, with_alpha,
+};
 
 use super::{Card, CardIcon};
+
+/// Inner padding — design `.card{padding:16px}`.
+const PAD: i8 = 16;
+/// Gap between the icon tile and the body — design `.card{gap:12px}`.
+const ICON_GAP: f32 = 12.0;
+/// Leading tile — design `.cicon{width:44px;height:44px;font-size:26px}`.
+const TILE: f32 = 44.0;
+/// Glyph size inside the tile — design `.cicon{font-size:26px}`.
+const TILE_GLYPH: f32 = 26.0;
+/// Tile tint — design `.cicon{background:accent@16%}`.
+const TILE_TINT_ALPHA: u8 = 41; // 16% of 255
+/// Tag chip text — design `.ctag{font-size:10px;font-family:mono}`.
+const FONT_TAG: f32 = 10.0;
+/// Tag chip corner — design `.ctag{border-radius:4px}`. Below the radius ladder's
+/// smallest rung, so it stays a raw value like the badge's 3px chips.
+const TAG_RADIUS: f32 = 4.0;
+/// Gap between tag chips — design `.ctags{gap:5px}`.
+const TAG_GAP: f32 = 5.0;
+/// Meta line — design `.cmeta{color:fg-muted@80%}`.
+const META_ALPHA: u8 = 204; // 80% of 255
+/// Subtitle offset — design `.csub{margin-top:4px}`.
+const GAP_SUB: f32 = 4.0;
+/// Tag / meta block offset — design `.ctags`/`.cmeta{margin-top:9px}`.
+const GAP_BLOCK: f32 = 9.0;
+/// Action row offset — design `.cact{margin-top:12px}`.
+const GAP_ACTIONS: f32 = 12.0;
+/// Gap between action buttons — design `.cact{gap:8px}`.
+const ACTION_GAP: f32 = 8.0;
 
 /// What the user did in a [`Card`] this frame.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -26,52 +59,33 @@ impl Card {
         let colors = ThemeColors::from_ctx(ui.ctx());
         let mut event = None;
 
+        // Design `.card`: a flat surface panel with a hairline edge — no drop
+        // shadow (cards sit *in* the layout, they don't float above it).
         egui::Frame::new()
             .fill(colors.surface)
-            .corner_radius(CornerRadius::same(12))
-            .inner_margin(16.0)
+            .stroke(edge_stroke(&colors))
+            .corner_radius(RADIUS_PANEL)
+            .inner_margin(PAD)
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
                     // ── Leading icon ─────────────────────────────────────────
-                    match &self.icon {
-                        Some(CardIcon::Glyph(glyph)) => {
-                            ui.add(Icon::builder().glyph(glyph.as_str()).size(28.0).build());
-                        }
-                        Some(CardIcon::Image { uri, bytes }) => {
-                            ui.add(
-                                egui::Image::from_bytes(uri.clone(), bytes.clone())
-                                    .fit_to_exact_size(egui::vec2(48.0, 48.0))
-                                    .corner_radius(CornerRadius::same(10)),
-                            );
-                        }
-                        Some(CardIcon::IconFile { path }) => {
-                            let (rect, _) = ui
-                                .allocate_exact_size(egui::vec2(48.0, 48.0), egui::Sense::hover());
-                            if let Some(texture) = crate::components::helpers::load_icon_texture(
-                                ui.ctx(),
-                                std::path::Path::new(path),
-                                "card_icon",
-                            ) {
-                                ui.put(
-                                    rect,
-                                    egui::Image::new(&texture)
-                                        .fit_to_exact_size(rect.size())
-                                        .corner_radius(CornerRadius::same(10)),
-                                );
-                            }
-                        }
-                        None => {}
+                    if let Some(icon) = &self.icon {
+                        ui.spacing_mut().item_spacing.x = 0.0;
+                        Self::icon_tile(ui, icon, &colors);
+                        ui.add_space(ICON_GAP);
                     }
-                    ui.add_space(12.0);
 
                     ui.vertical(|ui| {
                         // ── Title row (+ toggle) ─────────────────────────────
                         ui.horizontal(|ui| {
-                            ui.label(
-                                RichText::new(&self.title)
-                                    .color(colors.fg)
-                                    .size(16.0)
-                                    .strong(),
+                            // `.ctitle` — 16px `fg` at weight 600; egui has no
+                            // font weights, so this goes through Typography's
+                            // faux-bold pass (`Heading` is 16px + bold + `fg`).
+                            ui.add(
+                                Typography::builder()
+                                    .text(self.title.as_str())
+                                    .variant(TypographyVariant::Heading)
+                                    .build(),
                             );
                             if let Some(on) = self.enabled {
                                 ui.with_layout(Layout::right_to_left(egui::Align::Center), |ui| {
@@ -87,45 +101,53 @@ impl Card {
                         });
 
                         if let Some(subtitle) = &self.subtitle {
-                            ui.add_space(4.0);
-                            ui.label(RichText::new(subtitle).color(colors.fg_muted).size(13.0));
+                            ui.add_space(GAP_SUB);
+                            ui.label(
+                                RichText::new(subtitle)
+                                    .color(colors.fg_muted)
+                                    .size(FONT_BODY),
+                            );
                         }
 
                         if !self.tags.is_empty() {
-                            ui.add_space(6.0);
+                            ui.add_space(GAP_BLOCK);
                             ui.horizontal(|ui| {
+                                ui.spacing_mut().item_spacing.x = TAG_GAP;
                                 for tag in &self.tags {
                                     egui::Frame::new()
                                         .fill(colors.surface_raised)
-                                        .corner_radius(4.0)
+                                        .corner_radius(TAG_RADIUS)
                                         .inner_margin(egui::Margin::symmetric(6, 2))
                                         .show(ui, |ui| {
                                             ui.label(
-                                                RichText::new(tag).size(10.0).color(colors.info),
+                                                RichText::new(tag)
+                                                    .monospace()
+                                                    .size(FONT_TAG)
+                                                    .color(colors.syntax_key),
                                             );
                                         });
-                                    ui.add_space(2.0);
                                 }
                             });
                         }
 
                         if let Some(meta) = &self.meta {
-                            ui.add_space(4.0);
+                            ui.add_space(GAP_BLOCK);
                             ui.label(
                                 RichText::new(meta)
-                                    .color(colors.fg_muted.linear_multiply(0.8))
-                                    .size(11.0),
+                                    .color(with_alpha(colors.fg_muted, META_ALPHA))
+                                    .size(FONT_CAPTION),
                             );
                         }
 
                         if let Some(body) = &mut self.body {
-                            ui.add_space(8.0);
+                            ui.add_space(GAP_BLOCK);
                             body.show(ui, events);
                         }
 
                         if !self.actions.is_empty() {
-                            ui.add_space(8.0);
+                            ui.add_space(GAP_ACTIONS);
                             ui.with_layout(Layout::right_to_left(egui::Align::Min), |ui| {
+                                ui.spacing_mut().item_spacing.x = ACTION_GAP;
                                 for (i, action) in self.actions.iter().enumerate().rev() {
                                     let color = if action.danger {
                                         ButtonColor::Danger
@@ -152,5 +174,53 @@ impl Card {
             });
 
         event
+    }
+
+    /// Paint the 44×44 leading tile — design `.cicon`: an accent-tinted square
+    /// behind a centred accent glyph, or the icon image clipped to the same box.
+    fn icon_tile(ui: &mut egui::Ui, icon: &CardIcon, colors: &ThemeColors) {
+        let size = egui::vec2(TILE, TILE);
+        let radius = CornerRadius::same(RADIUS_CONTROL as u8);
+        match icon {
+            CardIcon::Glyph(glyph) => {
+                let (rect, _) = ui.allocate_exact_size(size, Sense::hover());
+                if ui.is_rect_visible(rect) {
+                    ui.painter().rect_filled(
+                        rect,
+                        RADIUS_CONTROL,
+                        with_alpha(colors.accent, TILE_TINT_ALPHA),
+                    );
+                    ui.painter().text(
+                        rect.center(),
+                        Align2::CENTER_CENTER,
+                        glyph,
+                        phosphor_font_id(TILE_GLYPH),
+                        colors.accent,
+                    );
+                }
+            }
+            CardIcon::Image { uri, bytes } => {
+                ui.add(
+                    egui::Image::from_bytes(uri.clone(), bytes.clone())
+                        .fit_to_exact_size(size)
+                        .corner_radius(radius),
+                );
+            }
+            CardIcon::IconFile { path } => {
+                let (rect, _) = ui.allocate_exact_size(size, Sense::hover());
+                if let Some(texture) = crate::components::helpers::load_icon_texture(
+                    ui.ctx(),
+                    std::path::Path::new(path),
+                    "card_icon",
+                ) {
+                    ui.put(
+                        rect,
+                        egui::Image::new(&texture)
+                            .fit_to_exact_size(rect.size())
+                            .corner_radius(radius),
+                    );
+                }
+            }
+        }
     }
 }

--- a/thoth-plugin-sdk/src/components/checkbox/mod.rs
+++ b/thoth-plugin-sdk/src/components/checkbox/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "egui")]
+mod ui;
+
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
@@ -23,19 +26,13 @@ pub struct Checkbox {
     #[builder(default)]
     #[serde(default)]
     pub checked: bool,
+    /// Mixed state — shows a minus glyph instead of a check, and takes
+    /// precedence over [`checked`](Checkbox::checked) while set.
+    #[builder(default)]
+    #[serde(default)]
+    pub indeterminate: bool,
     /// Disable interaction.
     #[builder(default)]
     #[serde(default)]
     pub disabled: bool,
-}
-
-#[cfg(feature = "egui")]
-impl Checkbox {
-    /// Render the checkbox, toggling [`checked`](Checkbox::checked) in place.
-    pub fn show(&mut self, ui: &mut egui::Ui) -> egui::Response {
-        ui.add_enabled(
-            !self.disabled,
-            egui::Checkbox::new(&mut self.checked, &self.label),
-        )
-    }
 }

--- a/thoth-plugin-sdk/src/components/checkbox/ui.rs
+++ b/thoth-plugin-sdk/src/components/checkbox/ui.rs
@@ -1,0 +1,108 @@
+use egui::{Align2, CornerRadius, Rect, Sense, StrokeKind, Vec2};
+
+use crate::theme::{
+    FONT_CONTROL, RADIUS_CHECK, ThemeColors, edge_stroke, get_contrast_text_color, phosphor_font_id,
+};
+
+use super::Checkbox;
+
+/// Box side — design `.cb { width:16px; height:16px }`.
+const BOX_SIZE: f32 = 16.0;
+/// Gap between the box and its label — design `.opt-lbl { gap:8px }`.
+const LABEL_GAP: f32 = 8.0;
+/// Glyph size inside the box — design `.cb { font-size:11px }`.
+const GLYPH_SIZE: f32 = 11.0;
+/// Opacity of a disabled checkbox. The design sheet has no disabled checkbox
+/// variant; match the switch (`.switch.dis { opacity:.4 }`).
+const DISABLED_OPACITY: f32 = 0.4;
+
+impl Checkbox {
+    /// Render the checkbox, toggling [`checked`](Checkbox::checked) in place.
+    pub fn show(&mut self, ui: &mut egui::Ui) -> egui::Response {
+        let colors = ThemeColors::from_ctx(ui.ctx());
+        let interactive = !self.disabled && ui.is_enabled();
+
+        let galley = ui.painter().layout_no_wrap(
+            self.label.clone(),
+            egui::FontId::proportional(FONT_CONTROL),
+            colors.fg,
+        );
+        let label_w = if self.label.is_empty() {
+            0.0
+        } else {
+            LABEL_GAP + galley.size().x
+        };
+        let desired = Vec2::new(BOX_SIZE + label_w, galley.size().y.max(BOX_SIZE));
+
+        // The label is part of the hit area — design wraps both in one `.opt-lbl`.
+        let (rect, mut response) = ui.allocate_exact_size(
+            desired,
+            if interactive {
+                Sense::click()
+            } else {
+                Sense::hover()
+            },
+        );
+        // Clicking a mixed box resolves it, as elsewhere on the platform.
+        if response.clicked() {
+            self.checked = !self.checked;
+            self.indeterminate = false;
+            response.mark_changed();
+        }
+
+        if ui.is_rect_visible(rect) {
+            // Disabled checkboxes fade through a *cloned* painter so the opacity
+            // never leaks into the widgets painted after this one.
+            let mut painter = ui.painter().clone();
+            if !interactive {
+                painter.multiply_opacity(DISABLED_OPACITY);
+            }
+
+            let box_rect = Rect::from_center_size(
+                egui::pos2(rect.left() + BOX_SIZE / 2.0, rect.center().y),
+                Vec2::splat(BOX_SIZE),
+            );
+            let radius = CornerRadius::same(RADIUS_CHECK as u8);
+
+            if self.checked || self.indeterminate {
+                // A filled box drops the hairline edge — design `.cb.on`/`.cb.ind`
+                // both set `box-shadow:none`.
+                painter.rect_filled(box_rect, radius, colors.accent);
+                let glyph = if self.indeterminate {
+                    egui_phosphor::regular::MINUS
+                } else {
+                    egui_phosphor::regular::CHECK
+                };
+                painter.text(
+                    box_rect.center(),
+                    Align2::CENTER_CENTER,
+                    glyph,
+                    phosphor_font_id(GLYPH_SIZE),
+                    get_contrast_text_color(colors.accent),
+                );
+            } else {
+                painter.rect(
+                    box_rect,
+                    radius,
+                    colors.surface,
+                    edge_stroke(&colors),
+                    StrokeKind::Inside,
+                );
+            }
+
+            if !self.label.is_empty() {
+                let text_pos = egui::pos2(
+                    box_rect.right() + LABEL_GAP,
+                    rect.center().y - galley.size().y / 2.0,
+                );
+                painter.galley(text_pos, galley, colors.fg);
+            }
+        }
+
+        if interactive {
+            response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
+        }
+
+        response
+    }
+}

--- a/thoth-plugin-sdk/src/components/code_editor/mod.rs
+++ b/thoth-plugin-sdk/src/components/code_editor/mod.rs
@@ -145,6 +145,11 @@ fn intern(s: &str) -> &'static str {
     leaked
 }
 
+/// Left padding of the code area, inside any run-marker gutter — design
+/// `.code pre{padding:6px 10px 8px 2px}`.
+#[cfg(feature = "egui")]
+const CODE_PADDING_LEFT: i8 = 2;
+
 #[cfg(feature = "egui")]
 impl CodeEditor {
     /// A hash of the syntax word lists that seed the autocomplete trie, so the
@@ -218,17 +223,21 @@ impl CodeEditor {
         } else {
             self.id.clone()
         };
+        // Syntax colours are handed to `egui_code_editor` through its `ColorTheme`
+        // (hex strings), so the design's `.code` mapping lives in the shared
+        // palette helper rather than being patched over the crate here.
         let theme = colors.code_editor_theme();
 
         // A single themed border around the whole editor; the inner `TextEdit`'s
         // own frame/focus stroke is suppressed so it doesn't draw a second border
         // around the code area on hover/selection.
         let stroke = if self.bordered {
-            egui::Stroke::new(1.0, colors.surface_raised)
+            crate::theme::edge_stroke(&colors)
         } else {
             egui::Stroke::NONE
         };
-        // Reserve a left gutter for ▶ run-markers when present.
+        // Reserve a left gutter for ▶ run-markers when present — design
+        // `.code .gutter{flex:0 0 18px}`, absent entirely when there are none.
         let gutter: i8 = if self.run_markers.is_empty() { 0 } else { 18 };
         // Stable id base for marker hit-testing (computed before `id_source` is
         // moved into the editor below). Derived from the `ui` (not a global
@@ -239,13 +248,16 @@ impl CodeEditor {
         let frame_resp = egui::Frame::new()
             .fill(colors.bg)
             .stroke(stroke)
-            .corner_radius(4)
-            // Top padding so the first line sits a little below the border.
+            // Design `.code{border-radius:4px}`, bumped to the control rung of the
+            // radius ladder per the handoff.
+            .corner_radius(crate::theme::RADIUS_CONTROL)
+            // Design `.code pre{padding:6px 10px 8px 2px}`, with the run-marker
+            // gutter (when present) added to the left.
             .inner_margin(egui::Margin {
-                left: gutter,
-                right: 0,
+                left: gutter + CODE_PADDING_LEFT,
+                right: 10,
                 top: 6,
-                bottom: 0,
+                bottom: 8,
             })
             .show(ui, |ui| {
                 ui.set_width(ui.available_width());
@@ -283,8 +295,11 @@ impl CodeEditor {
 
                     let mut editor = Editor::default()
                         .id_source(id_source)
-                        .with_fontsize(self.font_size.unwrap_or(13.0))
+                        .with_fontsize(self.font_size.unwrap_or(crate::theme::FONT_BODY))
                         .with_theme(theme)
+                        // Design `.code`: a bare frame with no line-number gutter
+                        // (the crate shows them by default).
+                        .with_numlines(false)
                         .with_syntax(syntax);
                     if let Some(rows) = self.rows {
                         editor = editor.with_rows(rows);

--- a/thoth-plugin-sdk/src/components/data_row/mod.rs
+++ b/thoth-plugin-sdk/src/components/data_row/mod.rs
@@ -30,6 +30,11 @@ pub struct DataRowIcon {
     /// Colour as a `#rrggbb` hex string; defaults to muted when unset.
     #[serde(default)]
     pub color: Option<String>,
+    /// Glyph size in points. Defaults to the row's body size (13) — design
+    /// `.dr .lead`. A marker rather than an icon takes its own size: the
+    /// design's non-primary-key column dot is `font-size:8px`.
+    #[serde(default)]
+    pub size: Option<f32>,
 }
 
 /// A single tree/data row: indentation, an optional expand caret or leaf
@@ -66,7 +71,8 @@ pub struct DataRow {
     #[serde(default)]
     pub value_token: Option<TextToken>,
     /// Background fill as a `#rrggbb`/`#rrggbbaa` hex string; transparent when
-    /// unset.
+    /// unset. Sits *under* the hover and selection washes, so a zebra stripe
+    /// survives both.
     #[serde(default)]
     pub background: Option<String>,
     /// Search-highlight ranges within the key/value text.
@@ -77,6 +83,12 @@ pub struct DataRow {
     #[builder(default)]
     #[serde(default)]
     pub syntax_highlighting: bool,
+    /// The value is a collapsed-container summary (`{…} (4 keys)`) and is drawn
+    /// muted rather than syntax-coloured — design `.dr .sum`. On a key-less row
+    /// (no `key: value` split) the whole text is treated as the summary.
+    #[builder(default)]
+    #[serde(default)]
+    pub summary_value: bool,
     /// Indentation depth (multiplied by a fixed step).
     #[builder(default)]
     #[serde(default)]
@@ -91,6 +103,14 @@ pub struct DataRow {
     /// Optional right-aligned muted text (e.g. a count or type).
     #[serde(default)]
     pub trailing: Option<String>,
+    /// Optional small chip drawn immediately *after* the row's text — design
+    /// `.dr .tybadge`: a surface-filled 9.5pt muted tag for a column's type.
+    ///
+    /// Distinct from [`trailing`](DataRow::trailing), which pins its text to the
+    /// row's right edge: a schema row wants both at once (`name [text]  … 14
+    /// tables`).
+    #[serde(default)]
+    pub chip: Option<String>,
     /// Optional right-aligned action icon (a Phosphor glyph). Clicking it reports
     /// [`DataRowOutput::action_clicked`] instead of a row click — e.g. an
     /// "open structure" affordance on a table row.

--- a/thoth-plugin-sdk/src/components/data_row/ui.rs
+++ b/thoth-plugin-sdk/src/components/data_row/ui.rs
@@ -4,13 +4,39 @@ use egui::{Color32, RichText, Ui, WidgetText, text::LayoutJob};
 
 use crate::components::IconButton;
 use crate::theme::{
-    ROW_HEIGHT, TextPalette, ThemeColors, hover_row_bg, phosphor_font_id, resolve_color,
+    FONT_BODY, FONT_CAPTION, RADIUS_CHECK, RADIUS_CHIP, ROW_HEIGHT, TextPalette, TextToken,
+    ThemeColors, phosphor_font_id, resolve_color, with_alpha,
 };
 
 use super::DataRow;
 
-/// Indentation step per tree depth level, in logical pixels.
+/// Indentation step per tree depth level — design nests a depth-1 row to
+/// `padding-left:24px`, i.e. 16px past the row's own 8px padding.
 const INDENT_STEP: f32 = 16.0;
+/// Horizontal row padding — design `.dr{padding:0 8px}`.
+const ROW_PAD_X: i8 = 8;
+/// Gap between the row's parts (caret, icon, key, `:`, value) — design
+/// `.dr{gap:5px}`.
+const PART_GAP: f32 = 5.0;
+/// Caret slot width; the glyph is centred in it — design `.dr .car{width:13px}`.
+const CARET_SLOT: f32 = 13.0;
+/// Row text size — design `.tree{font-size:12px}`, inherited by `.dr`.
+const ROW_FONT: f32 = 12.0;
+/// Gap before the trailing metadata — design `.dr .trail{padding-left:14px}`.
+const TRAIL_PAD: f32 = 14.0;
+/// Hover wash — design `.dr:hover{background:text 7%}`.
+const HOVER_ALPHA: u8 = 18;
+/// Selection wash — design `.dr.sel{background:accent 16%}`.
+const SELECT_ALPHA: u8 = 41;
+/// Search-highlight wash — design `.dr .hl{background:accent2 34%}`.
+const HIGHLIGHT_ALPHA: u8 = 87;
+/// Inline type chip — design `.dr .tybadge{font-size:9.5px}`…
+const CHIP_FONT: f32 = 9.5;
+/// …`padding:1px 5px`…
+const CHIP_PAD_X: f32 = 5.0;
+const CHIP_PAD_Y: f32 = 1.0;
+/// …and `margin-left:6px`, i.e. one point past the row's own 5px part gap.
+const CHIP_MARGIN: f32 = 6.0;
 
 /// Outcome of rendering a [`DataRow`].
 pub struct DataRowOutput {
@@ -27,8 +53,9 @@ pub struct DataRowOutput {
 }
 
 impl DataRow {
-    /// Render the row and report interaction.
+    /// Render the row and report interaction. Design `.dr`.
     pub fn show(&self, ui: &mut Ui) -> DataRowOutput {
+        let colors = ThemeColors::from_ctx(ui.ctx());
         let palette = TextPalette::from_ctx(ui.ctx());
 
         let mut parts = self.display_text.splitn(2, ':');
@@ -44,208 +71,304 @@ impl DataRow {
         );
         let resp = ui.interact(interact_rect, id, egui::Sense::click());
 
-        let colors = ThemeColors::from_ctx(ui.ctx());
-        let caller_bg = self
+        // The washes composite bottom-up: the caller's fill (a JsonTree zebra
+        // stripe, say) sits under the selection wash, which sits under hover —
+        // so a striped row still reads as selected and as hovered.
+        let mut background = self
             .background
             .as_deref()
             .and_then(|c| resolve_color(c, &colors))
             .unwrap_or(Color32::TRANSPARENT);
-        let base_bg = if self.selected {
-            ui.visuals().selection.bg_fill
-        } else {
-            caller_bg
-        };
+        if self.selected {
+            background = blend_colors(background, with_alpha(colors.accent, SELECT_ALPHA));
+        }
         let hovered = resp.hovered() || ui.rect_contains_pointer(interact_rect);
-        let background = if hovered {
-            blend_colors(base_bg, hover_row_bg(ui))
-        } else {
-            base_bg
-        };
+        if hovered {
+            background = blend_colors(background, with_alpha(colors.fg, HOVER_ALPHA));
+        }
 
-        let highlight_bg = ui.visuals().selection.bg_fill;
-        let highlight_fg = ui.visuals().strong_text_color();
-        let base_text_color = ui.visuals().text_color();
-        let muted = ui.visuals().weak_text_color();
+        let highlight_bg = with_alpha(colors.accent_secondary, HIGHLIGHT_ALPHA);
+        let highlight_fg = colors.fg;
+        let base_text_color = colors.fg;
+        let muted = colors.fg_muted;
 
         let mut caret_clicked = false;
         let mut action_clicked = false;
         let mut body_clicked = false;
         let mut body_secondary = false;
 
-        egui::Frame::new().fill(background).show(ui, |ui| {
-            ui.set_min_width(ui.available_width());
-            ui.horizontal(|ui| {
-                if self.indent > 0 {
-                    ui.add_space(self.indent as f32 * INDENT_STEP);
-                }
+        egui::Frame::NONE
+            .fill(background)
+            .corner_radius(RADIUS_CHIP)
+            .inner_margin(egui::Margin::symmetric(ROW_PAD_X, 0))
+            .show(ui, |ui| {
+                ui.set_min_width(ui.available_width());
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = PART_GAP;
+                    if self.indent > 0 {
+                        // The layout gap that follows completes the indent step.
+                        ui.add_space(self.indent as f32 * INDENT_STEP - PART_GAP);
+                    }
 
-                match self.caret {
-                    Some(expanded) => {
-                        let glyph = if expanded {
-                            egui_phosphor::regular::CARET_DOWN
-                        } else {
-                            egui_phosphor::regular::CARET_RIGHT
-                        };
-                        let clicked = ui
-                            .add(
-                                IconButton::builder()
-                                    .icon(glyph)
-                                    .tooltip(if expanded { "Collapse" } else { "Expand" })
-                                    .build(),
-                            )
-                            .clicked();
-                        if clicked {
-                            caret_clicked = true;
+                    // Design `.dr .car`: a fixed 13px slot with the glyph centred in
+                    // it, so leaf rows line up under their parent's caret.
+                    let caret_slot = egui::vec2(CARET_SLOT, ROW_HEIGHT);
+                    match self.caret {
+                        Some(expanded) => {
+                            let glyph = if expanded {
+                                egui_phosphor::regular::CARET_DOWN
+                            } else {
+                                egui_phosphor::regular::CARET_RIGHT
+                            };
+                            let (rect, caret_resp) =
+                                ui.allocate_exact_size(caret_slot, egui::Sense::click());
+                            ui.painter().text(
+                                rect.center(),
+                                egui::Align2::CENTER_CENTER,
+                                glyph,
+                                phosphor_font_id(FONT_CAPTION),
+                                muted,
+                            );
+                            if caret_resp.clicked() {
+                                caret_clicked = true;
+                            }
+                        }
+                        // Leaf row: the slot is reserved but left empty.
+                        None => {
+                            ui.allocate_exact_size(caret_slot, egui::Sense::hover());
                         }
                     }
-                    None => {
-                        // Aligned, invisible spacer so leaf rows line up with caret rows.
-                        ui.add_enabled_ui(false, |ui| {
-                            ui.visuals_mut().widgets.inactive.bg_fill = Color32::TRANSPARENT;
-                            ui.visuals_mut().widgets.inactive.weak_bg_fill = Color32::TRANSPARENT;
-                            ui.add(IconButton::builder().icon(" ").build());
-                        });
-                    }
-                }
 
-                if let Some(icon) = &self.leading_icon {
-                    let color = icon
-                        .color
-                        .as_deref()
-                        .and_then(|c| resolve_color(c, &colors))
-                        .unwrap_or(muted);
-                    body_label(
-                        ui,
-                        RichText::new(&icon.glyph)
-                            .font(phosphor_font_id(13.0))
-                            .color(color)
-                            .into(),
-                        false,
-                        &mut body_clicked,
-                        &mut body_secondary,
-                    );
-                    ui.add_space(4.0);
-                }
-
-                let key_label_text = format!("{}{}", key_part, if has_colon { ":" } else { "" });
-                let key_color = palette.color_with_highlighting(
-                    self.key_token,
-                    self.syntax_highlighting,
-                    base_text_color,
-                );
-                let key_label = highlighted_text(
-                    ui,
-                    &key_label_text,
-                    key_color,
-                    &self.highlights.key_ranges,
-                    highlight_bg,
-                    highlight_fg,
-                );
-
-                let value_label = self.value_token.map(|value_token| {
-                    let value_color = palette.color_with_highlighting(
-                        value_token,
-                        self.syntax_highlighting,
-                        base_text_color,
-                    );
-                    highlighted_text(
-                        ui,
-                        value_part,
-                        value_color,
-                        &self.highlights.value_ranges,
-                        highlight_bg,
-                        highlight_fg,
-                    )
-                });
-
-                // Trailing count + action, added right-to-left so they pin to the
-                // right edge. Flags are passed in (not captured) so the label/
-                // truncate code below can still borrow them.
-                let action_icon = self.action_icon.clone();
-                let action_tooltip = self.action_tooltip.clone();
-                let trailing_text = self.trailing.clone();
-                let render_trailing = |ui: &mut Ui, bc: &mut bool, bs: &mut bool| -> bool {
-                    let mut clicked = false;
-                    if let Some(glyph) = &action_icon {
-                        clicked = ui
-                            .add(
-                                IconButton::builder()
-                                    .icon(glyph.as_str())
-                                    .maybe_tooltip(action_tooltip.clone())
-                                    .build(),
-                            )
-                            .clicked();
-                    }
-                    if let Some(t) = &trailing_text {
+                    if let Some(icon) = &self.leading_icon {
+                        let color = icon
+                            .color
+                            .as_deref()
+                            .and_then(|c| resolve_color(c, &colors))
+                            .unwrap_or(muted);
                         body_label(
                             ui,
-                            RichText::new(t).color(muted).size(11.0).into(),
+                            RichText::new(&icon.glyph)
+                                .font(phosphor_font_id(icon.size.unwrap_or(FONT_BODY)))
+                                .color(color)
+                                .into(),
                             false,
-                            bc,
-                            bs,
-                        );
-                    }
-                    clicked
-                };
-
-                if self.truncate {
-                    // Full-width row: pin trailing/action right, and truncate the
-                    // key/value in the middle with an ellipsis so nothing bleeds.
-                    let remaining = egui::vec2(ui.available_width(), ROW_HEIGHT);
-                    ui.allocate_ui_with_layout(
-                        remaining,
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| {
-                            if render_trailing(ui, &mut body_clicked, &mut body_secondary) {
-                                action_clicked = true;
-                            }
-                            ui.with_layout(
-                                egui::Layout::left_to_right(egui::Align::Center),
-                                |ui| {
-                                    ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
-                                    body_label(
-                                        ui,
-                                        key_label,
-                                        true,
-                                        &mut body_clicked,
-                                        &mut body_secondary,
-                                    );
-                                    if let Some(value_label) = value_label {
-                                        body_label(
-                                            ui,
-                                            value_label,
-                                            true,
-                                            &mut body_clicked,
-                                            &mut body_secondary,
-                                        );
-                                    }
-                                },
-                            );
-                        },
-                    );
-                } else {
-                    // Extend: key/value keep their full width (so a horizontally
-                    // scrolling container can reveal long JSON), trailing after.
-                    body_label(ui, key_label, true, &mut body_clicked, &mut body_secondary);
-                    if let Some(value_label) = value_label {
-                        body_label(
-                            ui,
-                            value_label,
-                            true,
                             &mut body_clicked,
                             &mut body_secondary,
                         );
                     }
-                    if action_icon.is_some() || trailing_text.is_some() {
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            if render_trailing(ui, &mut body_clicked, &mut body_secondary) {
-                                action_clicked = true;
-                            }
-                        });
+
+                    let key_color = if self.summary_value && !has_colon {
+                        // A key-less collapsed container — the whole row is summary.
+                        muted
+                    } else {
+                        palette.color_with_highlighting(
+                            self.key_token,
+                            self.syntax_highlighting,
+                            base_text_color,
+                        )
+                    };
+                    let key_label = highlighted_text(
+                        key_part,
+                        key_color,
+                        &self.highlights.key_ranges,
+                        highlight_bg,
+                        highlight_fg,
+                    );
+
+                    // The separator is its own punctuation-coloured part — design
+                    // `<span class="k">key</span><span class="p">:</span>`.
+                    let colon_label = has_colon.then(|| {
+                        let color = palette.color_with_highlighting(
+                            TextToken::Bracket,
+                            self.syntax_highlighting,
+                            base_text_color,
+                        );
+                        mono_text(":", color)
+                    });
+
+                    // `display_text` separates key and value with `": "`; the 5px
+                    // part gap replaces that space, so drop it and shift the
+                    // caller's highlight ranges (byte offsets into the untrimmed
+                    // value) by as much.
+                    let trimmed = value_part.len() - value_part.trim_start().len();
+                    let value_text = &value_part[trimmed..];
+                    let value_ranges: Vec<std::ops::Range<usize>> = self
+                        .highlights
+                        .value_ranges
+                        .iter()
+                        .map(|r| r.start.saturating_sub(trimmed)..r.end.saturating_sub(trimmed))
+                        .collect();
+                    let value_label =
+                        self.value_token
+                            .filter(|_| !value_text.is_empty())
+                            .map(|value_token| {
+                                let value_color = if self.summary_value {
+                                    // Design `.dr .sum` — a collapsed-container summary
+                                    // reads as metadata, not as a value token.
+                                    muted
+                                } else {
+                                    palette.color_with_highlighting(
+                                        value_token,
+                                        self.syntax_highlighting,
+                                        base_text_color,
+                                    )
+                                };
+                                highlighted_text(
+                                    value_text,
+                                    value_color,
+                                    &value_ranges,
+                                    highlight_bg,
+                                    highlight_fg,
+                                )
+                            });
+
+                    // Inline type chip — design `.dr .tybadge`. Laid out up front
+                    // so its width can be reserved *before* the row's text
+                    // truncates, otherwise a long name would push it off the row.
+                    let chip = self
+                        .chip
+                        .as_deref()
+                        .filter(|t| !t.is_empty())
+                        .map(|t| chip_galley(ui, t, muted));
+
+                    // Trailing count + action, added right-to-left so they pin to the
+                    // right edge. Flags are passed in (not captured) so the label/
+                    // truncate code below can still borrow them.
+                    let action_icon = self.action_icon.clone();
+                    let action_tooltip = self.action_tooltip.clone();
+                    let trailing_text = self.trailing.clone();
+                    let render_trailing = |ui: &mut Ui, bc: &mut bool, bs: &mut bool| -> bool {
+                        let mut clicked = false;
+                        if let Some(glyph) = &action_icon {
+                            clicked = ui
+                                .add(
+                                    IconButton::builder()
+                                        .icon(glyph.as_str())
+                                        .maybe_tooltip(action_tooltip.clone())
+                                        .build(),
+                                )
+                                .clicked();
+                        }
+                        if let Some(t) = &trailing_text {
+                            body_label(
+                                ui,
+                                RichText::new(t)
+                                    .font(egui::FontId::monospace(FONT_CAPTION))
+                                    .color(muted)
+                                    .into(),
+                                false,
+                                bc,
+                                bs,
+                            );
+                            // Design `.dr .trail{padding-left:14px}` — laid out
+                            // right-to-left, so this space lands to its left.
+                            ui.add_space(TRAIL_PAD - PART_GAP);
+                        }
+                        clicked
+                    };
+
+                    if self.truncate {
+                        // Full-width row: pin trailing/action right, and truncate the
+                        // key/value in the middle with an ellipsis so nothing bleeds.
+                        let remaining = egui::vec2(ui.available_width(), ROW_HEIGHT);
+                        ui.allocate_ui_with_layout(
+                            remaining,
+                            egui::Layout::right_to_left(egui::Align::Center),
+                            |ui| {
+                                if render_trailing(ui, &mut body_clicked, &mut body_secondary) {
+                                    action_clicked = true;
+                                }
+                                ui.with_layout(
+                                    egui::Layout::left_to_right(egui::Align::Center),
+                                    |ui| {
+                                        ui.style_mut().wrap_mode =
+                                            Some(egui::TextWrapMode::Truncate);
+                                        let text = |ui: &mut Ui| {
+                                            body_label(
+                                                ui,
+                                                key_label,
+                                                true,
+                                                &mut body_clicked,
+                                                &mut body_secondary,
+                                            );
+                                            if let Some(colon_label) = colon_label {
+                                                body_label(
+                                                    ui,
+                                                    colon_label,
+                                                    true,
+                                                    &mut body_clicked,
+                                                    &mut body_secondary,
+                                                );
+                                            }
+                                            if let Some(value_label) = value_label {
+                                                body_label(
+                                                    ui,
+                                                    value_label,
+                                                    true,
+                                                    &mut body_clicked,
+                                                    &mut body_secondary,
+                                                );
+                                            }
+                                        };
+                                        match chip {
+                                            Some(chip) => {
+                                                // Cap the text at what's left once
+                                                // the chip has its room, so the
+                                                // ellipsis lands before it rather
+                                                // than shoving it off the row.
+                                                let room = (ui.available_width()
+                                                    - chip_width(&chip))
+                                                .max(0.0);
+                                                ui.horizontal(|ui| {
+                                                    ui.set_max_width(room);
+                                                    text(ui);
+                                                });
+                                                chip_label(ui, chip, muted, &colors);
+                                            }
+                                            None => text(ui),
+                                        }
+                                    },
+                                );
+                            },
+                        );
+                    } else {
+                        // Extend: key/value keep their full width (so a horizontally
+                        // scrolling container can reveal long JSON), trailing after.
+                        body_label(ui, key_label, true, &mut body_clicked, &mut body_secondary);
+                        if let Some(colon_label) = colon_label {
+                            body_label(
+                                ui,
+                                colon_label,
+                                true,
+                                &mut body_clicked,
+                                &mut body_secondary,
+                            );
+                        }
+                        if let Some(value_label) = value_label {
+                            body_label(
+                                ui,
+                                value_label,
+                                true,
+                                &mut body_clicked,
+                                &mut body_secondary,
+                            );
+                        }
+                        if let Some(chip) = chip {
+                            chip_label(ui, chip, muted, &colors);
+                        }
+                        if action_icon.is_some() || trailing_text.is_some() {
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    if render_trailing(ui, &mut body_clicked, &mut body_secondary) {
+                                        action_clicked = true;
+                                    }
+                                },
+                            );
+                        }
                     }
-                }
+                });
             });
-        });
 
         if hovered {
             ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
@@ -308,8 +431,54 @@ fn blend_colors(background: Color32, overlay: Color32) -> Color32 {
     )
 }
 
+/// Lay out an inline type chip's label — design `.dr .tybadge`, a proportional
+/// 9.5pt run (it carries a type name, not a code token).
+fn chip_galley(ui: &Ui, text: &str, color: Color32) -> Arc<egui::Galley> {
+    ui.painter().layout_no_wrap(
+        text.to_owned(),
+        egui::FontId::proportional(CHIP_FONT),
+        color,
+    )
+}
+
+/// Total width an inline chip occupies, including the extra point of left margin
+/// it carries over the row's part gap.
+fn chip_width(galley: &egui::Galley) -> f32 {
+    galley.size().x + CHIP_PAD_X * 2.0 + (CHIP_MARGIN - PART_GAP)
+}
+
+/// Draw the chip: a surface-filled tag riding just after the row's text. The
+/// design's radius (4px) is below the ladder's smallest rung, so the nearest one
+/// ([`RADIUS_CHECK`]) stands in.
+fn chip_label(ui: &mut Ui, galley: Arc<egui::Galley>, color: Color32, colors: &ThemeColors) {
+    // `.tybadge{margin-left:6px}` is one point more than the row's 5px part gap,
+    // so the chip carries the extra point inside its own allocation.
+    let lead = CHIP_MARGIN - PART_GAP;
+    let pad = egui::vec2(CHIP_PAD_X, CHIP_PAD_Y);
+    let size = galley.size() + pad * 2.0 + egui::vec2(lead, 0.0);
+    let (rect, _) = ui.allocate_exact_size(size, egui::Sense::hover());
+    if ui.is_rect_visible(rect) {
+        let chip = egui::Rect::from_min_size(
+            rect.min + egui::vec2(lead, 0.0),
+            rect.size() - egui::vec2(lead, 0.0),
+        );
+        ui.painter().rect_filled(chip, RADIUS_CHECK, colors.surface);
+        ui.painter().galley(chip.min + pad, galley, color);
+    }
+}
+
+/// One row part in the design's monospace row font.
+fn mono_text(text: &str, color: Color32) -> WidgetText {
+    RichText::new(text)
+        .font(egui::FontId::monospace(ROW_FONT))
+        .color(color)
+        .into()
+}
+
+/// A row part with the caller's search matches washed in `highlight_bg` —
+/// design `.dr .hl`. `TextFormat::expand_bg` defaults to the design's 1px
+/// horizontal padding.
 fn highlighted_text(
-    ui: &Ui,
     text: &str,
     base_color: Color32,
     ranges: &[std::ops::Range<usize>],
@@ -317,18 +486,17 @@ fn highlighted_text(
     highlight_fg: Color32,
 ) -> WidgetText {
     if text.is_empty() || ranges.is_empty() {
-        return RichText::new(text).monospace().color(base_color).into();
+        return mono_text(text, base_color);
     }
 
     let mut job = LayoutJob::default();
-    let font_size = ui.style().text_styles[&egui::TextStyle::Monospace].size;
     let base_format = egui::TextFormat {
-        font_id: egui::FontId::monospace(font_size),
+        font_id: egui::FontId::monospace(ROW_FONT),
         color: base_color,
         ..Default::default()
     };
     let highlight_format = egui::TextFormat {
-        font_id: egui::FontId::monospace(font_size),
+        font_id: egui::FontId::monospace(ROW_FONT),
         color: highlight_fg,
         background: highlight_bg,
         ..Default::default()

--- a/thoth-plugin-sdk/src/components/data_view/mod.rs
+++ b/thoth-plugin-sdk/src/components/data_view/mod.rs
@@ -263,16 +263,22 @@ impl DataView {
                 }
             }
 
-            // `copy` is handled in-widget (no plugin round-trip).
-            ui.add(
-                Button::builder()
-                    .label("Copy")
-                    .icon(egui_phosphor::regular::COPY)
-                    .button_type(ButtonType::Text)
-                    .hover_text("Copy as JSON")
-                    .copy(records_json(page, true))
-                    .build(),
-            );
+            // Copy is handled in-widget (no plugin round-trip). Serialised on the
+            // click rather than through `Button::copy`, which would re-encode the
+            // whole page into a String every frame just to have it ready.
+            if ui
+                .add(
+                    Button::builder()
+                        .label("Copy")
+                        .icon(egui_phosphor::regular::COPY)
+                        .button_type(ButtonType::Text)
+                        .hover_text("Copy as JSON")
+                        .build(),
+                )
+                .clicked()
+            {
+                ui.ctx().copy_text(records_json(page, true));
+            }
         });
     }
 
@@ -292,9 +298,13 @@ impl DataView {
         use crate::dataset::{PluginRenderResult, render_with_plugin};
         use crate::render_node::RenderNode;
 
-        egui::ScrollArea::both()
-            .id_salt((node_id, "data_view_scroll"))
-            .show(ui, |ui| match view {
+        // The grid scrolls itself: `TableView` wraps it in a horizontal scroll area
+        // and `TableBuilder::body.rows` virtualises vertically off *its* viewport.
+        // Nesting it in the body's own scroll area would hand it an infinite
+        // viewport, and it would lay out every row of the page instead of the
+        // visible ones. Every other view is plain content, and scrolls here.
+        scrolled(ui, !table_view(view), (node_id, "data_view_scroll"), |ui| {
+            match view {
                 "json" => {
                     JsonTree::builder()
                         .id(format!("{node_id}_tree"))
@@ -321,9 +331,7 @@ impl DataView {
                 // interactions are discarded rather than routed to the producer.
                 plugin if plugin.starts_with("plugin:") => {
                     match render_with_plugin(&plugin["plugin:".len()..], &self.handle) {
-                        PluginRenderResult::Rendered(mut node) => {
-                            node.show(ui, &mut Vec::new())
-                        }
+                        PluginRenderResult::Rendered(mut node) => node.show(ui, &mut Vec::new()),
                         PluginRenderResult::ConsentPending => {
                             ui.add(
                                 Typography::builder()
@@ -378,7 +386,33 @@ impl DataView {
                         .build()
                         .show(ui, events);
                 }
-            });
+            }
+        });
+    }
+}
+
+/// Whether `view` selects the built-in grid — the one branch of
+/// [`DataView::body`] that owns its own scrolling. Kept beside the match it
+/// mirrors: table is the fallback, so anything that isn't a named built-in or a
+/// renderer plugin lands there.
+#[cfg(feature = "egui")]
+fn table_view(view: &str) -> bool {
+    !matches!(view, "json" | "raw") && !view.starts_with("plugin:")
+}
+
+/// Run `content` inside the body's scroll area, or directly into `ui` when the
+/// content scrolls itself.
+#[cfg(feature = "egui")]
+fn scrolled(
+    ui: &mut egui::Ui,
+    scroll: bool,
+    id_salt: impl std::hash::Hash,
+    content: impl FnOnce(&mut egui::Ui),
+) {
+    if scroll {
+        egui::ScrollArea::both().id_salt(id_salt).show(ui, content);
+    } else {
+        content(ui);
     }
 }
 

--- a/thoth-plugin-sdk/src/components/data_view/mod.rs
+++ b/thoth-plugin-sdk/src/components/data_view/mod.rs
@@ -31,6 +31,17 @@ impl DataView {
     /// Max rows the host draws (the registry also caps a single read).
     const LIMIT: u32 = 1000;
 
+    /// Header strip height — design `.dvbar{height:40px}`.
+    const HEAD_H: f32 = 40.0;
+    /// Header strip side padding — design `.dvbar{padding:0 12px}`.
+    const HEAD_PAD_X: i8 = 12;
+    /// Gap between header strip controls — design `.dvbar{gap:12px}`.
+    const HEAD_GAP: f32 = 12.0;
+    /// Row-count label size — design `.rcount{font-size:12px}` (monospace).
+    const COUNT_FONT: f32 = 12.0;
+    /// The strip's inset top and bottom hairlines — design `surface1 @ 26%`.
+    const HEAD_DIVIDER_ALPHA: u8 = 66;
+
     /// Draw the referenced dataset (table, JSON tree, or raw JSON) from the
     /// host registry.
     ///
@@ -39,12 +50,9 @@ impl DataView {
     /// host intercepts it and opens Chart Studio bound to the emitting plugin's
     /// tab. All other controls (view toggle, Copy) are handled in-widget.
     pub fn show(&self, ui: &mut egui::Ui, events: &mut Vec<crate::render_node::UiEvent>) {
-        use crate::components::{
-            Button, ButtonColor, ButtonType, Code, ColumnType, JsonTree, Select, SelectOption,
-            Size, TableView, Typography, TypographyVariant,
-        };
-        use crate::dataset::{PluginRenderResult, render_with_plugin, renderers, resolve_dataset};
-        use crate::render_node::{RenderNode, UiEvent};
+        use crate::components::{SelectOption, Typography, TypographyVariant};
+        use crate::dataset::{renderers, resolve_dataset};
+        use crate::theme::{ThemeColors, with_alpha};
 
         let Some(page) = resolve_dataset(&self.handle, Self::LIMIT) else {
             ui.add(
@@ -97,128 +105,211 @@ impl DataView {
             .filter(|v| view_options.iter().any(|o| &o.value == v))
             .unwrap_or_else(|| "table".to_string());
 
-        // Header row: [View ▾] · count · <spacer> · Copy · Export · Charts.
-        // A fixed row height keeps the dropdown, count, and buttons centred.
-        ui.horizontal(|ui| {
-            ui.set_min_height(28.0);
-            if let Some(v) = Select::builder()
-                .id(format!("{node_id}_views"))
-                .value(view.clone())
-                .options(view_options)
-                .size(Size::Small)
-                .width(120.0)
-                .build()
-                .show(ui)
-                .inner
-                .selected
-            {
-                view = v;
-            }
-            ui.add_space(8.0);
-            // The resolver caps a read at LIMIT, so the fallback count reflects
-            // the rows actually drawn rather than over-reporting a large dataset.
-            let count = self.caption.clone().unwrap_or_else(|| {
-                let shown = page.rows.len() as u64;
-                if page.total > shown {
-                    format!("{shown} of {} rows", page.total)
-                } else {
-                    format!("{} rows", page.total)
-                }
-            });
-            ui.add(
-                Typography::builder()
-                    .text(count)
-                    .variant(TypographyVariant::BodyMuted)
-                    .build(),
-            );
+        let colors = ThemeColors::from_ctx(ui.ctx());
+        // No outer frame, corners or edge of its own. `DataView` always fills a
+        // surface that already floats — a dock leaf, or a plugin's results pane —
+        // and that surface owns the fill, hairline and rounding. Adding them here
+        // insets the whole view from its container, which reads as a stray margin
+        // around the data. See app-mockup.html, where `.dvbar` and the grid run
+        // edge to edge inside the results panel.
+        ui.spacing_mut().item_spacing.y = 0.0;
 
-            // Actions hang off the right edge, so add rightmost-first to read
-            // Copy · Export · Charts left-to-right on screen.
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                if ui
-                    .add(
-                        Button::builder()
-                            .label("Charts")
-                            .icon(egui_phosphor::regular::CHART_LINE)
-                            .button_type(ButtonType::Text)
-                            .color(ButtonColor::Secondary)
-                            .hover_text("Open in Chart Studio")
-                            .build(),
-                    )
-                    .clicked()
-                {
+        // Header strip — design `.dvbar`: mantle fill, 40px tall, 12px side
+        // padding, 12px gaps, and a 1px hairline along *both* its top and bottom
+        // edges. [View ▾] · count · <spacer> · Copy · Export · Charts.
+        let head = egui::Frame::NONE
+            .fill(colors.bg_panel)
+            .inner_margin(egui::Margin::symmetric(Self::HEAD_PAD_X, 0))
+            .show(ui, |ui| {
+                ui.spacing_mut().item_spacing.x = Self::HEAD_GAP;
+                ui.horizontal(|ui| {
+                    ui.set_min_height(Self::HEAD_H);
+                    self.header(ui, events, &page, node_id, view_options, &mut view);
+                });
+            });
+        let rule = egui::Stroke::new(
+            1.0,
+            with_alpha(colors.surface_raised, Self::HEAD_DIVIDER_ALPHA),
+        );
+        let strip = head.response.rect;
+        ui.painter().hline(strip.x_range(), strip.top() + 0.5, rule);
+        ui.painter()
+            .hline(strip.x_range(), strip.bottom() - 0.5, rule);
+        ui.data_mut(|d| d.insert_temp(mem_id, view.clone()));
+
+        self.body(ui, events, &page, node_id, &view);
+    }
+
+    /// Draw the header strip's controls: the view selector, the row-count label,
+    /// then the trailing actions (Copy · Export · Charts) pushed to the right
+    /// edge by a flexible spacer.
+    fn header(
+        &self,
+        ui: &mut egui::Ui,
+        events: &mut Vec<crate::render_node::UiEvent>,
+        page: &crate::dataset::DatasetPage,
+        node_id: &str,
+        view_options: Vec<crate::components::SelectOption>,
+        view: &mut String,
+    ) {
+        use crate::components::{
+            Button, ButtonColor, ButtonType, Select, SelectOption, Size, Typography,
+            TypographyVariant,
+        };
+        use crate::render_node::UiEvent;
+
+        // Design `.viewsel` is a 28px-tall select trigger at 12.5px — exactly
+        // `Size::Medium`'s field metrics, so the shared `Select` is used as-is —
+        // and it leads with a glyph for the current view.
+        let view_glyph = match view.as_str() {
+            "json" => egui_phosphor::regular::BRACKETS_CURLY,
+            "raw" => egui_phosphor::regular::CODE,
+            _ => egui_phosphor::regular::TABLE,
+        };
+        if let Some(v) = Select::builder()
+            .id(format!("{node_id}_views"))
+            .value(view.clone())
+            .options(view_options)
+            .icon(view_glyph)
+            .size(Size::Medium)
+            .width(136.0)
+            .build()
+            .show(ui)
+            .inner
+            .selected
+        {
+            *view = v;
+        }
+        // The resolver caps a read at LIMIT, so the fallback count reflects
+        // the rows actually drawn rather than over-reporting a large dataset.
+        let count = self.caption.clone().unwrap_or_else(|| {
+            let shown = page.rows.len() as u64;
+            if page.total > shown {
+                format!("{shown} of {} rows", page.total)
+            } else {
+                format!("{} rows", page.total)
+            }
+        });
+        // Design `.rcount` is monospace at 12px in `fg-muted` — the figures line
+        // up as the row count changes, which a proportional face won't do.
+        ui.add(
+            Typography::builder()
+                .text(count)
+                .variant(TypographyVariant::Mono)
+                .color("fg_muted")
+                .size(Self::COUNT_FONT)
+                .build(),
+        );
+
+        // Actions hang off the right edge — the flexible spacer is the
+        // right-to-left layout claiming the rest of the strip — so add
+        // rightmost-first to read Copy · Export · Charts left-to-right on screen.
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if ui
+                .add(
+                    Button::builder()
+                        .label("Charts")
+                        .icon(egui_phosphor::regular::CHART_LINE)
+                        .button_type(ButtonType::Text)
+                        .color(ButtonColor::Primary)
+                        .hover_text("Open in Chart Studio")
+                        .build(),
+                )
+                .clicked()
+            {
+                events.push(UiEvent {
+                    id: crate::actions::OPEN_IN_CHARTS.to_string(),
+                    kind: "click".to_string(),
+                    value: String::new(),
+                });
+            }
+
+            // Export dropdown — lists installed exporter plugins; picking one
+            // emits an EXPORT_DATASET action the host runs against this handle.
+            // Value stays empty so the trigger always reads "Export" (it's an
+            // action menu, not a persisted selection).
+            let exporters = crate::dataset::exporters();
+            if !exporters.is_empty() {
+                let options = exporters
+                    .iter()
+                    .map(|e| {
+                        SelectOption::builder()
+                            .value(e.id.clone())
+                            .label(format!("{} (.{})", e.label, e.extension))
+                            .build()
+                    })
+                    .collect();
+                let selected = Select::builder()
+                    .id(format!("{node_id}_export"))
+                    .value("")
+                    .prefix_label("Export")
+                    .options(options)
+                    // Design `.dvbar` renders Export as a `.viewsel`, the same
+                    // framed 28px trigger as the view switcher — it opens a menu,
+                    // so it reads as a control rather than a flat text action.
+                    .size(Size::Medium)
+                    .width(92.0)
+                    .build()
+                    .show(ui)
+                    .inner
+                    .selected;
+                if let Some(exporter) = selected {
                     events.push(UiEvent {
-                        id: crate::actions::OPEN_IN_CHARTS.to_string(),
+                        id: crate::actions::EXPORT_DATASET.to_string(),
                         kind: "click".to_string(),
-                        value: String::new(),
+                        value: serde_json::json!({ "handle": self.handle, "exporter": exporter })
+                            .to_string(),
                     });
                 }
+            }
 
-                // Export dropdown — lists installed exporter plugins; picking one
-                // emits an EXPORT_DATASET action the host runs against this handle.
-                // Value stays empty so the trigger always reads "Export" (it's an
-                // action menu, not a persisted selection).
-                let exporters = crate::dataset::exporters();
-                if !exporters.is_empty() {
-                    let options = exporters
-                        .iter()
-                        .map(|e| {
-                            SelectOption::builder()
-                                .value(e.id.clone())
-                                .label(format!("{} (.{})", e.label, e.extension))
-                                .build()
-                        })
-                        .collect();
-                    let selected = Select::builder()
-                        .id(format!("{node_id}_export"))
-                        .value("")
-                        .prefix_label("Export")
-                        .options(options)
-                        .size(Size::Small)
-                        .width(92.0)
-                        .build()
-                        .show(ui)
-                        .inner
-                        .selected;
-                    if let Some(exporter) = selected {
-                        events.push(UiEvent {
-                            id: crate::actions::EXPORT_DATASET.to_string(),
-                            kind: "click".to_string(),
-                            value:
-                                serde_json::json!({ "handle": self.handle, "exporter": exporter })
-                                    .to_string(),
-                        });
-                    }
-                }
-
-                // `copy` is handled in-widget (no plugin round-trip).
-                ui.add(
-                    Button::builder()
-                        .label("Copy")
-                        .icon(egui_phosphor::regular::COPY)
-                        .button_type(ButtonType::Text)
-                        .hover_text("Copy as JSON")
-                        .copy(records_json(&page, true))
-                        .build(),
-                );
-            });
+            // `copy` is handled in-widget (no plugin round-trip).
+            ui.add(
+                Button::builder()
+                    .label("Copy")
+                    .icon(egui_phosphor::regular::COPY)
+                    .button_type(ButtonType::Text)
+                    .hover_text("Copy as JSON")
+                    .copy(records_json(page, true))
+                    .build(),
+            );
         });
-        ui.data_mut(|d| d.insert_temp(mem_id, view.clone()));
+    }
+
+    /// Draw the body: the selected view's content, flush against the container
+    /// with no padding of its own (design `.dvbody{padding:0}`).
+    fn body(
+        &self,
+        ui: &mut egui::Ui,
+        events: &mut Vec<crate::render_node::UiEvent>,
+        page: &crate::dataset::DatasetPage,
+        node_id: &str,
+        view: &str,
+    ) {
+        use crate::components::{
+            Code, ColumnType, JsonTree, TableView, Typography, TypographyVariant,
+        };
+        use crate::dataset::{PluginRenderResult, render_with_plugin};
+        use crate::render_node::RenderNode;
 
         egui::ScrollArea::both()
             .id_salt((node_id, "data_view_scroll"))
-            .show(ui, |ui| match view.as_str() {
+            .show(ui, |ui| match view {
                 "json" => {
                     JsonTree::builder()
                         .id(format!("{node_id}_tree"))
-                        .value(records_value(&page))
+                        .value(records_value(page))
+                        // DataView already owns the rounded panel and hairline
+                        // edge, so the tree must not draw a second one inside it
+                        // (same reason `TableView` is unframed here).
+                        .framed(false)
                         .build()
                         .show(ui);
                 }
                 "raw" => {
                     ui.add(
                         Code::builder()
-                            .value(records_json(&page, true))
+                            .value(records_json(page, true))
                             .language("json")
                             .build(),
                     );
@@ -259,21 +350,31 @@ impl DataView {
                         .iter()
                         .map(|c| ColumnType::from_sql(&c.type_hint))
                         .collect();
+                    // Cells are styled by their column's type, so numeric and
+                    // temporal values read right-aligned in tinted mono (design
+                    // `.tv td.r`) instead of as plain text.
                     let rows: Vec<Vec<RenderNode>> = page
                         .rows
                         .iter()
                         .map(|row| {
                             row.iter()
-                                .map(|cell| {
-                                    RenderNode::Text(Typography::builder().text(cell).build())
+                                .zip(&page.columns)
+                                .map(|(cell, col)| {
+                                    RenderNode::typed_cell(
+                                        &typed_cell(cell, &col.type_hint),
+                                        ColumnType::from_sql(&col.type_hint),
+                                    )
                                 })
                                 .collect()
                         })
                         .collect();
+                    // The grid draws flush inside this container, which already
+                    // owns the background, edge, and corners.
                     TableView::builder()
                         .headers(headers)
                         .rows(rows)
                         .column_types(column_types)
+                        .framed(false)
                         .build()
                         .show(ui, events);
                 }

--- a/thoth-plugin-sdk/src/components/icon_button/mod.rs
+++ b/thoth-plugin-sdk/src/components/icon_button/mod.rs
@@ -10,6 +10,19 @@ fn size_small() -> Size {
     Size::Small
 }
 
+/// How an [`IconButton`] paints its [`selected`](IconButton::selected) state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IconButtonSelectedStyle {
+    /// Design `.ib.active`: a solid accent slab with a contrast glyph and a
+    /// matching glow. The default, and what every existing caller gets.
+    #[default]
+    Solid,
+    /// Design `.bell`: a 14% accent wash under an `fg` glyph, with no glow —
+    /// an "this popover is open" hint rather than a pressed toolbar toggle.
+    Wash,
+}
+
 /// A compact, square icon button rendered from a Phosphor glyph.
 ///
 /// Reports clicks through its [`egui::Widget`] response
@@ -30,7 +43,9 @@ pub struct IconButton {
     pub id: String,
     /// The icon glyph to display (a Phosphor character).
     pub icon: String,
-    /// Draw a solid frame behind the glyph. Defaults to `false`.
+    /// Draw a solid frame behind the glyph — design `.ib`: a surface fill with a
+    /// hairline edge. Defaults to `false`, the design's `.ib.ghost` variant, which
+    /// only fills on hover.
     #[builder(default)]
     #[serde(default)]
     pub frame: bool,
@@ -41,6 +56,25 @@ pub struct IconButton {
     /// colour.
     #[serde(default)]
     pub badge_color: Option<String>,
+    /// Badge dot diameter in points. Defaults to 9 — design `.ib .bdot`. The
+    /// design's `.bell .bd` is an 8px dot instead.
+    #[serde(default, rename = "badge-size")]
+    pub badge_size: Option<f32>,
+    /// How far the dot sits *inside* the top-right corner, in points. Defaults
+    /// to `-2`, i.e. the design's `.bdot{top:-2px;right:-2px}` overhang; the
+    /// design's `.bell .bd{top:3px;right:3px}` tucks it in at `3`.
+    #[serde(default, rename = "badge-inset")]
+    pub badge_inset: Option<f32>,
+    /// Colour of the 2pt ring around the badge dot (hex or theme token) — the
+    /// dot is ringed in whatever it sits on so it detaches from the glyph.
+    /// Defaults to the canvas background; a button on a panel wants the panel's.
+    #[serde(default, rename = "badge-ring-color")]
+    pub badge_ring_color: Option<String>,
+    /// Glyph colour override (hex or theme token). When unset the glyph follows
+    /// the button's state, which is what nearly every caller wants; the design's
+    /// `.bell` pins it to `fg` in every state instead.
+    #[serde(default, rename = "glyph-color")]
+    pub glyph_color: Option<String>,
     /// Square button size preset — shares heights with [`Button`]/[`Select`], so
     /// mixed toolbars line up. Defaults to [`Size::Small`] (24px), the common
     /// compact icon-button size. Prefer this; use [`size_px`](IconButton::size_px)
@@ -67,4 +101,9 @@ pub struct IconButton {
     #[builder(default)]
     #[serde(default)]
     pub selected: bool,
+    /// How [`selected`](IconButton::selected) is painted. Defaults to
+    /// [`IconButtonSelectedStyle::Solid`], the existing accent slab + glow.
+    #[builder(default)]
+    #[serde(default, rename = "selected-style")]
+    pub selected_style: IconButtonSelectedStyle,
 }

--- a/thoth-plugin-sdk/src/components/icon_button/mod.rs
+++ b/thoth-plugin-sdk/src/components/icon_button/mod.rs
@@ -75,10 +75,13 @@ pub struct IconButton {
     /// `.bell` pins it to `fg` in every state instead.
     #[serde(default, rename = "glyph-color")]
     pub glyph_color: Option<String>,
-    /// Square button size preset — shares heights with [`Button`]/[`Select`], so
-    /// mixed toolbars line up. Defaults to [`Size::Small`] (24px), the common
-    /// compact icon-button size. Prefer this; use [`size_px`](IconButton::size_px)
-    /// only for host chrome that must fit an exact pixel dimension.
+    /// Square button size preset — shares heights with [`Button`] (via
+    /// [`Size::metrics`]), so a toolbar of buttons and icon buttons lines up.
+    /// Defaults to [`Size::Small`] (22px), the common compact icon-button size.
+    /// Note these heights are deliberately shorter than a text-entry control's
+    /// ([`Size::field_metrics`], which [`Select`] uses). Prefer this prop; use
+    /// [`size_px`](IconButton::size_px) only for host chrome that must fit an
+    /// exact pixel dimension.
     ///
     /// [`Button`]: crate::components::Button
     /// [`Select`]: crate::components::Select

--- a/thoth-plugin-sdk/src/components/icon_button/ui.rs
+++ b/thoth-plugin-sdk/src/components/icon_button/ui.rs
@@ -1,17 +1,35 @@
-use egui::{Color32, Response, Sense, Widget};
+use egui::{Color32, Response, Sense, Shadow, Stroke, Widget};
 
 use crate::components::Size;
-use crate::theme::{ThemeColors, phosphor_font_id, resolve_color};
+use crate::theme::{
+    ICON_CONTROL, RADIUS_CONTROL, ThemeColors, edge_stroke, get_contrast_text_color, glow_shadow,
+    phosphor_font_id, resolve_color, with_alpha,
+};
 
-use super::IconButton;
+use super::{IconButton, IconButtonSelectedStyle};
 
 const DEFAULT_BUTTON_SIZE: f32 = 20.0;
 const DEFAULT_ICON_SIZE: f32 = 14.0;
 
+/// Ghost hover wash — design `.ib.ghost:hover{background:text@8%}`.
+const GHOST_HOVER_ALPHA: u8 = 20; // 8% of 255
+/// Disabled icon buttons drop to 42% opacity — design `.disabled{opacity:.42}`.
+const DISABLED_OPACITY: f32 = 0.42;
+/// Badge dot diameter — design `.ib .bdot{width:9px;height:9px}`.
+const BADGE_DIAMETER: f32 = 9.0;
+/// The dot hangs 2px outside the button's top-right corner — design
+/// `.bdot{top:-2px;right:-2px}`, i.e. a *negative* inset.
+const BADGE_INSET: f32 = -2.0;
+/// …and is ringed in the panel colour so it reads against any background —
+/// design `.bdot{box-shadow:0 0 0 2px var(--base)}`.
+const BADGE_RING_WIDTH: f32 = 2.0;
+/// Selected wash — design `.bell{background:color-mix(mauve 14%,transparent)}`.
+const SELECTED_WASH_ALPHA: u8 = 36; // 14% of 255
+
 impl IconButton {
     /// `(square dimension, default glyph size)` for this icon button's size
-    /// preset. Icon buttons stay compact, so `Medium` keeps the historical 20px
-    /// default; `Small`/`Large` step around it.
+    /// preset. Design `.ib` is 26px square with a 15px glyph ([`ICON_CONTROL`]);
+    /// `Small`/`Large` step 2px either side of that glyph size.
     fn dims(&self) -> (f32, f32) {
         // An explicit pixel override wins; its glyph scales from the 20px base.
         if let Some(px) = self.size_px {
@@ -22,23 +40,103 @@ impl IconButton {
         // The glyph size is icon-button-specific. `(square, glyph)`.
         let square = self.size.metrics().1;
         let glyph = match self.size {
-            Size::Small => 14.0,
-            Size::Medium => 16.0,
-            Size::Large => 18.0,
+            Size::Small => ICON_CONTROL - 2.0,
+            Size::Medium => ICON_CONTROL,
+            Size::Large => ICON_CONTROL + 2.0,
         };
         (square, glyph)
+    }
+
+    /// `(radius, offset)` of the badge dot: its radius, and how far its centre
+    /// sits in from the button's top-right corner. A negative
+    /// [`badge_inset`](IconButton::badge_inset) — the default — pushes the dot
+    /// out past the corner; a positive one tucks it inside.
+    fn badge_geometry(&self) -> (f32, f32) {
+        let radius = self.badge_size.unwrap_or(BADGE_DIAMETER) / 2.0;
+        (radius, radius + self.badge_inset.unwrap_or(BADGE_INSET))
+    }
+}
+
+/// Resolved paint colours for one icon-button state.
+struct Visual {
+    fill: Option<Color32>,
+    glyph: Color32,
+    stroke: Stroke,
+    shadow: Option<Shadow>,
+}
+
+impl Visual {
+    /// Design `.ib` (framed), `.ib.ghost`, `.ib.active` and `.bell`.
+    fn resolve(
+        framed: bool,
+        hovered: bool,
+        selected: bool,
+        selected_style: IconButtonSelectedStyle,
+        colors: &ThemeColors,
+    ) -> Self {
+        match (selected, framed, hovered) {
+            // `.bell` — a 14% accent wash under an `fg` glyph, no glow.
+            (true, _, _) if selected_style == IconButtonSelectedStyle::Wash => Self {
+                fill: Some(with_alpha(colors.accent, SELECTED_WASH_ALPHA)),
+                glyph: colors.fg,
+                stroke: Stroke::NONE,
+                shadow: None,
+            },
+            // `.ib.active` — mauve fill with a matching glow, framed or not.
+            (true, _, _) => Self {
+                fill: Some(colors.accent),
+                glyph: get_contrast_text_color(colors.accent),
+                stroke: Stroke::NONE,
+                shadow: Some(glow_shadow(colors.accent)),
+            },
+            // `.ib:hover`
+            (false, true, true) => Self {
+                fill: Some(colors.surface_raised),
+                glyph: colors.fg,
+                stroke: edge_stroke(colors),
+                shadow: None,
+            },
+            // `.ib`
+            (false, true, false) => Self {
+                fill: Some(colors.surface),
+                glyph: colors.fg_subtle(),
+                stroke: edge_stroke(colors),
+                shadow: None,
+            },
+            // `.ib.ghost:hover`
+            (false, false, true) => Self {
+                fill: Some(with_alpha(colors.fg, GHOST_HOVER_ALPHA)),
+                glyph: colors.fg,
+                stroke: Stroke::NONE,
+                shadow: None,
+            },
+            // `.ib.ghost`
+            (false, false, false) => Self {
+                fill: None,
+                glyph: colors.fg_muted,
+                stroke: Stroke::NONE,
+                shadow: None,
+            },
+        }
+    }
+
+    /// Design `.disabled{opacity:.42;box-shadow:none}`.
+    fn dimmed(self) -> Self {
+        Self {
+            fill: self.fill.map(|c| c.gamma_multiply(DISABLED_OPACITY)),
+            glyph: self.glyph.gamma_multiply(DISABLED_OPACITY),
+            stroke: Stroke::new(
+                self.stroke.width,
+                self.stroke.color.gamma_multiply(DISABLED_OPACITY),
+            ),
+            shadow: None,
+        }
     }
 }
 
 impl Widget for IconButton {
     fn ui(self, ui: &mut egui::Ui) -> Response {
         let colors = ThemeColors::from_ctx(ui.ctx());
-
-        let base_color = if self.disabled {
-            ui.style().visuals.weak_text_color()
-        } else {
-            ui.style().visuals.text_color()
-        };
 
         let (dim, default_icon) = self.dims();
         let size = egui::vec2(dim, dim);
@@ -52,31 +150,50 @@ impl Widget for IconButton {
         let (rect, response) = ui.allocate_exact_size(size, sense);
 
         if ui.is_rect_visible(rect) {
-            if self.frame {
-                ui.painter().rect_filled(rect, 4.0, colors.surface_raised);
+            let hovered = response.hovered() && !self.disabled;
+            let mut visual = Visual::resolve(
+                self.frame,
+                hovered,
+                self.selected,
+                self.selected_style,
+                &colors,
+            );
+            // An explicit glyph colour outranks the state's — design `.bell`
+            // keeps its `--text` glyph washed, hovered, or idle.
+            if let Some(c) = self
+                .glyph_color
+                .as_deref()
+                .and_then(|c| resolve_color(c, &colors))
+            {
+                visual.glyph = c;
             }
-
-            if response.hovered() && !self.disabled {
-                let hover_bg = Color32::from_rgba_premultiplied(
-                    colors.surface_raised.r(),
-                    colors.surface_raised.g(),
-                    colors.surface_raised.b(),
-                    40,
-                );
-                ui.painter().rect_filled(rect, 4.0, hover_bg);
-            }
-
-            let icon_color = if (response.hovered() && !self.disabled) || self.selected {
-                colors.accent
+            let visual = if self.disabled {
+                visual.dimmed()
             } else {
-                base_color
+                visual
             };
+
+            if let Some(shadow) = visual.shadow {
+                ui.painter().add(shadow.as_shape(rect, RADIUS_CONTROL));
+            }
+            if let Some(fill) = visual.fill {
+                ui.painter().rect_filled(rect, RADIUS_CONTROL, fill);
+            }
+            if visual.stroke != Stroke::NONE {
+                ui.painter().rect_stroke(
+                    rect,
+                    RADIUS_CONTROL,
+                    visual.stroke,
+                    egui::StrokeKind::Inside,
+                );
+            }
+
             ui.painter().text(
                 rect.center(),
                 egui::Align2::CENTER_CENTER,
                 &self.icon,
                 phosphor_font_id(icon_size),
-                icon_color,
+                visual.glyph,
             );
 
             if let Some(badge_color) = self
@@ -84,13 +201,23 @@ impl Widget for IconButton {
                 .as_deref()
                 .and_then(|c| resolve_color(c, &colors))
             {
-                let badge_center = egui::pos2(rect.right() - 6.0, rect.top() + 6.0);
-                ui.painter().circle_filled(badge_center, 2.0, badge_color);
+                // The dot straddles the top-right corner: by default it overhangs
+                // by 2px, but a tucked-in inset pulls it inside the box instead.
+                let (radius, offset) = self.badge_geometry();
+                let badge_center = egui::pos2(rect.right() - offset, rect.top() + offset);
+                let ring = self
+                    .badge_ring_color
+                    .as_deref()
+                    .and_then(|c| resolve_color(c, &colors))
+                    .unwrap_or(colors.bg);
+                // Ring first, sitting just outside the dot, then the dot itself.
                 ui.painter().circle_stroke(
                     badge_center,
-                    2.0,
-                    egui::Stroke::new(1.5, Color32::WHITE),
+                    radius + BADGE_RING_WIDTH / 2.0,
+                    Stroke::new(BADGE_RING_WIDTH, ring),
                 );
+                ui.painter()
+                    .circle_filled(badge_center, radius, badge_color);
             }
         }
 
@@ -118,5 +245,38 @@ impl Widget for IconButton {
         });
 
         response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BADGE_DIAMETER, BADGE_INSET};
+    use crate::components::{IconButton, IconButtonSelectedStyle};
+
+    #[test]
+    fn defaults_keep_the_original_badge_and_selected_chrome() {
+        let b = IconButton::builder().icon("x").build();
+        assert_eq!(b.selected_style, IconButtonSelectedStyle::Solid);
+        assert!(b.badge_size.is_none());
+        assert!(b.badge_inset.is_none());
+        assert!(b.badge_ring_color.is_none());
+        assert!(b.glyph_color.is_none());
+        // Design `.ib .bdot`: a 9px dot overhanging the corner by 2px, i.e. a
+        // centre 2.5px in from it.
+        let (radius, offset) = b.badge_geometry();
+        assert_eq!(radius, BADGE_DIAMETER / 2.0);
+        assert_eq!(offset, BADGE_DIAMETER / 2.0 + BADGE_INSET);
+        assert_eq!(offset, 2.5);
+    }
+
+    #[test]
+    fn the_bells_dot_tucks_inside_the_corner() {
+        // Design `.bell .bd{width:8px;top:3px;right:3px}` — a centre 7px in.
+        let b = IconButton::builder()
+            .icon("x")
+            .badge_size(8.0)
+            .badge_inset(3.0)
+            .build();
+        assert_eq!(b.badge_geometry(), (4.0, 7.0));
     }
 }

--- a/thoth-plugin-sdk/src/components/input/mod.rs
+++ b/thoth-plugin-sdk/src/components/input/mod.rs
@@ -54,10 +54,21 @@ pub struct Input {
     /// Optional leading Phosphor icon glyph (single-line only).
     #[serde(default)]
     pub icon: Option<String>,
-    /// Mask the text as bullets (password field).
+    /// Mask the text as bullets (password field). Renders a trailing eye that
+    /// toggles the mask off, matching design `.field[data-pw] .eye`.
     #[builder(default)]
     #[serde(default)]
     pub password: bool,
+    /// Render the value in the monospace family — design `.field.mono`. Use for
+    /// connection strings, ids, and other machine text.
+    #[builder(default)]
+    #[serde(default)]
+    pub mono: bool,
+    /// Validation message. When set the field switches to its error styling (red
+    /// hairline, no focus ring) and the message is shown below it — design
+    /// `.field.err` + `.err-msg`.
+    #[serde(default)]
+    pub error: Option<String>,
     /// Disable interaction.
     #[builder(default)]
     #[serde(default)]

--- a/thoth-plugin-sdk/src/components/input/ui.rs
+++ b/thoth-plugin-sdk/src/components/input/ui.rs
@@ -53,8 +53,15 @@ impl Input {
         };
 
         // Whether a password field is currently revealed is view-only state, so
-        // it lives in egui memory rather than on the serialisable struct.
-        let reveal_id = ui.make_persistent_id((self.id.as_str(), "reveal"));
+        // it lives in egui memory rather than on the serialisable struct. An
+        // id-less field falls back to this `ui`'s auto id (as `CodeEditor` does),
+        // so two anonymous fields in one container don't share reveal state.
+        let id_source: String = if self.id.is_empty() {
+            format!("sdk_input_{:?}", ui.next_auto_id())
+        } else {
+            self.id.clone()
+        };
+        let reveal_id = ui.make_persistent_id((id_source.as_str(), "reveal"));
         let mut reveal: bool = ui.ctx().data(|d| d.get_temp(reveal_id).unwrap_or(false));
 
         // `grow` (and the default) fill the available width; `desired_width`
@@ -227,7 +234,7 @@ impl Input {
         let response = inner_response.unwrap_or_else(|| {
             ui.interact(
                 field_rect,
-                ui.make_persistent_id((self.id.as_str(), "field")),
+                ui.make_persistent_id((id_source.as_str(), "field")),
                 egui::Sense::hover(),
             )
         });

--- a/thoth-plugin-sdk/src/components/input/ui.rs
+++ b/thoth-plugin-sdk/src/components/input/ui.rs
@@ -1,9 +1,18 @@
 use egui::{InnerResponse, RichText, Stroke, Widget};
 
 use crate::components::Size;
-use crate::theme::{ThemeColors, phosphor_font_id};
+use crate::theme::{
+    FONT_CAPTION, ICON_CONTROL, RADIUS_CONTROL, ThemeColors, edge_stroke, focus_stroke,
+    phosphor_font_id,
+};
 
 use super::Input;
+
+/// Horizontal padding inside the field — design `.field{padding:0 10px}`.
+const PAD_X: f32 = 10.0;
+/// Gap between the text and the leading icon / trailing eye — design
+/// `.field{gap:7px}`.
+const GAP: f32 = 7.0;
 
 impl Input {
     /// Render the input, mutating [`value`](Input::value) in place.
@@ -19,33 +28,64 @@ impl Input {
             } else {
                 self.label.clone()
             };
-            ui.label(RichText::new(text).color(colors.fg_muted).size(11.0));
+            ui.label(
+                RichText::new(text)
+                    .color(colors.fg_muted)
+                    .size(FONT_CAPTION),
+            );
         }
-        let width = if self.grow {
-            f32::INFINITY
+
+        // Text-entry metrics — 12.5px text in a 28px box at Medium (design `.field`).
+        let (font_size, height) = self.size.field_metrics();
+        let font_id = if self.mono {
+            egui::FontId::monospace(font_size)
         } else {
-            self.desired_width.unwrap_or(f32::INFINITY)
+            egui::FontId::proportional(font_size)
         };
 
-        // Medium keeps the default look (no explicit font); Small/Large adjust the
-        // font and vertical padding so the field matches small/large controls.
-        let (font_size, pad_y): (Option<f32>, i8) = match self.size {
-            Size::Small => (Some(11.0), 3),
-            Size::Medium => (None, 4),
-            Size::Large => (Some(14.0), 6),
+        // An errored field swaps the hairline for a red one and never draws the
+        // focus ring (the design's `.err` never also gains `.foc`).
+        let is_error = self.error.is_some();
+        let stroke = if is_error {
+            Stroke::new(1.0, colors.error)
+        } else {
+            edge_stroke(&colors)
+        };
+
+        // Whether a password field is currently revealed is view-only state, so
+        // it lives in egui memory rather than on the serialisable struct.
+        let reveal_id = ui.make_persistent_id((self.id.as_str(), "reveal"));
+        let mut reveal: bool = ui.ctx().data(|d| d.get_temp(reveal_id).unwrap_or(false));
+
+        // `grow` (and the default) fill the available width; `desired_width`
+        // pins it.
+        let outer_w = if self.grow {
+            ui.available_width()
+        } else {
+            self.desired_width.unwrap_or_else(|| ui.available_width())
         };
 
         let mut changed = false;
         let mut inner_response: Option<egui::Response> = None;
+        // Rect of the field box itself, used for the focus ring below.
+        let mut field_rect = egui::Rect::NOTHING;
 
-        let frame = egui::Frame::new()
-            .fill(colors.surface)
-            .stroke(Stroke::new(1.0, colors.surface_raised))
-            .corner_radius(4)
-            .inner_margin(egui::Margin::symmetric(8, pad_y))
-            .show(ui, |ui| {
-                ui.add_enabled_ui(!self.disabled, |ui| {
-                    if self.multiline {
+        ui.add_enabled_ui(!self.disabled, |ui| {
+            if self.multiline {
+                // No design spec for text areas; they reuse the field chrome with
+                // a vertical padding scaled to the size preset.
+                let pad_y: i8 = match self.size {
+                    Size::Small => 3,
+                    Size::Medium => 4,
+                    Size::Large => 6,
+                };
+                let frame = egui::Frame::new()
+                    .fill(colors.surface)
+                    .stroke(stroke)
+                    .corner_radius(RADIUS_CONTROL)
+                    .inner_margin(egui::Margin::symmetric(PAD_X as i8, pad_y))
+                    .show(ui, |ui| {
+                        ui.visuals_mut().weak_text_color = Some(colors.fg_muted);
                         let row_count = self.rows.max(1) as f32;
                         let row_height = ui.text_style_height(&egui::TextStyle::Body);
                         let fixed_h = row_height * row_count
@@ -60,42 +100,137 @@ impl Input {
                                     egui::TextEdit::multiline(&mut self.value)
                                         .hint_text(&self.placeholder)
                                         .desired_rows(self.rows.max(1))
-                                        .desired_width(width)
+                                        .desired_width(outer_w - 2.0 * PAD_X)
+                                        .font(font_id.clone())
+                                        .text_color(colors.fg)
+                                        .margin(egui::Margin::ZERO)
                                         .frame(egui::Frame::NONE),
                                 )
                             });
                         changed = scroll_out.inner.changed();
                         inner_response = Some(scroll_out.inner);
-                    } else {
-                        ui.horizontal(|ui| {
-                            if let Some(glyph) = &self.icon {
-                                ui.label(
-                                    RichText::new(glyph)
-                                        .font(phosphor_font_id(13.0))
-                                        .color(colors.fg_muted),
-                                );
-                                ui.add_space(4.0);
-                            }
-                            let mut edit = egui::TextEdit::singleline(&mut self.value)
-                                .hint_text(&self.placeholder)
-                                .desired_width(width)
-                                .vertical_align(egui::Align::Center)
-                                .frame(egui::Frame::NONE);
-                            if let Some(fs) = font_size {
-                                edit = edit.font(egui::FontId::proportional(fs));
-                            }
-                            if self.password {
-                                edit = edit.password(true);
-                            }
-                            let r = ui.add(edit);
-                            changed = r.changed();
-                            inner_response = Some(r);
-                        });
-                    }
-                });
-            });
+                    });
+                field_rect = frame.response.rect;
+            } else {
+                // The box is painted by hand so it is exactly `height` tall and so
+                // its click area (allocated *before* the text edit, hence below it)
+                // focuses the field when the padding is clicked.
+                let (rect, bg_resp) =
+                    ui.allocate_exact_size(egui::vec2(outer_w, height), egui::Sense::click());
+                field_rect = rect;
+                if ui.is_rect_visible(rect) {
+                    ui.painter()
+                        .rect_filled(rect, RADIUS_CONTROL, colors.surface);
+                    ui.painter().rect_stroke(
+                        rect,
+                        RADIUS_CONTROL,
+                        stroke,
+                        egui::StrokeKind::Inside,
+                    );
+                }
 
-        let response = inner_response.unwrap_or(frame.response);
+                let content = egui::UiBuilder::new()
+                    .max_rect(rect.shrink2(egui::vec2(PAD_X, 0.0)))
+                    .layout(egui::Layout::left_to_right(egui::Align::Center));
+                ui.scope_builder(content, |ui| {
+                    // Gaps are placed explicitly to hit the design's 7px.
+                    ui.spacing_mut().item_spacing.x = 0.0;
+                    ui.visuals_mut().weak_text_color = Some(colors.fg_muted);
+
+                    if let Some(glyph) = &self.icon {
+                        ui.label(
+                            RichText::new(glyph)
+                                .font(phosphor_font_id(ICON_CONTROL))
+                                .color(colors.fg_muted),
+                        );
+                        ui.add_space(GAP);
+                    }
+
+                    // Reserve the reveal eye up front so the text never runs under it.
+                    let trailing = if self.password {
+                        ICON_CONTROL + GAP
+                    } else {
+                        0.0
+                    };
+                    let text_w = (ui.available_width() - trailing).max(0.0);
+                    let mut edit = egui::TextEdit::singleline(&mut self.value)
+                        .hint_text(&self.placeholder)
+                        .desired_width(text_w)
+                        .font(font_id.clone())
+                        .text_color(colors.fg)
+                        .vertical_align(egui::Align::Center)
+                        .margin(egui::Margin::ZERO)
+                        .frame(egui::Frame::NONE);
+                    if self.password && !reveal {
+                        edit = edit.password(true);
+                    }
+                    let r = ui.add(edit);
+                    changed = r.changed();
+
+                    if self.password {
+                        ui.add_space(GAP);
+                        let glyph = if reveal {
+                            egui_phosphor::regular::EYE_SLASH
+                        } else {
+                            egui_phosphor::regular::EYE
+                        };
+                        let eye = ui.add(
+                            egui::Label::new(
+                                RichText::new(glyph)
+                                    .font(phosphor_font_id(ICON_CONTROL))
+                                    .color(colors.fg_muted),
+                            )
+                            .sense(egui::Sense::click()),
+                        );
+                        if eye.clicked() {
+                            reveal = !reveal;
+                            ui.ctx().data_mut(|d| d.insert_temp(reveal_id, reveal));
+                        }
+                        if eye.hovered() {
+                            ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                        }
+                    }
+
+                    // Clicking the padding around the text behaves like clicking
+                    // the text itself.
+                    if bg_resp.clicked() {
+                        ui.memory_mut(|m| m.request_focus(r.id));
+                    }
+                    if bg_resp.hovered() {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::Text);
+                    }
+                    inner_response = Some(r);
+                });
+            }
+        });
+
+        // Focus ring sits *outside* the hairline — design
+        // `.field.foc{box-shadow:var(--edge),var(--focus)}`.
+        let focused = inner_response.as_ref().is_some_and(|r| r.has_focus());
+        if focused && !is_error && ui.is_rect_visible(field_rect) {
+            ui.painter().rect_stroke(
+                field_rect,
+                RADIUS_CONTROL,
+                focus_stroke(&colors),
+                egui::StrokeKind::Outside,
+            );
+        }
+
+        if let Some(message) = &self.error {
+            ui.label(
+                RichText::new(message)
+                    .color(colors.error)
+                    .size(FONT_CAPTION),
+            );
+        }
+
+        let response = inner_response.unwrap_or_else(|| {
+            ui.interact(
+                field_rect,
+                ui.make_persistent_id((self.id.as_str(), "field")),
+                egui::Sense::hover(),
+            )
+        });
         InnerResponse::new(changed, response)
     }
 }

--- a/thoth-plugin-sdk/src/components/json_tree/mod.rs
+++ b/thoth-plugin-sdk/src/components/json_tree/mod.rs
@@ -29,4 +29,14 @@ pub struct JsonTree {
     #[builder(default)]
     #[serde(default)]
     pub id: String,
+    /// Draw the outer container (canvas fill + hairline edge + rounded corners +
+    /// 4px padding — design `.tree`). Defaults to `true`; set `false` when the
+    /// tree sits inside a container that already owns those corners.
+    #[builder(default = true)]
+    #[serde(default = "default_true")]
+    pub framed: bool,
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/thoth-plugin-sdk/src/components/json_tree/ui.rs
+++ b/thoth-plugin-sdk/src/components/json_tree/ui.rs
@@ -3,9 +3,16 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use crate::components::DataRow;
-use crate::theme::{ROW_HEIGHT, TextToken, color_to_hex};
+use crate::theme::{
+    RADIUS_PANEL, ROW_HEIGHT, TextToken, ThemeColors, color_to_hex, edge_stroke, with_alpha,
+};
 
 use super::JsonTree;
+
+/// Inner padding of the design's `.tree{padding:4px}` container.
+const TREE_PAD: i8 = 4;
+/// Zebra wash — design `.tree.zebra .dr:nth-child(even){background:text 3%}`.
+const ZEBRA_ALPHA: u8 = 8;
 
 /// A render-ready row, mapped directly onto [`DataRow`] fields.
 struct TreeRow {
@@ -19,6 +26,9 @@ struct TreeRow {
     value_token: Option<TextToken>,
     /// `Some(expanded)` for expandable container rows; `None` for leaves/closers.
     caret: Option<bool>,
+    /// The row's value is a collapsed-container summary (`{…} (4 keys)`), drawn
+    /// muted — design `.dr .sum`.
+    summary: bool,
 }
 
 #[derive(Clone, Default)]
@@ -50,34 +60,43 @@ impl JsonTree {
         let row_count = rows.len();
         let mut toggle_path: Option<String> = None;
 
-        // Zebra striping: faint fill on every other displayed row.
-        let stripe = color_to_hex(ui.visuals().faint_bg_color);
+        // Zebra striping: a text wash on every other displayed row. Handed to
+        // the row as its background so it composites *under* the row's own
+        // hover/selection washes.
+        let colors = ThemeColors::from_ctx(ui.ctx());
+        let stripe = color_to_hex(with_alpha(colors.fg, ZEBRA_ALPHA));
 
-        egui::ScrollArea::both()
-            .auto_shrink([false, false])
-            .show_rows(ui, ROW_HEIGHT, row_count, |ui, range| {
-                for idx in range {
-                    let row = &rows[idx];
-                    let background = (idx % 2 == 1).then(|| stripe.clone());
-                    let out = DataRow::builder()
-                        .display_text(row.text.clone())
-                        .row_id(row.path.clone())
-                        .key_token(row.key_token)
-                        .maybe_value_token(row.value_token)
-                        .maybe_caret(row.caret)
-                        .maybe_background(background)
-                        .syntax_highlighting(true)
-                        .indent(row.indent)
-                        .build()
-                        .show(ui);
+        container(ui, self.framed, &colors, |ui| {
+            // Design `.tree` stacks its rows flush, so the zebra stripes read as
+            // a continuous ladder; `show_rows` picks the pitch up from here.
+            ui.spacing_mut().item_spacing.y = 0.0;
+            egui::ScrollArea::both()
+                .auto_shrink([false, false])
+                .show_rows(ui, ROW_HEIGHT, row_count, |ui, range| {
+                    for idx in range {
+                        let row = &rows[idx];
+                        let background = (idx % 2 == 1).then(|| stripe.clone());
+                        let out = DataRow::builder()
+                            .display_text(row.text.clone())
+                            .row_id(row.path.clone())
+                            .key_token(row.key_token)
+                            .maybe_value_token(row.value_token)
+                            .maybe_caret(row.caret)
+                            .maybe_background(background)
+                            .syntax_highlighting(true)
+                            .summary_value(row.summary)
+                            .indent(row.indent)
+                            .build()
+                            .show(ui);
 
-                    // A caret click toggles this container; clicking the row
-                    // body also toggles, so expandable rows feel responsive.
-                    if row.caret.is_some() && (out.caret_clicked || out.clicked) {
-                        toggle_path = Some(row.path.clone());
+                        // A caret click toggles this container; clicking the row
+                        // body also toggles, so expandable rows feel responsive.
+                        if row.caret.is_some() && (out.caret_clicked || out.clicked) {
+                            toggle_path = Some(row.path.clone());
+                        }
                     }
-                }
-            });
+                });
+        });
 
         if let Some(path) = toggle_path
             && !expanded.0.remove(&path)
@@ -113,6 +132,7 @@ fn flatten_value(
                 key_token: TextToken::Bracket,
                 value_token: None,
                 caret: Some(is_expanded),
+                summary: !is_expanded,
             });
             if is_expanded {
                 for (key, val) in map {
@@ -141,6 +161,7 @@ fn flatten_value(
                 key_token: TextToken::Bracket,
                 value_token: None,
                 caret: Some(is_expanded),
+                summary: !is_expanded,
             });
             if is_expanded {
                 for (i, val) in arr.iter().enumerate() {
@@ -165,6 +186,7 @@ fn flatten_value(
                 key_token: token,
                 value_token: None,
                 caret: None,
+                summary: false,
             });
         }
     }
@@ -193,6 +215,7 @@ fn flatten_keyed(
                 key_token: TextToken::Key,
                 value_token: Some(TextToken::Bracket),
                 caret: Some(is_expanded),
+                summary: !is_expanded,
             });
             if is_expanded {
                 for (k, v) in map {
@@ -215,6 +238,7 @@ fn flatten_keyed(
                 key_token: TextToken::Key,
                 value_token: Some(TextToken::Bracket),
                 caret: Some(is_expanded),
+                summary: !is_expanded,
             });
             if is_expanded {
                 for (i, v) in arr.iter().enumerate() {
@@ -239,6 +263,7 @@ fn flatten_keyed(
                 key_token: TextToken::Key,
                 value_token: Some(token),
                 caret: None,
+                summary: false,
             });
         }
     }
@@ -253,7 +278,33 @@ fn closing(path: &str, indent: usize, bracket: &str) -> TreeRow {
         key_token: TextToken::Bracket,
         value_token: None,
         caret: None,
+        summary: false,
     }
+}
+
+/// Draw the tree inside the design's `.tree` container: a `bg` fill, a hairline
+/// [`edge_stroke`], [`RADIUS_PANEL`] corners and 4px of inner padding. `framed`
+/// is false when the tree is nested in a container that already owns those
+/// corners. Rows round their own washes to [`RADIUS_CHIP`] inside the padding,
+/// so nothing overruns the container's corners.
+///
+/// [`RADIUS_CHIP`]: crate::theme::RADIUS_CHIP
+fn container<R>(
+    ui: &mut egui::Ui,
+    framed: bool,
+    colors: &ThemeColors,
+    content: impl FnOnce(&mut egui::Ui) -> R,
+) -> R {
+    if !framed {
+        return content(ui);
+    }
+    egui::Frame::NONE
+        .fill(colors.bg)
+        .stroke(edge_stroke(colors))
+        .corner_radius(RADIUS_PANEL)
+        .inner_margin(TREE_PAD)
+        .show(ui, content)
+        .inner
 }
 
 fn collect_all_paths(value: &Value, path: &str, out: &mut HashSet<String>) {

--- a/thoth-plugin-sdk/src/components/layout.rs
+++ b/thoth-plugin-sdk/src/components/layout.rs
@@ -118,6 +118,10 @@ pub struct Column {
     /// Defaults to `0.0` — an unpadded column, which is what most callers want;
     /// set it for an inset region such as the design's `.tree{padding:4px}`.
     /// Nests *inside* [`framed`](Column::framed)'s card margin when both are set.
+    ///
+    /// egui margins are whole points (`i8`), so the value is truncated towards
+    /// zero — `4.6` renders as 4 — and saturates at ±127. Values at or below
+    /// `0.0` skip the padding frame entirely.
     #[builder(default)]
     #[serde(default)]
     pub padding: f32,
@@ -703,8 +707,13 @@ impl Split {
                             // grip (`.hhandle .grip`: 4x36, fully round,
                             // `surface-raised`), tinted mauve while hovered or
                             // dragging.
-                            let grip =
-                                egui::Rect::from_center_size(rect.center(), egui::vec2(4.0, 36.0));
+                            // 36pt tall where there's room; clamped to the handle
+                            // otherwise, since an unfilled row sizes it from
+                            // `row_min` and the grip would overhang both ends.
+                            let grip = egui::Rect::from_center_size(
+                                rect.center(),
+                                egui::vec2(4.0, 36.0_f32.min(rect.height())),
+                            );
                             ui.painter().rect_filled(
                                 grip,
                                 crate::theme::RADIUS_PILL,
@@ -768,7 +777,7 @@ impl VSplit {
             .fill(colors.bg_sunken)
             .inner_margin(GUTTER_GAP as i8)
             .show(ui, |ui| {
-                self.panes(ui, events, &pane_frame, handle_h);
+                self.panes(ui, events, &colors, &pane_frame, handle_h);
             });
     }
 
@@ -777,10 +786,10 @@ impl VSplit {
         &mut self,
         ui: &mut egui::Ui,
         events: &mut Vec<UiEvent>,
+        colors: &crate::theme::ThemeColors,
         pane_frame: &egui::Frame,
         handle_h: f32,
     ) {
-        let colors = crate::theme::ThemeColors::from_ctx(ui.ctx());
         let full = ui.available_size();
         let width = full.x;
         let total_h = full.y;

--- a/thoth-plugin-sdk/src/components/layout.rs
+++ b/thoth-plugin-sdk/src/components/layout.rs
@@ -114,6 +114,13 @@ pub struct Column {
     #[builder(default)]
     #[serde(default)]
     pub framed: bool,
+    /// Inner padding around the children, in points (matching [`Row::padding`]).
+    /// Defaults to `0.0` — an unpadded column, which is what most callers want;
+    /// set it for an inset region such as the design's `.tree{padding:4px}`.
+    /// Nests *inside* [`framed`](Column::framed)'s card margin when both are set.
+    #[builder(default)]
+    #[serde(default)]
+    pub padding: f32,
 }
 
 /// A scrollable region wrapping a single child.
@@ -148,7 +155,9 @@ pub struct Spacer {
 }
 
 /// Proportional horizontal split. `widths` are relative weights (empty = equal
-/// shares).
+/// shares). A two-column split can opt into a draggable divider with
+/// [`resizable`](Split::resizable), in which case `widths` only seeds the initial
+/// ratio.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Builder)]
 #[non_exhaustive]
 pub struct Split {
@@ -179,6 +188,47 @@ pub struct Split {
     #[builder(default)]
     #[serde(default)]
     pub fill_height: bool,
+    /// When true, each column becomes a floating card — panel fill, hairline edge
+    /// and [`RADIUS_PANEL`](crate::theme::RADIUS_PANEL) corners on the sunken
+    /// gutter, matching [`VSplit`]'s panes.
+    ///
+    /// Off by default, and deliberately opt-in: most `Split`s lay out form-field
+    /// pairs or table-like rows, which must stay flush. Turn it on only for a
+    /// split whose columns are genuine resizable *regions* (a request/response
+    /// pair, say).
+    #[builder(default)]
+    #[serde(default)]
+    pub framed: bool,
+    /// Let the user drag the gutter between the two columns to re-apportion the
+    /// width — the horizontal twin of [`VSplit`]'s divider. The dragged ratio is
+    /// persisted in egui memory, keyed by [`id`](Split::id).
+    ///
+    /// Off by default, for the same reason as [`framed`](Split::framed): a
+    /// form-field pair or a table-like row must stay proportional and
+    /// non-interactive. Only honoured for a *two*-column split — with three or
+    /// more columns there is no single unambiguous divider, so the flag is
+    /// ignored and the split stays purely proportional.
+    #[builder(default)]
+    #[serde(default)]
+    pub resizable: bool,
+    /// Stable id salt for the persisted divider position. Only consulted when
+    /// [`resizable`](Split::resizable) is set; `None` (the default) falls back to
+    /// egui's positional id for this `Ui`, which is enough while a view holds a
+    /// single resizable split.
+    #[builder(into)]
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Minimum width, in points, for each column of a [`resizable`](Split::resizable)
+    /// split (keeps a drag from swallowing either side). Defaults to `120.0` —
+    /// narrower than that and a pane stops being able to hold a toolbar. Ignored
+    /// when the split is not resizable.
+    #[builder(default = 120.0)]
+    #[serde(default = "min_col")]
+    pub min_pane: f32,
+}
+
+fn min_col() -> f32 {
+    120.0
 }
 
 /// A vertical split with a draggable divider: `top` over `bottom`, each filling
@@ -410,6 +460,18 @@ impl Column {
     }
 
     fn body(&mut self, ui: &mut egui::Ui, events: &mut Vec<UiEvent>) {
+        // Zero padding skips the frame entirely, so the (many) unpadded columns
+        // keep exactly the layout they had before the prop existed.
+        if self.padding > 0.0 {
+            egui::Frame::NONE
+                .inner_margin(egui::Margin::same(self.padding as i8))
+                .show(ui, |ui| self.children_vertical(ui, events));
+        } else {
+            self.children_vertical(ui, events);
+        }
+    }
+
+    fn children_vertical(&mut self, ui: &mut egui::Ui, events: &mut Vec<UiEvent>) {
         ui.vertical(|ui| {
             ui.spacing_mut().item_spacing.y = self.gap;
             for child in &mut self.children {
@@ -453,21 +515,81 @@ impl Spacer {
     }
 }
 
+/// Width of a [`resizable`](Split::resizable) split's first column: `ratio` of the
+/// `usable` width, clamped so neither column drops below `min_pane`.
+///
+/// When the split is too narrow to honour the minimum on both sides the minimum
+/// degrades to half the usable width, so the columns stay even rather than one
+/// collapsing — the same rule `VSplit` applies to its pane heights.
+#[cfg(feature = "egui")]
+fn resizable_col_width(usable: f32, ratio: f32, min_pane: f32) -> f32 {
+    let min = min_pane.min(usable / 2.0).max(0.0);
+    (usable * ratio).clamp(min, (usable - min).max(min))
+}
+
 #[cfg(feature = "egui")]
 impl Split {
     /// Render the proportional columns, each filling the full row height.
     pub fn show(&mut self, ui: &mut egui::Ui, events: &mut Vec<UiEvent>) {
-        let n = self.children.len();
-        if n == 0 {
+        if self.children.is_empty() {
             return;
         }
+        // A framed split owns the whole floating posture, exactly as `VSplit`
+        // does: the crust canvas its cards sit on, and a `GUTTER_GAP` inset so
+        // they don't touch the container's edges. Leaving the canvas to the caller
+        // made the two split components asymmetric and every call site had to
+        // re-derive it.
+        if self.framed {
+            let colors = crate::theme::ThemeColors::from_ctx(ui.ctx());
+            let gutter = crate::theme::GUTTER_GAP;
+            egui::Frame::NONE
+                .fill(colors.bg_sunken)
+                .inner_margin(gutter as i8)
+                .show(ui, |ui| self.columns(ui, events));
+        } else {
+            self.columns(ui, events);
+        }
+    }
+
+    /// Lay the columns out (and their cards, when framed) in a horizontal row.
+    fn columns(&mut self, ui: &mut egui::Ui, events: &mut Vec<UiEvent>) {
+        let n = self.children.len();
         let gap = self.gap;
-        let total_gap = gap * n.saturating_sub(1) as f32;
+        // Only a two-column split has one unambiguous divider to drag; with three
+        // or more the flag is ignored and the layout stays proportional (see the
+        // prop's docs).
+        let resizable = self.resizable && n == 2;
+        // A resizable split's divider doubles as the gutter, so it is sized to the
+        // design's grab handle (`.hhandle{width:11px}`) rather than the plain 8px
+        // panel gap — exactly as `VSplit` sizes its 11px `.vhandle`. `gap` is
+        // superseded for that one divider.
+        let handle_w = 11.0_f32;
+        let total_gap = if resizable {
+            handle_w
+        } else {
+            gap * n.saturating_sub(1) as f32
+        };
         let available = ui.available_width();
         let usable = (available - total_gap).max(0.0);
 
-        // Resolve per-column widths from relative weights (equal if absent).
-        let col_widths: Vec<f32> = if self.widths.len() == n {
+        // Persisted first-column fraction, seeded from `widths` (or an equal share)
+        // until the user drags. Keyed by `id` so it survives across frames.
+        let ratio_id = ui.make_persistent_id((&self.id, "split_ratio"));
+        let min_pane = self.min_pane;
+
+        // Resolve per-column widths from relative weights (equal if absent), or —
+        // when resizable — from the dragged ratio.
+        let weight_ratio = |w: &[f32]| w[0] / (w[0] + w[1]).max(0.001);
+        let col_widths: Vec<f32> = if resizable {
+            let seed = if self.widths.len() == n {
+                weight_ratio(&self.widths)
+            } else {
+                0.5
+            };
+            let ratio: f32 = ui.ctx().data(|d| d.get_temp(ratio_id)).unwrap_or(seed);
+            let first = resizable_col_width(usable, ratio, min_pane);
+            vec![first, (usable - first).max(0.0)]
+        } else if self.widths.len() == n {
             let sum: f32 = self.widths.iter().copied().sum::<f32>().max(0.001);
             self.widths.iter().map(|w| usable * (w / sum)).collect()
         } else {
@@ -483,6 +605,26 @@ impl Split {
         let separator = self.separator;
         let fill = self.fill_height;
         let center = self.align == Align::Center && !fill;
+        // Opt-in floating columns, matching `VSplit`'s panes. The fill is carried
+        // alongside the frame so the corner mask can restore it.
+        let card = if self.framed {
+            let colors = crate::theme::ThemeColors::from_ctx(ui.ctx());
+            Some((
+                egui::Frame::NONE
+                    .fill(colors.bg)
+                    .corner_radius(crate::theme::RADIUS_PANEL)
+                    .stroke(crate::theme::edge_stroke(&colors)),
+                colors.bg,
+            ))
+        } else {
+            None
+        };
+        // Grabber colours resolved up front — the layout closure below only gets a
+        // `&mut Ui`, and a non-resizable split must not pay for the lookup.
+        let grip_colors = resizable.then(|| {
+            let c = crate::theme::ThemeColors::from_ctx(ui.ctx());
+            (c.surface_raised, c.accent)
+        });
         let row_min = ui.spacing().interact_size.y;
         let avail_h = ui.available_height();
         let children = &mut self.children;
@@ -509,14 +651,79 @@ impl Split {
                             // rather than wrapping to a second row.
                             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
                         }
-                        child.show(ui, events);
+                        match &card {
+                            Some((frame, pane_fill)) => {
+                                let painted = frame.show(ui, |ui| {
+                                    ui.set_min_size(ui.available_size());
+                                    ui.set_clip_rect(ui.max_rect());
+                                    child.show(ui, events);
+                                });
+                                // A child that fills its own band (a status strip,
+                                // a tab bar) paints square over the card's corners,
+                                // since egui has no rounded clip rect. Mask the
+                                // corner wedges back to the card's fill and re-lay
+                                // the hairline on top — same approach as
+                                // `TableView`/`DataView`.
+                                let rect = painted.response.rect;
+                                crate::components::table_view::ui::paint_corner_mask(
+                                    ui.painter(),
+                                    rect,
+                                    crate::theme::RADIUS_PANEL,
+                                    *pane_fill,
+                                );
+                                ui.painter().rect_stroke(
+                                    rect,
+                                    crate::theme::RADIUS_PANEL,
+                                    crate::theme::edge_stroke(
+                                        &crate::theme::ThemeColors::from_ctx(ui.ctx()),
+                                    ),
+                                    egui::StrokeKind::Inside,
+                                );
+                            }
+                            None => child.show(ui, events),
+                        }
                     },
                 );
                 if i + 1 < n {
-                    if separator {
-                        ui.add(egui::Separator::default().vertical());
-                    } else {
-                        ui.add_space(gap);
+                    match &grip_colors {
+                        // ── Draggable divider ────────────────────────────────
+                        // Sits in the gutter *between* the two cards: `framed`'s
+                        // sunken canvas shows through around it, so the grip reads
+                        // as floating on the crust rather than drawn on a pane.
+                        Some((resting, active)) => {
+                            let handle_h = if fill { avail_h } else { row_min };
+                            let (rect, resp) = ui.allocate_exact_size(
+                                egui::vec2(handle_w, handle_h),
+                                egui::Sense::drag(),
+                            );
+                            let hovered = resp.hovered() || resp.dragged();
+                            // No rule down the gutter — the panes are separate
+                            // floating cards and a line spanning the gap would tie
+                            // them back together. Just the design's centred pill
+                            // grip (`.hhandle .grip`: 4x36, fully round,
+                            // `surface-raised`), tinted mauve while hovered or
+                            // dragging.
+                            let grip =
+                                egui::Rect::from_center_size(rect.center(), egui::vec2(4.0, 36.0));
+                            ui.painter().rect_filled(
+                                grip,
+                                crate::theme::RADIUS_PILL,
+                                if hovered { *active } else { *resting },
+                            );
+                            if hovered {
+                                ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
+                            }
+                            if resp.dragged() && usable > 0.0 {
+                                let dragged = col_widths[0] + resp.drag_delta().x;
+                                let first = resizable_col_width(usable, dragged / usable, min_pane);
+                                ui.ctx()
+                                    .data_mut(|d| d.insert_temp(ratio_id, first / usable));
+                            }
+                        }
+                        None if separator => {
+                            ui.add(egui::Separator::default().vertical());
+                        }
+                        None => ui.add_space(gap),
                     }
                 }
             }
@@ -535,9 +742,45 @@ impl VSplit {
     /// pane is given a fixed height (from the persisted ratio) so its content
     /// scrolls within, and dragging the divider re-apportions the height.
     pub fn show(&mut self, ui: &mut egui::Ui, events: &mut Vec<UiEvent>) {
-        let colors = crate::theme::ThemeColors::from_ctx(ui.ctx());
-        let handle_h = 7.0_f32;
+        use crate::theme::{GUTTER_GAP, RADIUS_PANEL, edge_stroke, panel_shadow};
 
+        let colors = crate::theme::ThemeColors::from_ctx(ui.ctx());
+        // The divider doubles as the gutter between the two panes, so it is sized
+        // to the design's grab handle (`.vhandle{height:11px}`) rather than the
+        // plain 8px panel gap.
+        let handle_h = 11.0_f32;
+        // Each pane is a floating card — fill, hairline edge, panel corners and a
+        // soft shadow (design: editor and results are two stacked `.panel sq`
+        // cards). The shadow has somewhere to fall because the crust gutter below
+        // insets them from the container on every side.
+        let pane_frame = egui::Frame::NONE
+            .fill(colors.bg)
+            .corner_radius(RADIUS_PANEL)
+            .stroke(edge_stroke(&colors))
+            .shadow(panel_shadow(ui.visuals().dark_mode));
+
+        // The split's own area is the *sunken* canvas, not a panel: the two cards
+        // float on it and the crust shows through as the gutter, which is what
+        // separates them (design `.splitv{background:bg-sunken;padding:8px}`).
+        // Leaving it transparent would inherit the enclosing panel's `bg` and the
+        // two cards would blend back into one continuous slab.
+        egui::Frame::NONE
+            .fill(colors.bg_sunken)
+            .inner_margin(GUTTER_GAP as i8)
+            .show(ui, |ui| {
+                self.panes(ui, events, &pane_frame, handle_h);
+            });
+    }
+
+    /// Lay the two cards and the drag handle out inside the crust gutter.
+    fn panes(
+        &mut self,
+        ui: &mut egui::Ui,
+        events: &mut Vec<UiEvent>,
+        pane_frame: &egui::Frame,
+        handle_h: f32,
+    ) {
+        let colors = crate::theme::ThemeColors::from_ctx(ui.ctx());
         let full = ui.available_size();
         let width = full.x;
         let total_h = full.y;
@@ -565,8 +808,14 @@ impl VSplit {
                 |ui| {
                     ui.set_min_size(egui::vec2(width, top_h));
                     ui.set_max_size(egui::vec2(width, top_h));
-                    ui.set_clip_rect(ui.max_rect());
-                    self.top.show(ui, events);
+                    // Clip the card's *content*, not the card: narrowing this
+                    // `ui`'s clip would also cut off the frame's shadow, which is
+                    // painted outside the frame rect.
+                    pane_frame.show(ui, |ui| {
+                        ui.set_min_size(ui.available_size());
+                        ui.set_clip_rect(ui.max_rect());
+                        self.top.show(ui, events);
+                    });
                 },
             );
 
@@ -574,23 +823,19 @@ impl VSplit {
             let (handle_rect, resp) =
                 ui.allocate_exact_size(egui::vec2(width, handle_h), egui::Sense::drag());
             let hovered = resp.hovered() || resp.dragged();
-            let line_y = handle_rect.center().y;
-            ui.painter().hline(
-                handle_rect.x_range(),
-                line_y,
-                egui::Stroke::new(1.0, colors.surface_raised),
-            );
-            // A short grip in the centre, brighter on hover/drag.
-            let grip_c = if hovered {
-                colors.accent
-            } else {
-                colors.fg_muted
-            };
-            let grip_w = 24.0;
-            ui.painter().hline(
-                (handle_rect.center().x - grip_w / 2.0)..=(handle_rect.center().x + grip_w / 2.0),
-                line_y,
-                egui::Stroke::new(2.0, grip_c),
+            // No rule across the gutter — the panes are separate floating cards and
+            // a line spanning the gap between them would tie them back together.
+            // Just the design's centred pill grip (`.vhandle .grip`: 36x4, fully
+            // round, `surface1`), tinted mauve while hovered or dragging.
+            let grip = egui::Rect::from_center_size(handle_rect.center(), egui::vec2(36.0, 4.0));
+            ui.painter().rect_filled(
+                grip,
+                crate::theme::RADIUS_PILL,
+                if hovered {
+                    colors.accent
+                } else {
+                    colors.surface_raised
+                },
             );
             if hovered {
                 ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeVertical);
@@ -608,8 +853,11 @@ impl VSplit {
                 |ui| {
                     ui.set_min_size(egui::vec2(width, bottom_h));
                     ui.set_max_size(egui::vec2(width, bottom_h));
-                    ui.set_clip_rect(ui.max_rect());
-                    self.bottom.show(ui, events);
+                    pane_frame.show(ui, |ui| {
+                        ui.set_min_size(ui.available_size());
+                        ui.set_clip_rect(ui.max_rect());
+                        self.bottom.show(ui, events);
+                    });
                 },
             );
         });
@@ -683,5 +931,40 @@ impl Colored {
             }
             self.child.show(ui, events);
         });
+    }
+}
+
+#[cfg(all(test, feature = "egui"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_dragged_ratio_never_collapses_a_column() {
+        // 600pt of usable width, 120pt minimum per column: a ratio dragged past
+        // either end pins to the minimum instead of swallowing the other pane.
+        assert_eq!(resizable_col_width(600.0, 0.5, 120.0), 300.0);
+        assert_eq!(resizable_col_width(600.0, 0.0, 120.0), 120.0);
+        assert_eq!(resizable_col_width(600.0, -3.0, 120.0), 120.0);
+        assert_eq!(resizable_col_width(600.0, 1.0, 120.0), 480.0);
+        assert_eq!(resizable_col_width(600.0, 4.0, 120.0), 480.0);
+    }
+
+    #[test]
+    fn a_split_too_narrow_for_the_minimum_stays_even() {
+        // Below `2 * min_pane` there is no honouring the minimum on both sides, so
+        // it degrades to half the width rather than starving one column.
+        assert_eq!(resizable_col_width(200.0, 0.9, 120.0), 100.0);
+        assert_eq!(resizable_col_width(0.0, 0.5, 120.0), 0.0);
+    }
+
+    #[test]
+    fn the_defaults_leave_a_split_proportional() {
+        // Every pre-existing call site builds a `Split` without the new props, and
+        // must keep the non-interactive proportional behaviour.
+        let split = Split::builder().build();
+        assert!(!split.resizable);
+        assert_eq!(split.id, None);
+        assert_eq!(split.min_pane, min_col());
+        assert_eq!(Column::builder().build().padding, 0.0);
     }
 }

--- a/thoth-plugin-sdk/src/components/list/mod.rs
+++ b/thoth-plugin-sdk/src/components/list/mod.rs
@@ -38,6 +38,30 @@ pub struct ListItemBadge {
     pub color: Option<String>,
 }
 
+/// How a [`List`]'s rows are chromed.
+///
+/// The design sheet draws list rows two ways, and they are not interchangeable:
+///
+/// * In a sidebar panel each row is its own **card** — an app-mockup `.card`:
+///   base fill, hairline edge, 6px gap to the next row, no dividers.
+/// * Inside a framed list each row is **flush** — a display-sheet `.li`:
+///   transparent, separated from its neighbour by a 1px inset hairline.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ListStyle {
+    /// Pick from context: [`Flush`](Self::Flush) for a [`framed`](List::framed)
+    /// list or a [`compact`](List::compact) strip, [`Card`](Self::Card)
+    /// otherwise. This is the default.
+    #[default]
+    Auto,
+    /// Sidebar shape — app-mockup `.card`: each row is a card on the panel
+    /// (base fill, hairline edge, 10px padding, 6px gaps, 3px accent stripe).
+    Card,
+    /// Framed/dense shape — display `.li`: transparent rows with 8px padding, a
+    /// 1px hairline between neighbours, and a 2px accent stripe.
+    Flush,
+}
+
 /// A leading element rendered before a row's content area.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ListItemPrefix {
@@ -77,6 +101,48 @@ pub enum ListItemPrefix {
     },
 }
 
+/// Per-tier type overrides for a [`List`]'s rows.
+///
+/// Every field defaults to "leave it alone", so a list that doesn't set one
+/// renders exactly as it always has. Reach for this when a screen's rows carry a
+/// different type ramp from the default flush/card row — design `.nrow`'s
+/// 12.5/11.5/10.5 stack, or `.pl .by`'s monospace author line.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Builder)]
+#[builder(on(String, into))]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct ListTextStyle {
+    /// Title size in points; the row shape's own size when unset.
+    #[serde(default)]
+    pub title_size: Option<f32>,
+    /// Thicken the title. Defaults to `false`.
+    #[builder(default)]
+    #[serde(default)]
+    pub title_bold: bool,
+    /// Title colour (hex or theme token) for every row; `fg` when unset. A single
+    /// row can override it again with [`ListItem::title_color`].
+    #[serde(default)]
+    pub title_color: Option<String>,
+    /// Description size in points; [`FONT_CAPTION`](crate::theme::FONT_CAPTION)
+    /// when unset.
+    #[serde(default)]
+    pub description_size: Option<f32>,
+    /// Description colour (hex or theme token); `fg-muted` when unset.
+    #[serde(default)]
+    pub description_color: Option<String>,
+    /// Meta-line size in points; 10.5 when unset.
+    #[serde(default)]
+    pub meta_size: Option<f32>,
+    /// Meta-line colour (hex or theme token); `fg-faint` when unset.
+    #[serde(default)]
+    pub meta_color: Option<String>,
+    /// Render the meta line in the monospace family — design `.pl .by`. Defaults
+    /// to `false` (proportional).
+    #[builder(default)]
+    #[serde(default)]
+    pub meta_mono: bool,
+}
+
 /// An always-visible element on the right of a row's title (unlike hover-revealed
 /// [`actions`](ListItem::actions)).
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -91,6 +157,18 @@ pub enum ListItemPostfix {
         /// Text colour (hex or token); defaults to a contrasting colour.
         #[serde(default)]
         fg: Option<String>,
+    },
+    /// Plain trailing text, with no chip chrome at all — design `.cat .c`, a
+    /// bare count pinned to the row's right edge.
+    Text {
+        /// The text.
+        text: String,
+        /// Colour (hex or token); defaults to `fg-muted`.
+        #[serde(default)]
+        color: Option<String>,
+        /// Render in the monospace family — design `.cat .c{font-family:mono}`.
+        #[serde(default)]
+        mono: bool,
     },
     /// A full button. Reported via [`ListEvent::PostfixClicked`].
     Button(Button),
@@ -112,6 +190,10 @@ pub struct ListItem {
     /// Optional secondary description line (`\n` splits into two lines).
     #[serde(default)]
     pub description: Option<String>,
+    /// Optional third, quietest text line below the description (timestamps,
+    /// origins). Rendered one step under the description in size and colour.
+    #[serde(default)]
+    pub meta: Option<String>,
     /// Optional leading element rendered before the content area.
     #[serde(default)]
     pub prefix: Option<ListItemPrefix>,
@@ -132,6 +214,12 @@ pub struct ListItem {
     /// Optional left accent border colour (hex or token); non-compact rows only.
     #[serde(default)]
     pub accent: Option<String>,
+    /// Optional title colour for *this* row (hex or theme token), overriding both
+    /// the row shape's default and [`ListTextStyle::title_color`] — design
+    /// `.cat.on{color:var(--accent)}`, where a selected category's label itself
+    /// goes accent rather than just its background.
+    #[serde(default, rename = "title-color")]
+    pub title_color: Option<String>,
     /// Persistent highlight — used for the active/selected row.
     #[builder(default)]
     #[serde(default)]
@@ -141,6 +229,10 @@ pub struct ListItem {
 /// A scrollable list of rich rows with optional prefix, badge, description, tags,
 /// postfix, and per-row action buttons. Render with [`List::show`], which reports
 /// the clicked row, action, or postfix.
+///
+/// Rows are sized by their content, never pinned to a fixed height: a row is its
+/// padding around the taller of its leading media and its stacked text. See
+/// [`ListStyle`] for the two chrome shapes and how they're picked.
 ///
 /// ```
 /// use thoth_plugin_sdk::components::{List, ListItem};
@@ -164,12 +256,20 @@ pub struct List {
     /// Message shown when `items` is empty.
     #[serde(default)]
     pub empty_label: Option<String>,
-    /// Use compact 26px rows (navigation / category strips). No description,
-    /// tile prefix, or tags.
+    /// Use compact rows (navigation / category strips) — the dense 22px
+    /// data-row height from design `.dr`. No description, tile prefix, or tags.
     #[builder(default)]
     #[serde(default)]
     pub compact: bool,
-    /// Draw a separator line between rows. Defaults to `true`.
+    /// How rows are chromed — cards on a panel, or flush rows in a frame.
+    /// Defaults to [`ListStyle::Auto`], which picks from `framed`/`compact`.
+    #[builder(default)]
+    #[serde(default)]
+    pub style: ListStyle,
+    /// Draw a separator line between rows. Defaults to `true`. Only applies to
+    /// [`ListStyle::Flush`] rows — design puts a hairline between the rows of a
+    /// framed `.list`, never between sidebar cards (which are already separated
+    /// by a gap and their own edge) or between `.dr`-height compact rows.
     #[builder(default = true)]
     #[serde(default = "default_true")]
     pub show_separators: bool,
@@ -186,4 +286,9 @@ pub struct List {
     /// Cap the scroll area at this height (px) and scroll beyond it.
     #[serde(default)]
     pub max_height: Option<f32>,
+    /// Per-tier type overrides for the rows' title / description / meta lines.
+    /// Defaults to the row shape's own ramp.
+    #[builder(default)]
+    #[serde(default, rename = "text-style")]
+    pub text_style: ListTextStyle,
 }

--- a/thoth-plugin-sdk/src/components/list/ui.rs
+++ b/thoth-plugin-sdk/src/components/list/ui.rs
@@ -1,18 +1,108 @@
-use egui::{Align, Align2, CornerRadius, FontId, Layout, RichText, Sense, Vec2};
+use egui::{Align, Align2, CornerRadius, FontId, Layout, RichText, Sense, StrokeKind, Vec2};
 
 use crate::components::helpers::load_icon_texture;
-use crate::theme::{ThemeColors, get_contrast_text_color, phosphor_font_id, resolve_color};
+use crate::theme::{
+    FONT_BODY, FONT_CAPTION, GUTTER_GAP, ICON_CONTROL, RADIUS_CHIP, RADIUS_CONTROL, RADIUS_PANEL,
+    RADIUS_PILL, ROW_HEIGHT, ThemeColors, edge_stroke, phosphor_font_id, resolve_color, with_alpha,
+};
 
-use super::{List, ListItem, ListItemPostfix, ListItemPrefix};
+use super::{List, ListItem, ListItemPostfix, ListItemPrefix, ListStyle};
 
-// Row heights — must match what a row actually draws.
-const ROW_H: f32 = 36.0; // title only
-const ROW_H_DESC: f32 = 50.0; // title + description
-const ROW_H_DESC2: f32 = 70.0; // two-line description
-const ROW_H_TILE: f32 = 48.0; // icon-tile / file-icon prefix
-const ROW_H_COMPACT: f32 = 26.0; // compact strip rows
-const ROW_H_TAGS_ADD: f32 = 20.0; // extra height for a tags row
-const SEP_H: f32 = 1.5;
+// ── Row metrics ───────────────────────────────────────────────────────────────
+//
+// A row is *never* a fixed box. Design draws it as padding around the taller of
+// its leading media and its text block, which is why the display sheet's
+// `.li{height:48px}` and the app-mockup's padded `.card` are the same rule with
+// different padding. Reproducing that rule (rather than pinning 48px) is what
+// makes a title-only sidebar row short and a title + description row tall.
+
+/// Compact strip rows — design `.dr{height:22px}`, the dense data-row shape.
+const ROW_H_COMPACT: f32 = ROW_HEIGHT;
+
+// Card rows — app-mockup `.card`, the sidebar shape.
+/// `.card{padding:10px}`.
+const CARD_PAD: f32 = 10.0;
+/// `.card{margin-bottom:6px}` — cards are parted by a gap, never by a divider.
+const CARD_GAP_Y: f32 = 6.0;
+/// `.cscroll{padding:0 12px}`, pinned to the panel's content gutter so a card's
+/// edge lines up with the `SidebarHeader` above it.
+const CARD_INSET_X: f32 = GUTTER_GAP;
+/// `.cmeta{gap:2px}`.
+const CARD_TEXT_GAP: f32 = 2.0;
+/// `.card::before{width:3px}`.
+const CARD_STRIPE_W: f32 = 3.0;
+
+// Flush rows — display `.li`, the rows of a framed `.list`.
+/// `.li{padding:0 8px}`; also the vertical padding implied by
+/// `.li{height:48px}` around a 32px tile.
+const FLUSH_PAD: f32 = 8.0;
+/// `.li .ld{margin-top:1px}`.
+const FLUSH_TEXT_GAP: f32 = 1.0;
+/// `.li.sel::before{width:2px}`.
+const FLUSH_STRIPE_W: f32 = 2.0;
+
+/// Gap between a row's elements — design `.li{gap:10px}` / `.card{gap:10px}`.
+const GAP: f32 = 10.0;
+/// …and in a compact strip — design `.dr{gap:5px}`.
+const GAP_COMPACT: f32 = 5.0;
+/// Framed container padding — design `.list{padding:4px}`.
+const FRAME_PAD: i8 = 4;
+
+/// Divider between adjacent flush rows — design
+/// `.li+.li{box-shadow:inset 0 1px 0 surface1@24%}`.
+const DIVIDER_ALPHA: u8 = 61; // 24% of 255
+/// Hover wash — design `.li:hover{background:text@5%}`.
+const HOVER_ALPHA: u8 = 13; // 5% of 255
+/// Selected wash — design `.li.sel{background:accent@12%}`.
+const SELECTED_ALPHA: u8 = 31; // 12% of 255
+/// Compact rows follow the data row instead — design `.dr:hover{text@7%}`.
+const HOVER_ALPHA_COMPACT: u8 = 18; // 7% of 255
+/// …and `.dr.sel{background:accent@16%}`.
+const SELECTED_ALPHA_COMPACT: u8 = 41; // 16% of 255
+
+/// Accent stripe inset from the row's top and bottom edges — design
+/// `top:9px;bottom:9px`.
+const STRIPE_INSET_Y: f32 = 9.0;
+
+/// Leading media box — design `.li .tile{width:32px;height:32px}`. Tiles,
+/// host icons and embedded logos all share it, so every row with leading media
+/// is the same shape.
+const TILE: f32 = 32.0;
+/// Tile tint — design `.tile{background:color-mix(accent 15%,transparent)}`.
+const TILE_TINT_ALPHA: u8 = 38; // 15% of 255
+/// Bare-glyph prefixes in a flush/compact row — design `.dr .lead{font-size:13px}`.
+const PREFIX_GLYPH: f32 = 13.0;
+
+/// Flush/compact row title — design `.li .lt{font-size:12px}` (a card row uses
+/// the app-mockup's `.cn`, i.e. [`FONT_BODY`]).
+const FONT_TITLE: f32 = 12.0;
+/// Quietest text tier — design `.lbl{font-size:10.5px}`.
+const FONT_META: f32 = 10.5;
+/// Trailing chip — design `.li .lpost{font-size:10px;padding:2px 8px}`.
+const POSTFIX_FONT: f32 = 10.0;
+/// …and its padding.
+const POSTFIX_PAD_X: f32 = 8.0;
+/// …vertically.
+const POSTFIX_PAD_Y: f32 = 2.0;
+/// Leading badge before the title — app-mockup `.card .badge`, rendered with the
+/// shared [`Badge`](crate::components::Badge) component at this size.
+const BADGE_SIZE: crate::components::Size = crate::components::Size::Medium;
+/// Gap between the leading badge and the title — design `.card{gap:10px}` is for
+/// the row's top-level children; inside the title line the sheet uses 5px.
+const BADGE_GAP: f32 = 5.0;
+/// Tag pills — an SDK extension, drawn as app-mockup `.chip`
+/// (`border-radius:6px;padding:0 6px;color:overlay1`).
+const TAG_PAD_X: f32 = 6.0;
+/// …with enough vertical padding to clear the 10px text.
+const TAG_PAD_Y: f32 = 2.0;
+/// Gap above the tag row, and between wrapped pills.
+const TAG_GAP: f32 = 4.0;
+/// Trailing icon actions — design `.li .lacts{gap:1px}`.
+const ACTION_GAP: f32 = 1.0;
+/// …each a ghost `.ib`: 24px square with a 14px glyph.
+const ACTION_SIZE: f32 = 24.0;
+/// …glyph size inside it.
+const ACTION_GLYPH: f32 = 14.0;
 
 /// What the user did in a [`List`] this frame.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -30,34 +120,190 @@ pub enum ListEvent {
     PostfixClicked(usize),
 }
 
-fn item_height(item: &ListItem, compact: bool) -> f32 {
-    if compact {
-        return ROW_H_COMPACT;
-    }
-    let tile = matches!(
-        item.prefix,
-        Some(ListItemPrefix::IconTile { .. }) | Some(ListItemPrefix::IconFile { .. })
+/// A row title at a faux-bold weight, truncated to the width it is given —
+/// design `.pl .nm{font-weight:600}` / `.nrow .nt{font-weight:600}`. egui ships
+/// no bold face, so the galley is painted twice 0.5pt apart to thicken its
+/// vertical strokes.
+fn bold_title(ui: &mut egui::Ui, text: &str, size: f32, color: egui::Color32) {
+    let mut job = egui::text::LayoutJob::single_section(
+        text.to_owned(),
+        egui::TextFormat {
+            font_id: FontId::proportional(size),
+            color,
+            ..Default::default()
+        },
     );
-    let two_line = item
-        .description
-        .as_deref()
-        .is_some_and(|d| d.contains('\n'));
-    let tags_h = if item.tags.is_empty() {
-        0.0
-    } else {
-        ROW_H_TAGS_ADD
-    };
-    let base = if two_line {
-        ROW_H_DESC2
-    } else {
-        match (tile, item.description.is_some()) {
-            (true, true) => ROW_H_TILE.max(ROW_H_DESC),
-            (true, false) => ROW_H_TILE,
-            (false, true) => ROW_H_DESC,
-            (false, false) => ROW_H,
+    // The same one-line-with-an-ellipsis shape `Label::truncate` produces.
+    job.wrap.max_width = ui.available_width();
+    job.wrap.max_rows = 1;
+    job.wrap.break_anywhere = false;
+    job.wrap.overflow_character = Some('…');
+    let galley = ui.painter().layout_job(job);
+    let (rect, _) = ui.allocate_exact_size(galley.size(), Sense::hover());
+    if ui.is_rect_visible(rect) {
+        ui.painter()
+            .galley(rect.min + egui::vec2(0.5, 0.0), galley.clone(), color);
+        ui.painter().galley(rect.min, galley, color);
+    }
+}
+
+/// Every number a row draws with, resolved once per frame from the list's
+/// [`ListStyle`]. Text line heights are measured from the live font set here so
+/// per-row height stays plain arithmetic even for a list of thousands.
+struct RowMetrics {
+    /// Card rows paint their own fill and hairline edge; flush rows don't.
+    card: bool,
+    /// Compact rows are a fixed `.dr` height with no description or media.
+    compact: bool,
+    /// Inset of the row box from the list's full width.
+    inset_x: f32,
+    /// Padding inside the row box.
+    pad: f32,
+    /// Gap between the row's top-level elements.
+    gap: f32,
+    /// Gap below each row.
+    gap_y: f32,
+    /// Row box corner radius.
+    radius: f32,
+    /// Draw a hairline between adjacent rows.
+    dividers: bool,
+    /// Width of the left accent stripe.
+    stripe_w: f32,
+    /// Size of a bare leading glyph.
+    prefix_glyph: f32,
+    /// Title font size and its laid-out line height.
+    title_font: f32,
+    title_h: f32,
+    /// Thicken every title — [`ListTextStyle::title_bold`].
+    title_bold: bool,
+    /// Gap above each line below the title.
+    text_gap: f32,
+    /// Description font size and the laid-out height of one line.
+    desc_font: f32,
+    desc_h: f32,
+    /// Meta-line font size, whether it is monospace, and its laid-out height.
+    meta_font: f32,
+    meta_mono: bool,
+    meta_h: f32,
+    /// Height of the tag-pill block, including the gap above it.
+    tags_h: f32,
+    /// List-wide type-tier colour overrides, resolved once per frame. `None`
+    /// leaves the tier on its own default.
+    title_color: Option<egui::Color32>,
+    desc_color: Option<egui::Color32>,
+    meta_color: Option<egui::Color32>,
+    /// Hover wash alpha over `fg` (unused by card rows, which go opaque).
+    hover_alpha: u8,
+    /// Selected wash alpha over `accent`.
+    selected_alpha: u8,
+}
+
+impl RowMetrics {
+    fn new(ui: &egui::Ui, list: &List) -> Self {
+        let compact = list.compact;
+        // `Auto`: a framed list holds flush `.li` rows, a bare one holds sidebar
+        // `.card` rows. Compact strips are always the flush `.dr` shape.
+        let card = match list.style {
+            ListStyle::Card => !compact,
+            ListStyle::Flush => false,
+            ListStyle::Auto => !compact && !list.framed,
+        };
+        let line = |size: f32| ui.fonts_mut(|f| f.row_height(&FontId::proportional(size)));
+        let mono_line = |size: f32| ui.fonts_mut(|f| f.row_height(&FontId::monospace(size)));
+        // Type overrides layer on top of the row shape's own ramp; unset fields
+        // leave every existing list exactly where it was.
+        let style = &list.text_style;
+        let title_font = style
+            .title_size
+            .unwrap_or(if card { FONT_BODY } else { FONT_TITLE });
+        let desc_font = style.description_size.unwrap_or(FONT_CAPTION);
+        let meta_font = style.meta_size.unwrap_or(FONT_META);
+        let meta_mono = style.meta_mono;
+        let colors = ThemeColors::from_ctx(ui.ctx());
+        let tint =
+            |token: &Option<String>| token.as_deref().and_then(|c| resolve_color(c, &colors));
+        Self {
+            card,
+            compact,
+            inset_x: if card { CARD_INSET_X } else { 0.0 },
+            pad: if card { CARD_PAD } else { FLUSH_PAD },
+            gap: if compact { GAP_COMPACT } else { GAP },
+            gap_y: if card { CARD_GAP_Y } else { 0.0 },
+            radius: if card { RADIUS_CONTROL } else { RADIUS_CHIP },
+            dividers: list.show_separators && !card && !compact,
+            stripe_w: if card { CARD_STRIPE_W } else { FLUSH_STRIPE_W },
+            prefix_glyph: if card { ICON_CONTROL } else { PREFIX_GLYPH },
+            title_font,
+            title_h: line(title_font),
+            title_bold: style.title_bold,
+            text_gap: if card { CARD_TEXT_GAP } else { FLUSH_TEXT_GAP },
+            desc_font,
+            desc_h: line(desc_font),
+            meta_font,
+            meta_mono,
+            meta_h: if meta_mono {
+                mono_line(meta_font)
+            } else {
+                line(meta_font)
+            },
+            tags_h: TAG_GAP + line(POSTFIX_FONT) + TAG_PAD_Y * 2.0,
+            title_color: tint(&style.title_color),
+            desc_color: tint(&style.description_color),
+            meta_color: tint(&style.meta_color),
+            hover_alpha: if compact {
+                HOVER_ALPHA_COMPACT
+            } else {
+                HOVER_ALPHA
+            },
+            selected_alpha: if compact {
+                SELECTED_ALPHA_COMPACT
+            } else {
+                SELECTED_ALPHA
+            },
         }
-    };
-    base + tags_h
+    }
+
+    /// Height of a row's stacked text: title, description line(s), meta, tags.
+    fn text_height(&self, item: &ListItem) -> f32 {
+        let mut h = self.title_h;
+        if self.compact {
+            return h;
+        }
+        if let Some(desc) = &item.description {
+            let lines = if desc.contains('\n') { 2.0 } else { 1.0 };
+            h += (self.text_gap + self.desc_h) * lines;
+        }
+        if item.meta.is_some() {
+            h += self.text_gap + self.meta_h;
+        }
+        if !item.tags.is_empty() {
+            h += self.tags_h;
+        }
+        h
+    }
+
+    /// Total row height: padding around the taller of the row's leading media
+    /// and its text block. For a flush row with a 32px tile plus a title and a
+    /// description this is `8 + 32 + 8` — the design's `.li{height:48px}`.
+    fn height(&self, item: &ListItem) -> f32 {
+        if self.compact {
+            return ROW_H_COMPACT;
+        }
+        self.pad * 2.0 + self.text_height(item).max(prefix_height(item))
+    }
+}
+
+/// Height a row's leading element needs. Bare glyphs never out-measure the
+/// title line they sit beside, so only media boxes count.
+fn prefix_height(item: &ListItem) -> f32 {
+    match &item.prefix {
+        Some(
+            ListItemPrefix::IconTile { .. }
+            | ListItemPrefix::IconFile { .. }
+            | ListItemPrefix::Image { .. },
+        ) => TILE,
+        _ => 0.0,
+    }
 }
 
 impl List {
@@ -65,12 +311,14 @@ impl List {
     pub fn show(&self, ui: &mut egui::Ui) -> Option<ListEvent> {
         let colors = ThemeColors::from_ctx(ui.ctx());
         if self.framed {
+            // Design `.list`: a panel-filled box with a hairline edge and 4px of
+            // padding, so the first and last rows' hover fills stay inside it.
             egui::Frame::new()
                 .fill(colors.bg_panel)
-                .stroke(egui::Stroke::new(1.0, colors.surface))
-                .corner_radius(6)
-                .inner_margin(egui::Margin::same(4))
-                .outer_margin(egui::Margin::same(8))
+                .stroke(edge_stroke(&colors))
+                .corner_radius(RADIUS_PANEL)
+                .inner_margin(egui::Margin::same(FRAME_PAD))
+                .outer_margin(egui::Margin::same(GUTTER_GAP as i8))
                 .show(ui, |ui| self.render(ui, colors))
                 .inner
         } else {
@@ -79,31 +327,39 @@ impl List {
     }
 
     fn render(&self, ui: &mut egui::Ui, colors: ThemeColors) -> Option<ListEvent> {
+        let m = RowMetrics::new(ui, self);
+
         if self.items.is_empty() {
-            ui.add_space(12.0);
+            ui.add_space(GAP);
             ui.vertical_centered(|ui| {
                 ui.label(
                     RichText::new(self.empty_label.as_deref().unwrap_or("No items"))
                         .color(colors.fg_muted)
-                        .size(12.0),
+                        .size(m.title_font),
                 );
             });
-            ui.add_space(12.0);
+            ui.add_space(GAP);
             return None;
         }
 
         let n = self.items.len();
-        let compact = self.compact;
-        let show_sep = self.show_separators;
 
-        // Cumulative Y offsets for virtual scrolling.
+        // Cumulative Y offsets for virtual scrolling. A row's slot is its height
+        // plus the gap below it (0 for flush rows, whose divider is an inset line
+        // rather than a spacer).
         let mut offsets = Vec::with_capacity(n + 1);
         offsets.push(0.0f32);
         for (i, item) in self.items.iter().enumerate() {
-            let sep = if show_sep && i + 1 < n { SEP_H } else { 0.0 };
-            offsets.push(offsets[i] + item_height(item, compact) + sep);
+            offsets.push(offsets[i] + m.height(item) + m.gap_y);
         }
         let total_h = offsets[n];
+
+        // Design `.li+.li{box-shadow:inset 0 1px 0 surface1@24%}` — built once per
+        // frame, then painted per visible row.
+        let divider = crate::components::Separator::rule(crate::theme::color_to_hex(with_alpha(
+            colors.surface_raised,
+            DIVIDER_ALPHA,
+        )));
 
         let scroll_id = ui.next_auto_id();
         let mut scroll = egui::ScrollArea::vertical()
@@ -117,6 +373,8 @@ impl List {
 
         scroll.show_viewport(ui, |ui, viewport| {
             ui.set_min_height(total_h);
+            // Row spacing is explicit — either a card gap or nothing at all.
+            ui.spacing_mut().item_spacing.y = 0.0;
             let start = offsets
                 .partition_point(|&y| y < viewport.min.y)
                 .saturating_sub(1);
@@ -128,10 +386,10 @@ impl List {
             for idx in start..end {
                 let item = &self.items[idx];
                 let item_id = scroll_id.with(idx);
-                let row_h = item_height(item, compact);
+                let row_h = m.height(item);
                 let was_hovered = ui
                     .ctx()
-                    .memory(|m| m.data.get_temp::<bool>(item_id).unwrap_or(false));
+                    .memory(|mem| mem.data.get_temp::<bool>(item_id).unwrap_or(false));
 
                 let mut postfix_clicked = false;
                 let mut row_action_clicked: Option<usize> = None;
@@ -147,16 +405,20 @@ impl List {
                             ui.horizontal(|ui| {
                                 ui.set_min_width(ui.available_width());
                                 ui.set_min_height(row_h);
-                                Self::row_prefix(ui, item, &colors);
+                                // Every gap inside a row is explicit.
+                                ui.spacing_mut().item_spacing.x = 0.0;
+                                Self::row_prefix(ui, item, &colors, &m);
                                 ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                                     Self::row_postfix(
                                         ui,
                                         item,
                                         &colors,
+                                        &m,
+                                        was_hovered,
                                         &mut postfix_clicked,
                                         &mut row_action_clicked,
                                     );
-                                    Self::row_content(ui, item, &colors, compact, row_h);
+                                    Self::row_content(ui, item, &colors, &m, row_h);
                                 });
                             });
                         })
@@ -164,36 +426,80 @@ impl List {
                     })
                     .inner;
 
-                let is_hovered = ui.rect_contains_pointer(row_resp.rect);
+                // The painted row box — inset from the list's width for cards, so
+                // they read as separate panels sitting in a gutter.
+                let box_rect = row_resp.rect.shrink2(egui::vec2(m.inset_x, 0.0));
+
+                let is_hovered = ui.rect_contains_pointer(box_rect);
                 if is_hovered {
                     ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
                 }
                 ui.ctx()
-                    .memory_mut(|m| m.data.insert_temp(item_id, is_hovered));
+                    .memory_mut(|mem| mem.data.insert_temp(item_id, is_hovered));
 
-                // Row background.
+                // Row background — design `.li.sel` wins over `.li:hover`.
                 let hovering = is_hovered || was_hovered;
-                let bg = if item.selected && hovering {
-                    egui::Shape::rect_filled(row_resp.rect, 3.0, colors.surface_raised)
-                } else if item.selected || hovering {
-                    egui::Shape::rect_filled(row_resp.rect, 3.0, colors.sidebar_hover)
-                } else {
-                    egui::Shape::Noop
-                };
-                ui.painter().set(bg_slot, bg);
+                let mut shapes: Vec<egui::Shape> = Vec::new();
+                if m.card {
+                    // Design `.card`: base fill lifted to `surface0` on hover,
+                    // under a hairline edge.
+                    let fill = if hovering { colors.surface } else { colors.bg };
+                    shapes.push(egui::Shape::rect_filled(box_rect, m.radius, fill));
+                    if item.selected {
+                        shapes.push(egui::Shape::rect_filled(
+                            box_rect,
+                            m.radius,
+                            with_alpha(colors.accent, m.selected_alpha),
+                        ));
+                    }
+                    shapes.push(egui::Shape::rect_stroke(
+                        box_rect,
+                        m.radius,
+                        edge_stroke(&colors),
+                        StrokeKind::Inside,
+                    ));
+                } else if item.selected {
+                    shapes.push(egui::Shape::rect_filled(
+                        box_rect,
+                        m.radius,
+                        with_alpha(colors.accent, m.selected_alpha),
+                    ));
+                } else if hovering {
+                    shapes.push(egui::Shape::rect_filled(
+                        box_rect,
+                        m.radius,
+                        with_alpha(colors.fg, m.hover_alpha),
+                    ));
+                }
+                ui.painter().set(bg_slot, egui::Shape::Vec(shapes));
 
-                // Left accent border.
-                if !compact
-                    && let Some(accent) = item
-                        .accent
-                        .as_deref()
-                        .and_then(|c| resolve_color(c, &colors))
-                {
-                    let border = egui::Rect::from_min_size(
-                        row_resp.rect.min,
-                        egui::vec2(2.0, row_resp.rect.height()),
-                    );
-                    ui.painter().rect_filled(border, 0.0, accent);
+                // Divider — an inset hairline along the top edge, between the rows
+                // of a framed list only. Cards are already parted by a gap and
+                // their own edge; a hairline there just adds noise. Drawn through
+                // the shared `Separator`, without allocating: the row is already
+                // laid out, and a point of height here would push it down.
+                if m.dividers && idx > 0 {
+                    divider.paint_at(ui, box_rect.x_range(), box_rect.top());
+                }
+
+                // Left accent stripe — design `.li.sel::before` / `.card::before`.
+                // Selection wins over the row's own accent so the two can't
+                // disagree about the colour.
+                if !m.compact {
+                    let stripe = if item.selected {
+                        Some(colors.accent)
+                    } else {
+                        item.accent
+                            .as_deref()
+                            .and_then(|c| resolve_color(c, &colors))
+                    };
+                    if let Some(color) = stripe {
+                        Self::left_stripe(ui, box_rect, color, m.stripe_w);
+                    }
+                }
+
+                if m.gap_y > 0.0 {
+                    ui.add_space(m.gap_y);
                 }
 
                 if postfix_clicked {
@@ -206,10 +512,6 @@ impl List {
                 } else if is_hovered && ui.input(|i| i.pointer.primary_clicked()) {
                     event = Some(ListEvent::ItemClicked(idx));
                 }
-
-                if show_sep && idx + 1 < n {
-                    ui.add(crate::components::Separator::plain());
-                }
             }
 
             let remaining = total_h - offsets[end];
@@ -221,38 +523,51 @@ impl List {
         event
     }
 
-    fn row_prefix(ui: &mut egui::Ui, item: &ListItem, colors: &ThemeColors) {
+    /// A vertical bar on the row's left edge, inset from top and bottom. Its
+    /// corner radius is its own width — design `width:2px;border-radius:2px`
+    /// and `width:3px;border-radius:3px`.
+    fn left_stripe(ui: &egui::Ui, row: egui::Rect, color: egui::Color32, width: f32) {
+        let rect = egui::Rect::from_min_size(
+            egui::pos2(row.left(), row.top() + STRIPE_INSET_Y),
+            egui::vec2(width, (row.height() - STRIPE_INSET_Y * 2.0).max(0.0)),
+        );
+        ui.painter().rect_filled(rect, width, color);
+    }
+
+    fn row_prefix(ui: &mut egui::Ui, item: &ListItem, colors: &ThemeColors, m: &RowMetrics) {
+        ui.add_space(m.inset_x + m.pad);
         match &item.prefix {
             Some(ListItemPrefix::Icon { glyph, color }) => {
-                ui.add_space(8.0);
                 let c = color
                     .as_deref()
                     .and_then(|c| resolve_color(c, colors))
                     .unwrap_or(colors.fg_muted);
-                ui.label(RichText::new(glyph).font(phosphor_font_id(13.0)).color(c));
-                ui.add_space(4.0);
+                ui.label(
+                    RichText::new(glyph)
+                        .font(phosphor_font_id(m.prefix_glyph))
+                        .color(c),
+                );
+                ui.add_space(m.gap);
             }
             Some(ListItemPrefix::IconTile { glyph, color }) => {
-                ui.add_space(8.0);
+                // Design `.li .tile`: a tinted square behind a centred glyph.
                 let c = resolve_color(color, colors).unwrap_or(colors.accent);
-                let tile_slot = ui.painter().add(egui::Shape::Noop);
-                let (rect, _) = ui.allocate_exact_size(egui::vec2(32.0, 32.0), Sense::hover());
-                ui.painter().text(
-                    rect.center(),
-                    Align2::CENTER_CENTER,
-                    glyph,
-                    phosphor_font_id(14.0),
-                    c,
-                );
-                ui.painter().set(
-                    tile_slot,
-                    egui::Shape::rect_filled(rect, 7.0, c.linear_multiply(0.15)),
-                );
-                ui.add_space(8.0);
+                let (rect, _) = ui.allocate_exact_size(egui::vec2(TILE, TILE), Sense::hover());
+                if ui.is_rect_visible(rect) {
+                    ui.painter()
+                        .rect_filled(rect, RADIUS_CONTROL, with_alpha(c, TILE_TINT_ALPHA));
+                    ui.painter().text(
+                        rect.center(),
+                        Align2::CENTER_CENTER,
+                        glyph,
+                        phosphor_font_id(ICON_CONTROL),
+                        c,
+                    );
+                }
+                ui.add_space(m.gap);
             }
             Some(ListItemPrefix::IconFile { path }) => {
-                ui.add_space(8.0);
-                let (rect, _) = ui.allocate_exact_size(Vec2::new(48.0, 48.0), Sense::hover());
+                let (rect, _) = ui.allocate_exact_size(Vec2::new(TILE, TILE), Sense::hover());
                 if let Some(texture) =
                     load_icon_texture(ui.ctx(), std::path::Path::new(path), "list_icon")
                 {
@@ -260,26 +575,24 @@ impl List {
                         rect,
                         egui::Image::new(&texture)
                             .fit_to_exact_size(rect.size())
-                            .corner_radius(CornerRadius::same(10)),
+                            .corner_radius(CornerRadius::same(RADIUS_CONTROL as u8)),
                     );
                 }
-                ui.add_space(8.0);
+                ui.add_space(m.gap);
             }
             Some(ListItemPrefix::Image { uri, bytes }) => {
-                ui.add_space(8.0);
-                // Fit within a 48×48 box preserving aspect ratio — logos aren't
+                // Fit within the media box preserving aspect ratio — logos aren't
                 // square, so exact-fit would distort wide marks (e.g. MySQL).
                 ui.add(
                     egui::Image::from_bytes(uri.clone(), bytes.clone())
                         .maintain_aspect_ratio(true)
-                        .max_size(Vec2::new(48.0, 48.0)),
+                        .max_size(Vec2::new(TILE, TILE)),
                 );
-                ui.add_space(8.0);
+                ui.add_space(m.gap);
             }
-            // Still inset so titles line up with prefixed rows.
-            None => {
-                ui.add_space(8.0);
-            }
+            // The row's left padding above is enough — titles in prefix-less rows
+            // line up with the padding, not with prefixed rows' text.
+            None => {}
         }
     }
 
@@ -287,12 +600,48 @@ impl List {
         ui: &mut egui::Ui,
         item: &ListItem,
         colors: &ThemeColors,
+        m: &RowMetrics,
+        hovering: bool,
         postfix_clicked: &mut bool,
         row_action_clicked: &mut Option<usize>,
     ) {
+        // Right-to-left layout: this is the row's right-hand padding.
+        ui.add_space(m.inset_x + m.pad);
+
+        // Hover-revealed trailing action icons (rightmost; iterate reversed so
+        // action[0] ends up leftmost). Design `.lacts{opacity:0}` /
+        // `.li:hover .lacts{opacity:1}` — the space stays reserved either way so
+        // the row's text doesn't reflow under the pointer.
+        for (a, action) in item.actions.iter().enumerate().rev() {
+            if a + 1 < item.actions.len() {
+                ui.add_space(ACTION_GAP);
+            }
+            if hovering {
+                let hit = ui
+                    .add(
+                        crate::components::IconButton::builder()
+                            .icon(action.icon.as_str())
+                            .maybe_tooltip(action.tooltip.as_deref())
+                            .frame(false)
+                            .size_px(ACTION_SIZE)
+                            .icon_size(ACTION_GLYPH)
+                            .build(),
+                    )
+                    .clicked();
+                if hit {
+                    *row_action_clicked = Some(a);
+                }
+            } else {
+                ui.allocate_exact_size(egui::vec2(ACTION_SIZE, ACTION_SIZE), Sense::hover());
+            }
+        }
+        if !item.actions.is_empty() && item.postfix.is_some() {
+            ui.add_space(m.gap);
+        }
+
         match &item.postfix {
             Some(ListItemPostfix::Badge { text, bg, fg }) => {
-                ui.add_space(6.0);
+                // Design `.li .lpost`: a fully-round mono chip.
                 let bg_c = bg
                     .as_deref()
                     .and_then(|c| resolve_color(c, colors))
@@ -300,34 +649,44 @@ impl List {
                 let fg_c = fg
                     .as_deref()
                     .and_then(|c| resolve_color(c, colors))
-                    .unwrap_or_else(|| get_contrast_text_color(bg_c));
+                    .unwrap_or_else(|| crate::theme::get_contrast_text_color(bg_c));
                 let bg_slot = ui.painter().add(egui::Shape::Noop);
-                let galley =
-                    ui.painter()
-                        .layout_no_wrap(text.clone(), FontId::proportional(10.0), fg_c);
-                let pad = egui::vec2(6.0, 2.0);
+                let galley = ui.painter().layout_no_wrap(
+                    text.clone(),
+                    FontId::monospace(POSTFIX_FONT),
+                    fg_c,
+                );
+                let pad = egui::vec2(POSTFIX_PAD_X, POSTFIX_PAD_Y);
                 let size = galley.size() + pad * 2.0;
                 let (rect, _) = ui.allocate_exact_size(size, Sense::hover());
                 if ui.is_rect_visible(rect) {
                     ui.painter().galley(rect.min + pad, galley, fg_c);
-                    ui.painter()
-                        .set(bg_slot, egui::Shape::rect_filled(rect, u8::MAX, bg_c));
+                    ui.painter().set(
+                        bg_slot,
+                        egui::Shape::rect_filled(rect, CornerRadius::same(RADIUS_PILL as u8), bg_c),
+                    );
                 }
+            }
+            Some(ListItemPostfix::Text { text, color, mono }) => {
+                // Design `.cat .c`: a bare count with no chip chrome at all.
+                let c = color
+                    .as_deref()
+                    .and_then(|c| resolve_color(c, colors))
+                    .unwrap_or(colors.fg_muted);
+                let font = if *mono {
+                    FontId::monospace(POSTFIX_FONT)
+                } else {
+                    FontId::proportional(POSTFIX_FONT)
+                };
+                ui.add(egui::Label::new(RichText::new(text).font(font).color(c)));
             }
             Some(ListItemPostfix::Button(btn)) => {
-                ui.add_space(8.0);
-                if ui.add(btn.clone()).clicked() {
-                    *postfix_clicked = true;
-                }
+                *postfix_clicked |= ui.add(btn.clone()).clicked();
             }
             Some(ListItemPostfix::IconButton(btn)) => {
-                ui.add_space(8.0);
-                if ui.add(btn.clone()).clicked() {
-                    *postfix_clicked = true;
-                }
+                *postfix_clicked |= ui.add(btn.clone()).clicked();
             }
             Some(ListItemPostfix::Progress(bar)) => {
-                ui.add_space(8.0);
                 // Keep list bars compact; the Progress component fills the width
                 // it's given and carries its own colour/height.
                 ui.allocate_ui(egui::vec2(80.0, 6.0), |ui| {
@@ -337,23 +696,8 @@ impl List {
             None => {}
         }
 
-        // Hover-revealed trailing action icons (rightmost; iterate reversed so
-        // action[0] ends up leftmost).
-        for (a, action) in item.actions.iter().enumerate().rev() {
-            ui.add_space(4.0);
-            let hit = ui
-                .add(
-                    crate::components::IconButton::builder()
-                        .icon(action.icon.as_str())
-                        .maybe_tooltip(action.tooltip.as_deref())
-                        .frame(false)
-                        .size_px(22.0)
-                        .build(),
-                )
-                .clicked();
-            if hit {
-                *row_action_clicked = Some(a);
-            }
+        if item.postfix.is_some() || !item.actions.is_empty() {
+            ui.add_space(m.gap);
         }
     }
 
@@ -361,7 +705,7 @@ impl List {
         ui: &mut egui::Ui,
         item: &ListItem,
         colors: &ThemeColors,
-        compact: bool,
+        m: &RowMetrics,
         row_h: f32,
     ) {
         let content_w = ui.available_width();
@@ -369,99 +713,102 @@ impl List {
             egui::vec2(content_w, row_h),
             Layout::top_down(Align::LEFT),
             |ui| {
-                let title_h = 15.0;
-                let two_line = item
-                    .description
-                    .as_deref()
-                    .is_some_and(|d| d.contains('\n'));
-                let desc_h = if two_line {
-                    2.0 + 13.0 + 5.0 + 13.0
-                } else if item.description.is_some() {
-                    2.0 + 13.0
-                } else {
-                    0.0
-                };
-                let tags_h = if item.tags.is_empty() {
-                    0.0
-                } else {
-                    ROW_H_TAGS_ADD
-                };
-                let pad = (row_h - (title_h + desc_h + tags_h)).max(0.0) / 2.0;
+                // Design `.cmeta{gap:2px}` / `.ld{margin-top:1px}` — the text is
+                // one tight block, vertically centred in the row.
+                ui.spacing_mut().item_spacing.y = m.text_gap;
+                let pad = (row_h - m.text_height(item)).max(0.0) / 2.0;
                 if pad > 0.0 {
                     ui.add_space(pad);
                 }
 
                 ui.horizontal(|ui| {
-                    ui.spacing_mut().item_spacing.x = 5.0;
+                    ui.spacing_mut().item_spacing.x = BADGE_GAP;
                     if let Some(badge) = &item.badge {
-                        let bg = badge
-                            .color
-                            .as_deref()
-                            .and_then(|c| resolve_color(c, colors))
-                            .unwrap_or(colors.accent_secondary);
-                        let fg = get_contrast_text_color(bg);
-                        let text_w = badge.text.len() as f32 * 6.0;
-                        let (rect, _) =
-                            ui.allocate_exact_size(egui::vec2(text_w + 8.0, 14.0), Sense::hover());
-                        ui.painter().rect_filled(rect, 3.0, bg);
-                        ui.painter().text(
-                            rect.center(),
-                            Align2::CENTER_CENTER,
-                            &badge.text,
-                            FontId::proportional(10.0),
-                            fg,
+                        // App-mockup `.card .badge`: a filled mono chip — the
+                        // shared Badge component, so list badges and standalone
+                        // ones can't drift apart.
+                        ui.add(
+                            crate::components::Badge::builder()
+                                .label(badge.text.clone())
+                                .maybe_color(badge.color.clone())
+                                .size(BADGE_SIZE)
+                                .build(),
                         );
                     }
-                    let title_color = if compact && !item.selected {
-                        colors.fg_muted
+                    // A row's own colour wins, then the list's override, then
+                    // the row shape's default.
+                    let title_color = item
+                        .title_color
+                        .as_deref()
+                        .and_then(|c| resolve_color(c, colors))
+                        .or(m.title_color)
+                        .unwrap_or(if m.compact && !item.selected {
+                            colors.fg_muted
+                        } else {
+                            colors.fg
+                        });
+                    if m.title_bold {
+                        // egui has no bold face, and `RichText::strong` only
+                        // reaches for a colour we've already pinned — so weight
+                        // is faked with a second 0.5pt-offset pass, as
+                        // `Typography` does.
+                        bold_title(ui, &item.title, m.title_font, title_color);
                     } else {
-                        colors.fg
-                    };
-                    let title = RichText::new(&item.title).size(12.0).color(title_color);
-                    let title = if item.selected && compact {
-                        title.strong()
-                    } else {
-                        title
-                    };
-                    ui.add(egui::Label::new(title).truncate());
+                        let title = RichText::new(&item.title)
+                            .size(m.title_font)
+                            .color(title_color);
+                        let title = if item.selected && m.compact {
+                            title.strong()
+                        } else {
+                            title
+                        };
+                        ui.add(egui::Label::new(title).truncate());
+                    }
                 });
 
+                if m.compact {
+                    return;
+                }
+
                 if let Some(desc) = &item.description {
-                    let mut parts = desc.splitn(2, '\n');
-                    if let Some(first) = parts.next() {
+                    let color = m.desc_color.unwrap_or(colors.fg_muted);
+                    for line in desc.splitn(2, '\n') {
                         ui.add(
-                            egui::Label::new(
-                                RichText::new(first).size(11.0).color(colors.fg_muted),
-                            )
-                            .truncate(),
-                        );
-                    }
-                    if let Some(second) = parts.next() {
-                        ui.add_space(3.0);
-                        ui.add(
-                            egui::Label::new(
-                                RichText::new(second).size(11.0).color(colors.fg_muted),
-                            )
-                            .truncate(),
+                            egui::Label::new(RichText::new(line).size(m.desc_font).color(color))
+                                .truncate(),
                         );
                     }
                 }
 
+                // Third tier: one step quieter than the description.
+                if let Some(meta) = &item.meta {
+                    let color = m.meta_color.unwrap_or_else(|| colors.fg_faint());
+                    let text = if m.meta_mono {
+                        RichText::new(meta)
+                            .font(FontId::monospace(m.meta_font))
+                            .color(color)
+                    } else {
+                        RichText::new(meta).size(m.meta_font).color(color)
+                    };
+                    ui.add(egui::Label::new(text).truncate());
+                }
+
                 if !item.tags.is_empty() {
-                    ui.add_space(4.0);
+                    ui.add_space(TAG_GAP - m.text_gap);
                     ui.horizontal_wrapped(|ui| {
-                        ui.spacing_mut().item_spacing = egui::vec2(4.0, 2.0);
+                        ui.spacing_mut().item_spacing = egui::vec2(TAG_GAP, TAG_PAD_Y);
                         for tag in &item.tags {
                             let galley = ui.painter().layout_no_wrap(
                                 tag.clone(),
-                                FontId::proportional(10.0),
+                                FontId::proportional(POSTFIX_FONT),
                                 colors.fg_muted,
                             );
-                            let pad = egui::vec2(5.0, 2.0);
+                            let pad = egui::vec2(TAG_PAD_X, TAG_PAD_Y);
                             let size = galley.size() + pad * 2.0;
                             let (rect, _) = ui.allocate_exact_size(size, Sense::hover());
                             if ui.is_rect_visible(rect) {
-                                ui.painter().rect_filled(rect, 3.0, colors.bg_sunken);
+                                ui.painter()
+                                    .rect_filled(rect, RADIUS_CHIP, colors.bg_sunken);
                                 ui.painter().galley(rect.min + pad, galley, colors.fg_muted);
                             }
                         }
@@ -469,5 +816,154 @@ impl List {
                 }
             },
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::{ListItem, ListItemPrefix};
+
+    /// Run one headless frame and hand the closure a real `Ui`, so row metrics
+    /// are measured against live font data like they are in the app.
+    fn with_ui<R>(f: impl FnOnce(&mut egui::Ui) -> R) -> R {
+        let ctx = egui::Context::default();
+        let mut f = Some(f);
+        let mut out = None;
+        let _ = ctx.run_ui(Default::default(), |ui| {
+            if let Some(f) = f.take() {
+                out = Some(f(ui));
+            }
+        });
+        out.expect("the test frame ran")
+    }
+
+    fn tile_row() -> ListItem {
+        ListItem::builder()
+            .title("production.db")
+            .description("PostgreSQL · 24 tables")
+            .prefix(ListItemPrefix::IconTile {
+                glyph: "d".to_string(),
+                color: "accent".to_string(),
+            })
+            .build()
+    }
+
+    #[test]
+    fn framed_tile_row_is_the_designs_48px() {
+        // Design `.li{height:48px}` is 8px of padding around a 32px tile — the
+        // content-driven rule has to reproduce it exactly.
+        let list = List::builder().framed(true).build();
+        let h = with_ui(|ui| RowMetrics::new(ui, &list).height(&tile_row()));
+        assert_eq!(h, 48.0);
+    }
+
+    #[test]
+    fn card_rows_grow_with_their_content() {
+        let list = List::builder().build();
+        let title_only = ListItem::builder().title("data.json").build();
+        let with_desc = ListItem::builder()
+            .title("data.json")
+            .description("~/Documents")
+            .build();
+        let with_meta = ListItem::builder()
+            .title("data.json")
+            .description("~/Documents")
+            .meta("2 minutes ago")
+            .build();
+        with_ui(|ui| {
+            let m = RowMetrics::new(ui, &list);
+            assert!(m.card, "a bare list uses the sidebar card shape");
+            let (a, b, c) = (
+                m.height(&title_only),
+                m.height(&with_desc),
+                m.height(&with_meta),
+            );
+            assert_eq!(a, CARD_PAD * 2.0 + m.title_h);
+            assert!(
+                a < b,
+                "title-only rows must be shorter than titled+described"
+            );
+            assert!(b < c, "a meta line must add a line's height");
+        });
+    }
+
+    #[test]
+    fn compact_rows_are_the_dense_data_row() {
+        let list = List::builder().compact(true).build();
+        with_ui(|ui| {
+            let m = RowMetrics::new(ui, &list);
+            assert_eq!(m.height(&tile_row()), ROW_HEIGHT);
+            assert!(!m.card, "a compact strip is never a stack of cards");
+            assert!(!m.dividers, "design `.dr` rows carry no hairline");
+        });
+    }
+
+    #[test]
+    fn text_style_defaults_leave_every_tier_alone() {
+        // The whole point of the override struct: a list that doesn't set one
+        // measures exactly as it did before it existed.
+        let plain = List::builder().framed(true).build();
+        with_ui(|ui| {
+            let m = RowMetrics::new(ui, &plain);
+            assert_eq!(m.title_font, FONT_TITLE);
+            assert_eq!(m.desc_font, FONT_CAPTION);
+            assert_eq!(m.meta_font, FONT_META);
+            assert!(!m.title_bold);
+            assert!(!m.meta_mono);
+            assert!(m.title_color.is_none());
+            assert!(m.desc_color.is_none());
+            assert!(m.meta_color.is_none());
+        });
+    }
+
+    #[test]
+    fn text_style_sizes_drive_the_row_height() {
+        // Design `.pl`: a 12.5px title over an 11px description over a 10.5px
+        // monospace author line. The taller ramp has to make the row taller.
+        let styled = List::builder()
+            .style(ListStyle::Flush)
+            .text_style(
+                crate::components::ListTextStyle::builder()
+                    .title_size(20.0)
+                    .title_bold(true)
+                    .meta_mono(true)
+                    .build(),
+            )
+            .build();
+        let plain = List::builder().style(ListStyle::Flush).build();
+        let row = ListItem::builder()
+            .title("plugin")
+            .description("does a thing")
+            .meta("by someone")
+            .build();
+        with_ui(|ui| {
+            let (a, b) = (RowMetrics::new(ui, &plain), RowMetrics::new(ui, &styled));
+            assert_eq!(b.title_font, 20.0);
+            assert!(b.title_bold);
+            assert!(b.meta_mono);
+            assert!(
+                b.height(&row) > a.height(&row),
+                "a bigger title tier must grow the row"
+            );
+        });
+    }
+
+    #[test]
+    fn style_resolution_follows_the_lists_context() {
+        let bare = List::builder().build();
+        let framed = List::builder().framed(true).build();
+        let forced_flush = List::builder().style(ListStyle::Flush).build();
+        let forced_card = List::builder().framed(true).style(ListStyle::Card).build();
+        let no_seps = List::builder().framed(true).show_separators(false).build();
+        with_ui(|ui| {
+            assert!(RowMetrics::new(ui, &bare).card);
+            assert!(!RowMetrics::new(ui, &bare).dividers);
+            assert!(!RowMetrics::new(ui, &framed).card);
+            assert!(RowMetrics::new(ui, &framed).dividers);
+            assert!(!RowMetrics::new(ui, &forced_flush).card);
+            assert!(RowMetrics::new(ui, &forced_card).card);
+            assert!(!RowMetrics::new(ui, &no_seps).dividers);
+        });
     }
 }

--- a/thoth-plugin-sdk/src/components/list/ui.rs
+++ b/thoth-plugin-sdk/src/components/list/ui.rs
@@ -95,7 +95,7 @@ const BADGE_GAP: f32 = 5.0;
 const TAG_PAD_X: f32 = 6.0;
 /// …with enough vertical padding to clear the 10px text.
 const TAG_PAD_Y: f32 = 2.0;
-/// Gap above the tag row, and between wrapped pills.
+/// Gap above the tag row, and between pills.
 const TAG_GAP: f32 = 4.0;
 /// Trailing icon actions — design `.li .lacts{gap:1px}`.
 const ACTION_GAP: f32 = 1.0;
@@ -185,7 +185,8 @@ struct RowMetrics {
     meta_font: f32,
     meta_mono: bool,
     meta_h: f32,
-    /// Height of the tag-pill block, including the gap above it.
+    /// Height of the tag-pill row, including the gap above it. Tags are a single
+    /// row (see [`List::row_content`]), so this is one pill tall.
     tags_h: f32,
     /// List-wide type-tier colour overrides, resolved once per frame. `None`
     /// leaves the tier on its own default.
@@ -795,9 +796,14 @@ impl List {
 
                 if !item.tags.is_empty() {
                     ui.add_space(TAG_GAP - m.text_gap);
-                    ui.horizontal_wrapped(|ui| {
+                    // One row only: `RowMetrics::tags_h` reserves a single pill's
+                    // height, so a wrapped second row would paint over the row
+                    // below (virtual-scroll offsets come from that metric). Pills
+                    // that don't fit the content width are dropped rather than
+                    // wrapped — the first one always draws, however narrow the row.
+                    ui.horizontal(|ui| {
                         ui.spacing_mut().item_spacing = egui::vec2(TAG_GAP, TAG_PAD_Y);
-                        for tag in &item.tags {
+                        for (i, tag) in item.tags.iter().enumerate() {
                             let galley = ui.painter().layout_no_wrap(
                                 tag.clone(),
                                 FontId::proportional(POSTFIX_FONT),
@@ -805,6 +811,9 @@ impl List {
                             );
                             let pad = egui::vec2(TAG_PAD_X, TAG_PAD_Y);
                             let size = galley.size() + pad * 2.0;
+                            if i > 0 && size.x > ui.available_width() {
+                                break;
+                            }
                             let (rect, _) = ui.allocate_exact_size(size, Sense::hover());
                             if ui.is_rect_visible(rect) {
                                 ui.painter()

--- a/thoth-plugin-sdk/src/components/mod.rs
+++ b/thoth-plugin-sdk/src/components/mod.rs
@@ -57,7 +57,7 @@ pub use data_row::DataRowOutput;
 pub use data_row::{DataRow, DataRowIcon, RowHighlights};
 pub use data_view::DataView;
 pub use icon::Icon;
-pub use icon_button::IconButton;
+pub use icon_button::{IconButton, IconButtonSelectedStyle};
 pub use input::Input;
 pub use json_tree::JsonTree;
 pub use key_value_list::{KeyValueList, KvEntry};
@@ -68,7 +68,10 @@ pub use layout::{
 pub use link::Link;
 #[cfg(feature = "egui")]
 pub use list::ListEvent;
-pub use list::{List, ListItem, ListItemAction, ListItemBadge, ListItemPostfix, ListItemPrefix};
+pub use list::{
+    List, ListItem, ListItemAction, ListItemBadge, ListItemPostfix, ListItemPrefix, ListStyle,
+    ListTextStyle,
+};
 pub use markdown::Markdown;
 pub use modal::Modal;
 pub use multi_select::MultiSelect;

--- a/thoth-plugin-sdk/src/components/modal/mod.rs
+++ b/thoth-plugin-sdk/src/components/modal/mod.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::render_node::RenderNode;
 
+/// `serde` default for [`Modal::dismissible`], which defaults to `true`.
+fn default_true() -> bool {
+    true
+}
+
 /// A centered modal overlay dialog with a dimmed backdrop.
 ///
 /// Visibility is plugin-controlled via [`open`](Modal::open): the host only
@@ -29,6 +34,16 @@ pub struct Modal {
     pub id: String,
     /// Title shown in the modal header.
     pub title: String,
+    /// Optional tiny label *above* the title — design `.grouplabel`, the
+    /// header's eyebrow ("PERMISSION REQUESTED"). Text is used verbatim, so pass
+    /// it already upper-cased if that is the intent.
+    #[serde(default)]
+    pub eyebrow: Option<String>,
+    /// Colour for [`eyebrow`](Modal::eyebrow) as a theme token or hex (e.g.
+    /// `"warning"` for design `.grouplabel.warn`). Defaults to the group-label
+    /// muted foreground.
+    #[serde(default, rename = "eyebrow-color")]
+    pub eyebrow_color: Option<String>,
     /// Optional secondary line under the title (e.g. a step hint).
     #[serde(default)]
     pub subtitle: Option<String>,
@@ -50,8 +65,37 @@ pub struct Modal {
     /// Height as a fraction of the viewport (0.0–1.0). When unset, auto-sizes.
     #[serde(default, rename = "height-pct")]
     pub height_pct: Option<f32>,
+    /// Optional leading glyph in the header, before the title — design
+    /// `.m-head`'s status glyph / avatar slot. A Phosphor glyph string.
+    #[serde(default)]
+    pub glyph: Option<String>,
+    /// Colour for [`glyph`](Modal::glyph) as a theme token name (e.g. `"error"`,
+    /// `"warning"`, `"info"`, `"accent"`). Defaults to `accent`.
+    #[serde(default, rename = "glyph-color")]
+    pub glyph_color: Option<String>,
+    /// Render the glyph as a filled 44px tile with a hairline edge (design
+    /// `.avatar`) rather than a bare glyph (design `.glyph`). Defaults to `false`.
+    #[builder(default)]
+    #[serde(default)]
+    pub glyph_tile: bool,
+    /// Whether the header shows a close (✕) affordance and Escape / backdrop
+    /// clicks dismiss the modal. Defaults to `true`; set `false` for a dialog the
+    /// user must answer (the design's update-consent card has no `.x`).
+    #[builder(default = true)]
+    #[serde(default = "crate::components::modal::default_true")]
+    pub dismissible: bool,
     /// Body content, rendered top-to-bottom inside the modal.
     #[builder(default)]
     #[serde(default)]
     pub children: Vec<RenderNode>,
+    /// Action bar pinned to the bottom of the card — design `.m-foot`: a
+    /// full-bleed panel strip with a hairline along its top edge, laid out
+    /// right-to-left so the first node ends up rightmost.
+    ///
+    /// This is the DSL equivalent of [`Modal::show_with_footer`], so a plugin gets
+    /// the same footer chrome the host does instead of approximating it with a
+    /// separator and a row inside the body.
+    #[builder(default)]
+    #[serde(default)]
+    pub footer: Vec<RenderNode>,
 }

--- a/thoth-plugin-sdk/src/components/modal/mod.rs
+++ b/thoth-plugin-sdk/src/components/modal/mod.rs
@@ -26,7 +26,7 @@ fn default_true() -> bool {
 ///
 /// let modal = Modal::builder().id("confirm").title("Delete file?").open(true).build();
 /// ```
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Builder)]
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 #[builder(on(String, into))]
 #[non_exhaustive]
 pub struct Modal {
@@ -98,4 +98,30 @@ pub struct Modal {
     #[builder(default)]
     #[serde(default)]
     pub footer: Vec<RenderNode>,
+}
+
+impl Default for Modal {
+    /// A closed, dismissible modal — mirrors the builder's and the
+    /// deserializer's defaults (a derived `Default` would leave
+    /// [`dismissible`](Modal::dismissible) `false`).
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            title: String::new(),
+            eyebrow: None,
+            eyebrow_color: None,
+            subtitle: None,
+            open: false,
+            close_id: None,
+            width: None,
+            width_pct: None,
+            height_pct: None,
+            glyph: None,
+            glyph_color: None,
+            glyph_tile: false,
+            dismissible: default_true(),
+            children: Vec::new(),
+            footer: Vec::new(),
+        }
+    }
 }

--- a/thoth-plugin-sdk/src/components/modal/ui.rs
+++ b/thoth-plugin-sdk/src/components/modal/ui.rs
@@ -1,12 +1,54 @@
 use egui::Widget;
 
-use crate::components::{IconButton, Separator};
+use crate::components::{IconButton, Typography, TypographyVariant};
 use crate::render_node::UiEvent;
 use crate::theme::ThemeColors;
 
 use super::Modal;
 
+/// A modal's action bar. Boxed so [`Modal::frame`] can take it as one optional
+/// argument regardless of what the caller closes over.
+type Footer<'a> = Box<dyn FnOnce(&mut egui::Ui) + 'a>;
+
+/// Header eyebrow type size — design `.grouplabel{font-size:10px}`.
+const EYEBROW_FONT: f32 = 10.0;
+
+/// The header and sizing configuration lifted off a [`Modal`], so `frame` takes
+/// one argument instead of eight. Borrowed field-wise, which lets `show` hand it
+/// the chrome while still mutably borrowing `children`.
+struct Chrome<'a> {
+    id: &'a str,
+    title: &'a str,
+    eyebrow: Option<&'a str>,
+    eyebrow_color: Option<&'a str>,
+    subtitle: Option<&'a str>,
+    glyph: Option<&'a str>,
+    glyph_color: Option<&'a str>,
+    glyph_tile: bool,
+    dismissible: bool,
+    width: Option<f32>,
+    width_pct: Option<f32>,
+    height_pct: Option<f32>,
+}
+
 impl Modal {
+    /// Borrow this modal's header/sizing config for [`Modal::frame`].
+    fn chrome(&self) -> Chrome<'_> {
+        Chrome {
+            id: &self.id,
+            title: &self.title,
+            eyebrow: self.eyebrow.as_deref(),
+            eyebrow_color: self.eyebrow_color.as_deref(),
+            subtitle: self.subtitle.as_deref(),
+            glyph: self.glyph.as_deref(),
+            glyph_color: self.glyph_color.as_deref(),
+            glyph_tile: self.glyph_tile,
+            dismissible: self.dismissible,
+            width: self.width,
+            width_pct: self.width_pct,
+            height_pct: self.height_pct,
+        }
+    }
     /// Render the modal overlay, drawing its [`children`](Modal::children) (the
     /// DSL path) and collecting their events.
     ///
@@ -14,21 +56,66 @@ impl Modal {
     /// backdrop click, or the header close button). The caller (or the
     /// `RenderNode` renderer) turns that into the close event.
     pub fn show(&mut self, ui: &mut egui::Ui, events: &mut Vec<UiEvent>) -> bool {
-        let children = &mut self.children;
-        Self::frame(
-            &self.id,
-            &self.title,
-            self.subtitle.as_deref(),
-            self.width,
-            self.width_pct,
-            self.height_pct,
+        // Field-wise borrows: the chrome reads the header fields while `children`
+        // is borrowed mutably for the body.
+        let Modal {
+            id,
+            title,
+            eyebrow,
+            eyebrow_color,
+            subtitle,
+            glyph,
+            glyph_color,
+            glyph_tile,
+            dismissible,
+            width,
+            width_pct,
+            height_pct,
+            children,
+            footer,
+            ..
+        } = self;
+        let chrome = Chrome {
+            id,
+            title,
+            eyebrow: eyebrow.as_deref(),
+            eyebrow_color: eyebrow_color.as_deref(),
+            subtitle: subtitle.as_deref(),
+            glyph: glyph.as_deref(),
+            glyph_color: glyph_color.as_deref(),
+            glyph_tile: *glyph_tile,
+            dismissible: *dismissible,
+            width: *width,
+            width_pct: *width_pct,
+            height_pct: *height_pct,
+        };
+        // `events` is borrowed by both closures, so the footer collects into its
+        // own buffer and they're merged after the frame returns.
+        let mut footer_events = Vec::new();
+        let footer_bar: Option<Footer<'_>> = if footer.is_empty() {
+            None
+        } else {
+            let sink = &mut footer_events;
+            Some(Box::new(move |ui: &mut egui::Ui| {
+                // Right-to-left, so declaration order reads rightmost-first —
+                // the same contract as `show_with_footer`.
+                for node in footer {
+                    node.show(ui, sink);
+                }
+            }))
+        };
+        let closed = Self::frame(
+            chrome,
             ui,
             |ui| {
                 for child in children {
                     child.show(ui, events);
                 }
             },
-        )
+            footer_bar,
+        );
+        events.append(&mut footer_events);
+        closed
     }
 
     /// Render the modal overlay, drawing its content with the `body` closure
@@ -39,33 +126,54 @@ impl Modal {
     where
         F: FnOnce(&mut egui::Ui),
     {
-        Self::frame(
-            &self.id,
-            &self.title,
-            self.subtitle.as_deref(),
-            self.width,
-            self.width_pct,
-            self.height_pct,
-            ui,
-            body,
-        )
+        Self::frame(self.chrome(), ui, body, None)
     }
 
-    /// Draw the backdrop + centered window chrome and run `body` for content.
-    #[allow(clippy::too_many_arguments)]
+    /// As [`show_with`](Modal::show_with), plus an action bar pinned to the bottom
+    /// of the card — design `.m-foot`.
+    ///
+    /// The footer is a *sibling* of the body, not part of it: it spans the card's
+    /// full width with its own panel fill and a hairline along its top edge, so it
+    /// cannot be drawn from inside `body` (which is inset by the body padding).
+    /// Lay the actions out right-to-left; they render right-aligned as the design
+    /// specifies.
+    /// The footer only has to live for the duration of this call, so it may borrow
+    /// locals — no need to route clicks through a cell.
+    pub fn show_with_footer<'f, F, G>(&self, ui: &mut egui::Ui, body: F, footer: G) -> bool
+    where
+        F: FnOnce(&mut egui::Ui),
+        G: FnOnce(&mut egui::Ui) + 'f,
+    {
+        Self::frame(self.chrome(), ui, body, Some(Box::new(footer)))
+    }
+
+    /// Draw the backdrop + centered window chrome and run `body` for content,
+    /// optionally followed by a full-bleed action bar.
     fn frame<F: FnOnce(&mut egui::Ui)>(
-        id: &str,
-        title: &str,
-        subtitle: Option<&str>,
-        width: Option<f32>,
-        width_pct: Option<f32>,
-        height_pct: Option<f32>,
+        chrome: Chrome<'_>,
         ui: &mut egui::Ui,
         body: F,
+        footer: Option<Footer<'_>>,
     ) -> bool {
+        let Chrome {
+            id,
+            title,
+            eyebrow,
+            eyebrow_color,
+            subtitle,
+            glyph,
+            glyph_color,
+            glyph_tile,
+            dismissible,
+            width,
+            width_pct,
+            height_pct,
+        } = chrome;
         let ctx = ui.ctx().clone();
         let colors = ThemeColors::from_ctx(&ctx);
-        let mut close_requested = ctx.input(|i| i.key_pressed(egui::Key::Escape));
+        // A non-dismissible modal must be answered: Escape and backdrop clicks do
+        // nothing and no ✕ is drawn.
+        let mut close_requested = dismissible && ctx.input(|i| i.key_pressed(egui::Key::Escape));
 
         let screen = ctx.content_rect();
 
@@ -80,16 +188,19 @@ impl Modal {
                 ui.allocate_rect(screen, egui::Sense::click())
             })
             .inner;
-        if backdrop.clicked() {
+        if backdrop.clicked() && dismissible {
             close_requested = true;
         }
 
         // ── Window (fixed px width, or a fraction of the viewport) ───────────
+        // Design `.card`: canvas fill (*not* the panel tint), hairline edge, panel
+        // corners and the dialog shadow. No inner margin — the head and body own
+        // their own padding, which is asymmetric (18/20/14 vs 0/20/16).
         let modal_frame = egui::Frame::new()
-            .fill(colors.bg_panel)
-            .stroke(egui::Stroke::new(1.0, colors.surface_raised))
-            .corner_radius(10.0)
-            .inner_margin(egui::Margin::same(16));
+            .fill(colors.bg)
+            .stroke(crate::theme::edge_stroke(&colors))
+            .corner_radius(crate::theme::RADIUS_PANEL)
+            .shadow(crate::theme::dialog_shadow(ui.visuals().dark_mode));
         let win = egui::Window::new(format!("__modal_{id}"))
             .order(egui::Order::Foreground)
             .collapsible(false)
@@ -113,39 +224,169 @@ impl Modal {
         };
 
         win.show(&ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.vertical(|ui| {
-                    ui.label(
-                        egui::RichText::new(title)
-                            .size(14.0)
-                            .strong()
-                            .color(colors.fg),
-                    );
-                    if let Some(sub) = subtitle.filter(|s| !s.is_empty()) {
-                        ui.label(egui::RichText::new(sub).size(11.0).color(colors.fg_muted));
-                    }
-                });
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if IconButton::builder()
-                        .icon(egui_phosphor::regular::X)
-                        .frame(true)
-                        .build()
-                        .ui(ui)
-                        .clicked()
-                    {
-                        close_requested = true;
-                    }
-                });
-            });
-            ui.add(Separator::with_margins(6.0, 8.0));
+            ui.spacing_mut().item_spacing.y = 0.0;
 
-            if let Some(h) = h {
-                let header_overhead = 40.0;
-                egui::ScrollArea::vertical()
-                    .max_height((h - header_overhead).max(0.0))
-                    .show(ui, body);
-            } else {
-                body(ui);
+            // ── Header — design `.m-head{padding:18px 20px 14px;gap:13px}` ────
+            egui::Frame::NONE
+                .inner_margin(egui::Margin {
+                    left: 20,
+                    right: 20,
+                    top: 18,
+                    bottom: 14,
+                })
+                .show(ui, |ui| {
+                    ui.spacing_mut().item_spacing.x = 13.0;
+                    ui.horizontal_top(|ui| {
+                        // Leading status glyph — design `.glyph` (a bare 44px cell)
+                        // or `.avatar` (the same box filled, with a hairline edge).
+                        if let Some(g) = glyph.filter(|g| !g.is_empty()) {
+                            let tint = glyph_color
+                                .and_then(|t| crate::theme::resolve_color(t, &colors))
+                                .unwrap_or(colors.accent);
+                            let (rect, _) = ui
+                                .allocate_exact_size(egui::vec2(44.0, 44.0), egui::Sense::hover());
+                            if glyph_tile {
+                                ui.painter().rect_filled(
+                                    rect,
+                                    crate::theme::RADIUS_PANEL,
+                                    colors.surface,
+                                );
+                                ui.painter().rect_stroke(
+                                    rect,
+                                    crate::theme::RADIUS_PANEL,
+                                    crate::theme::edge_stroke(&colors),
+                                    egui::StrokeKind::Inside,
+                                );
+                            }
+                            ui.painter().text(
+                                if glyph_tile {
+                                    rect.center()
+                                } else {
+                                    // Design `.glyph` is left-aligned in its cell.
+                                    egui::pos2(rect.left(), rect.center().y)
+                                },
+                                if glyph_tile {
+                                    egui::Align2::CENTER_CENTER
+                                } else {
+                                    egui::Align2::LEFT_CENTER
+                                },
+                                g,
+                                crate::theme::phosphor_font_id(if glyph_tile {
+                                    24.0
+                                } else {
+                                    30.0
+                                }),
+                                tint,
+                            );
+                        }
+                        ui.vertical(|ui| {
+                            ui.spacing_mut().item_spacing.y = 3.0;
+                            // Design `.grouplabel`: the eyebrow above the title,
+                            // 10px bold, muted unless the caller tints it.
+                            if let Some(label) = eyebrow.filter(|e| !e.is_empty()) {
+                                ui.add(
+                                    Typography::builder()
+                                        .text(label)
+                                        .variant(TypographyVariant::GroupLabel)
+                                        .size(EYEBROW_FONT)
+                                        .maybe_color(eyebrow_color)
+                                        .build(),
+                                );
+                            }
+                            ui.add(
+                                Typography::builder()
+                                    .text(title)
+                                    .variant(TypographyVariant::Heading)
+                                    .size(15.0)
+                                    .build(),
+                            );
+                            if let Some(sub) = subtitle.filter(|s| !s.is_empty()) {
+                                ui.label(
+                                    egui::RichText::new(sub).size(12.0).color(colors.fg_muted),
+                                );
+                            }
+                        });
+                        // Design `.m-head .x` is a *ghost* 24px close affordance —
+                        // no fill or edge until hovered. Omitted entirely when the
+                        // modal is not dismissible.
+                        if dismissible {
+                            ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
+                                if IconButton::builder()
+                                    .icon(egui_phosphor::regular::X)
+                                    .frame(false)
+                                    .size_px(24.0)
+                                    .icon_size(15.0)
+                                    .tooltip("Close")
+                                    .build()
+                                    .ui(ui)
+                                    .clicked()
+                                {
+                                    close_requested = true;
+                                }
+                            });
+                        }
+                    });
+                });
+
+            // ── Body — design `.m-body{padding:0 20px 16px}` ──────────────────
+            egui::Frame::NONE
+                .inner_margin(egui::Margin {
+                    left: 20,
+                    right: 20,
+                    top: 0,
+                    bottom: 16,
+                })
+                .show(ui, |ui| {
+                    ui.spacing_mut().item_spacing.y = 8.0;
+                    // Body copy is 13px in the softer `subtext0`; children that set
+                    // their own size or colour still win.
+                    ui.visuals_mut().widgets.noninteractive.fg_stroke.color = colors.fg_subtle();
+                    if let Some(h) = h {
+                        // Head padding + title + body padding, so a height-capped
+                        // modal scrolls its body rather than overflowing the card.
+                        let header_overhead = 78.0;
+                        egui::ScrollArea::vertical()
+                            .max_height((h - header_overhead).max(0.0))
+                            .show(ui, body);
+                    } else {
+                        body(ui);
+                    }
+                });
+
+            // ── Footer — design `.m-foot`: full-bleed panel strip with a hairline
+            // along its top edge, actions right-aligned. Drawn edge to edge, so it
+            // uses the card's own width rather than the body's inset.
+            if let Some(footer) = footer {
+                let strip = egui::Frame::NONE
+                    .fill(colors.bg_panel)
+                    .inner_margin(egui::Margin {
+                        left: 20,
+                        right: 20,
+                        top: 12,
+                        bottom: 16,
+                    })
+                    .show(ui, |ui| {
+                        ui.spacing_mut().item_spacing.x = 8.0;
+                        // `horizontal` bounds the row to its content height first.
+                        // Laying the actions out right-to-left directly on this
+                        // vertical ui would let a nested layout (e.g. a `.m-foot
+                        // .split` left-hand control) claim the window's whole
+                        // remaining height, inflating the strip.
+                        ui.horizontal(|ui| {
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                footer,
+                            );
+                        });
+                    });
+                ui.painter().hline(
+                    strip.response.rect.x_range(),
+                    strip.response.rect.top() + 0.5,
+                    egui::Stroke::new(
+                        1.0,
+                        crate::theme::with_alpha(colors.surface_raised, 66), // 26%
+                    ),
+                );
             }
         });
 

--- a/thoth-plugin-sdk/src/components/modal/ui.rs
+++ b/thoth-plugin-sdk/src/components/modal/ui.rs
@@ -212,6 +212,16 @@ impl Modal {
 
         let w = width.or_else(|| width_pct.map(|p| screen.width() * p.clamp(0.0, 1.0)));
         let h = height_pct.map(|p| screen.height() * p.clamp(0.0, 1.0));
+        // The footer strip is a *sibling* of the body, so a height-capped card has
+        // to take it out of the body's budget. Its height only exists once it's
+        // drawn (below the body), so the previous pass's measurement is cached and
+        // reserved here.
+        let footer_id = egui::Id::new(("modal_footer_h", id));
+        let footer_h = if footer.is_some() && h.is_some() {
+            ctx.data(|d| d.get_temp::<f32>(footer_id).unwrap_or(0.0))
+        } else {
+            0.0
+        };
         let win = match (w, h) {
             (Some(w), Some(h)) => win.fixed_size([w, h]),
             (Some(w), None) => win.min_width(w).max_width(w),
@@ -341,12 +351,15 @@ impl Modal {
                     // Body copy is 13px in the softer `subtext0`; children that set
                     // their own size or colour still win.
                     ui.visuals_mut().widgets.noninteractive.fg_stroke.color = colors.fg_subtle();
-                    if let Some(h) = h {
-                        // Head padding + title + body padding, so a height-capped
-                        // modal scrolls its body rather than overflowing the card.
-                        let header_overhead = 78.0;
+                    if h.is_some() {
+                        // What's left of the card: `available_height` already nets
+                        // out the *measured* header (whose height varies with the
+                        // glyph tile, eyebrow and subtitle) and this frame's own
+                        // padding, so only the footer has to be subtracted. The
+                        // body then scrolls rather than overflowing the card.
+                        let budget = (ui.available_height() - footer_h).max(0.0);
                         egui::ScrollArea::vertical()
-                            .max_height((h - header_overhead).max(0.0))
+                            .max_height(budget)
                             .show(ui, body);
                     } else {
                         body(ui);
@@ -387,6 +400,14 @@ impl Modal {
                         crate::theme::with_alpha(colors.surface_raised, 66), // 26%
                     ),
                 );
+                // Feed the measurement back for the next pass's body budget.
+                if h.is_some() {
+                    let measured = strip.response.rect.height();
+                    if (measured - footer_h).abs() > 0.5 {
+                        ui.ctx().data_mut(|d| d.insert_temp(footer_id, measured));
+                        ui.ctx().request_repaint();
+                    }
+                }
             }
         });
 

--- a/thoth-plugin-sdk/src/components/multi_select/mod.rs
+++ b/thoth-plugin-sdk/src/components/multi_select/mod.rs
@@ -42,10 +42,17 @@ pub struct MultiSelect {
     #[builder(default)]
     #[serde(default)]
     pub disabled: bool,
-    /// Singular noun used in the trigger's count summary, e.g. `"column"` renders
-    /// as `"2 columns"`. When `None` the summary reads `"2 selected"`.
+    /// Singular noun used in the trigger's count summary for a single selection,
+    /// e.g. `"column"` renders as `"1 column"`. When `None` the summary reads
+    /// `"1 selected"`.
     #[serde(default)]
     pub item_noun: Option<String>,
+    /// Plural noun used for counts above one, e.g. `"columns"` renders as
+    /// `"2 columns"`. Plurals are never derived from
+    /// [`item_noun`](MultiSelect::item_noun) — some nouns don't take a bare `s`
+    /// (`"entry"`, `"match"`) — so without this the summary reads `"2 selected"`.
+    #[serde(default)]
+    pub item_noun_plural: Option<String>,
     /// Trigger size. Defaults to [`Size::Medium`].
     #[builder(default)]
     #[serde(default)]

--- a/thoth-plugin-sdk/src/components/multi_select/mod.rs
+++ b/thoth-plugin-sdk/src/components/multi_select/mod.rs
@@ -1,9 +1,14 @@
+#[cfg(feature = "egui")]
+mod ui;
+
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
 use super::SelectOption;
+use crate::components::Size;
 
-/// A checkbox list selecting multiple values. Owns the selected `value` set;
+/// A dropdown selecting multiple values: a trigger summarising the selection
+/// count, opening a popover of checkbox rows. Owns the selected `value` set;
 /// [`MultiSelect::show`] updates it in place.
 ///
 /// ```
@@ -21,7 +26,7 @@ pub struct MultiSelect {
     #[builder(default)]
     #[serde(default)]
     pub id: String,
-    /// Optional group label shown above the options.
+    /// Optional group label shown above the trigger.
     #[builder(default)]
     #[serde(default)]
     pub label: String,
@@ -37,32 +42,15 @@ pub struct MultiSelect {
     #[builder(default)]
     #[serde(default)]
     pub disabled: bool,
-}
-
-#[cfg(feature = "egui")]
-impl MultiSelect {
-    /// Render the list, updating [`value`](MultiSelect::value) in place.
-    /// Returns `true` if the selection changed this frame.
-    pub fn show(&mut self, ui: &mut egui::Ui) -> bool {
-        let mut changed = false;
-        ui.add_enabled_ui(!self.disabled, |ui| {
-            ui.vertical(|ui| {
-                if !self.label.is_empty() {
-                    ui.label(&self.label);
-                }
-                for opt in &self.options {
-                    let mut on = self.value.contains(&opt.value);
-                    if ui.checkbox(&mut on, &opt.label).changed() {
-                        changed = true;
-                        if on {
-                            self.value.push(opt.value.clone());
-                        } else {
-                            self.value.retain(|v| v != &opt.value);
-                        }
-                    }
-                }
-            });
-        });
-        changed
-    }
+    /// Singular noun used in the trigger's count summary, e.g. `"column"` renders
+    /// as `"2 columns"`. When `None` the summary reads `"2 selected"`.
+    #[serde(default)]
+    pub item_noun: Option<String>,
+    /// Trigger size. Defaults to [`Size::Medium`].
+    #[builder(default)]
+    #[serde(default)]
+    pub size: Size,
+    /// Fixed trigger width. When `None`, the trigger fills the available width.
+    #[serde(default)]
+    pub width: Option<f32>,
 }

--- a/thoth-plugin-sdk/src/components/multi_select/ui.rs
+++ b/thoth-plugin-sdk/src/components/multi_select/ui.rs
@@ -1,0 +1,203 @@
+use crate::components::select::ui::{paint_trigger, paint_truncated, show_popover};
+use crate::theme::{
+    FONT_CONTROL, RADIUS_CHECK, RADIUS_CHIP, ThemeColors, edge_stroke, get_contrast_text_color,
+    phosphor_font_id, with_alpha,
+};
+
+use super::MultiSelect;
+
+// ── Design metrics ────────────────────────────────────────────────────────────
+
+/// Option row height — design the multi-select `.popover` rows (32px).
+const ROW_HEIGHT: f32 = 32.0;
+/// Option row horizontal padding — design `padding:0 6px`.
+const ROW_PAD_X: f32 = 6.0;
+/// Gap between the checkbox and its label — design `.opt-lbl{gap:8px}`.
+const ROW_GAP: f32 = 8.0;
+/// Checkbox side — design `.cb{width:16px;height:16px}`.
+const CB_SIZE: f32 = 16.0;
+/// Checkbox glyph size — design `.cb{font-size:11px}`.
+const CB_GLYPH: f32 = 11.0;
+/// Row-hover wash, matching the single select's `.opt:hover` (text@7%).
+const HOVER_ALPHA: u8 = 18;
+/// Rows shown before the list starts scrolling.
+const MAX_VISIBLE: usize = 8;
+
+impl MultiSelect {
+    /// Render the dropdown, updating [`value`](MultiSelect::value) in place.
+    /// Returns `true` if the selection changed this frame.
+    pub fn show(&mut self, ui: &mut egui::Ui) -> bool {
+        let colors = ThemeColors::from_ctx(ui.ctx());
+        let (font_size, trigger_h) = self.size.field_metrics();
+        let mut changed = false;
+
+        ui.add_enabled_ui(!self.disabled, |ui| {
+            ui.vertical(|ui| {
+                if !self.label.is_empty() {
+                    ui.label(&self.label);
+                }
+
+                // Derived from the `ui` (not a global `Id::new`) so two instances
+                // sharing a string id keep distinct open/closed state.
+                let id = ui.make_persistent_id(&self.id);
+                let mut is_open: bool = ui.ctx().data(|d| d.get_temp(id).unwrap_or(false));
+
+                // ── Trigger ───────────────────────────────────────────────────
+                let trigger_w = self.width.unwrap_or_else(|| ui.available_width());
+                let (trigger_rect, trigger_resp) = paint_trigger(
+                    ui,
+                    &colors,
+                    egui::vec2(trigger_w, trigger_h),
+                    font_size,
+                    &self.summary(),
+                    is_open,
+                    // No leading glyph on a multi-select trigger — its label is a
+                    // selection count, not a named value.
+                    None,
+                );
+
+                if trigger_resp.clicked() {
+                    is_open = !is_open;
+                    ui.ctx().data_mut(|d| d.insert_temp(id, is_open));
+                }
+                if !is_open {
+                    return;
+                }
+
+                // ── Popover ───────────────────────────────────────────────────
+                let scroll_h = ROW_HEIGHT * MAX_VISIBLE.min(self.options.len().max(1)) as f32;
+                let text_color = if ui.is_enabled() {
+                    colors.fg
+                } else {
+                    colors.fg_faint()
+                };
+
+                // Collected rather than applied inline: the row loop borrows
+                // `options`, so `value` can only be edited once it's done.
+                let mut toggled: Option<String> = None;
+
+                let (popover_resp, ()) = show_popover(
+                    ui,
+                    id.with("_area"),
+                    trigger_rect,
+                    &colors,
+                    |ui, popup_w| {
+                        egui::ScrollArea::vertical()
+                            .max_height(scroll_h)
+                            .auto_shrink([false, true])
+                            .show(ui, |ui| {
+                                ui.set_min_width(popup_w);
+                                ui.spacing_mut().item_spacing.y = 0.0;
+                                for opt in &self.options {
+                                    let on = self.value.contains(&opt.value);
+                                    if row(ui, &colors, &opt.label, on, text_color) {
+                                        toggled = Some(opt.value.clone());
+                                    }
+                                }
+                            });
+                    },
+                );
+
+                if let Some(value) = toggled {
+                    changed = true;
+                    if self.value.contains(&value) {
+                        self.value.retain(|v| v != &value);
+                    } else {
+                        self.value.push(value);
+                    }
+                }
+
+                let escape = ui.ctx().input(|i| i.key_pressed(egui::Key::Escape));
+                let interact_pos = ui
+                    .ctx()
+                    .input(|i| i.pointer.interact_pos())
+                    .unwrap_or_default();
+                // Toggling a row keeps the popover open, so it only closes on a
+                // click outside it and the trigger — or on Escape.
+                let click_outside =
+                    popover_resp.clicked_elsewhere() && !trigger_rect.contains(interact_pos);
+                if escape || click_outside {
+                    ui.ctx().data_mut(|d| d.insert_temp::<bool>(id, false));
+                }
+            });
+        });
+
+        changed
+    }
+
+    /// The trigger label: a count of what's selected, e.g. `"2 columns"`.
+    fn summary(&self) -> String {
+        let n = self.value.len();
+        match &self.item_noun {
+            Some(noun) if n == 1 => format!("1 {noun}"),
+            Some(noun) => format!("{n} {noun}s"),
+            None if n == 0 => "None selected".to_owned(),
+            None => format!("{n} selected"),
+        }
+    }
+}
+
+/// Paint one checkbox row of the popover — design an `.opt-lbl` (checkbox + label,
+/// 8px gap) inside a 32px row. Returns `true` when the row was clicked.
+fn row(
+    ui: &mut egui::Ui,
+    colors: &ThemeColors,
+    label: &str,
+    checked: bool,
+    text_color: egui::Color32,
+) -> bool {
+    let (rect, resp) = ui.allocate_exact_size(
+        egui::vec2(ui.available_width(), ROW_HEIGHT),
+        egui::Sense::click(),
+    );
+
+    if ui.is_rect_visible(rect) {
+        if resp.hovered() {
+            ui.painter()
+                .rect_filled(rect, RADIUS_CHIP, with_alpha(colors.fg, HOVER_ALPHA));
+        }
+
+        // ── Checkbox — design `.cb` / `.cb.on` ────────────────────────────────
+        let cb_rect = egui::Rect::from_center_size(
+            egui::pos2(rect.min.x + ROW_PAD_X + CB_SIZE / 2.0, rect.center().y),
+            egui::Vec2::splat(CB_SIZE),
+        );
+        if checked {
+            // Checked drops the edge entirely and fills with mauve.
+            ui.painter()
+                .rect_filled(cb_rect, RADIUS_CHECK, colors.accent);
+            ui.painter().text(
+                cb_rect.center(),
+                egui::Align2::CENTER_CENTER,
+                egui_phosphor::regular::CHECK,
+                phosphor_font_id(CB_GLYPH),
+                get_contrast_text_color(colors.accent),
+            );
+        } else {
+            ui.painter().rect(
+                cb_rect,
+                RADIUS_CHECK,
+                colors.surface,
+                edge_stroke(colors),
+                egui::StrokeKind::Inside,
+            );
+        }
+
+        // ── Label ─────────────────────────────────────────────────────────────
+        let label_x = cb_rect.max.x + ROW_GAP;
+        paint_truncated(
+            ui.painter(),
+            egui::pos2(label_x, rect.center().y),
+            label,
+            egui::FontId::proportional(FONT_CONTROL),
+            text_color,
+            (rect.max.x - ROW_PAD_X - label_x).max(0.0),
+        );
+
+        if resp.hovered() {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+        }
+    }
+
+    resp.clicked()
+}

--- a/thoth-plugin-sdk/src/components/multi_select/ui.rs
+++ b/thoth-plugin-sdk/src/components/multi_select/ui.rs
@@ -1,7 +1,7 @@
 use crate::components::select::ui::{paint_trigger, paint_truncated, show_popover};
 use crate::theme::{
-    FONT_CONTROL, RADIUS_CHECK, RADIUS_CHIP, ThemeColors, edge_stroke, get_contrast_text_color,
-    phosphor_font_id, with_alpha,
+    FONT_CONTROL, RADIUS_CHECK, RADIUS_CHIP, ThemeColors, edge_stroke, focus_stroke,
+    get_contrast_text_color, phosphor_font_id, with_alpha,
 };
 
 use super::MultiSelect;
@@ -107,15 +107,19 @@ impl MultiSelect {
                     }
                 }
 
-                let escape = ui.ctx().input(|i| i.key_pressed(egui::Key::Escape));
-                let interact_pos = ui
+                // Consumed, so an Escape that closes this popover doesn't also
+                // reach an enclosing overlay (e.g. a dismissible `Modal`).
+                let escape = ui
                     .ctx()
-                    .input(|i| i.pointer.interact_pos())
-                    .unwrap_or_default();
+                    .input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
+                // An unknown pointer position counts as *outside* the trigger —
+                // defaulting it to the origin would read as a trigger click for any
+                // trigger containing (0, 0).
+                let interact_pos = ui.ctx().input(|i| i.pointer.interact_pos());
                 // Toggling a row keeps the popover open, so it only closes on a
                 // click outside it and the trigger — or on Escape.
-                let click_outside =
-                    popover_resp.clicked_elsewhere() && !trigger_rect.contains(interact_pos);
+                let click_outside = popover_resp.clicked_elsewhere()
+                    && !interact_pos.is_some_and(|p| trigger_rect.contains(p));
                 if escape || click_outside {
                     ui.ctx().data_mut(|d| d.insert_temp::<bool>(id, false));
                 }
@@ -128,11 +132,16 @@ impl MultiSelect {
     /// The trigger label: a count of what's selected, e.g. `"2 columns"`.
     fn summary(&self) -> String {
         let n = self.value.len();
-        match &self.item_noun {
-            Some(noun) if n == 1 => format!("1 {noun}"),
-            Some(noun) => format!("{n} {noun}s"),
-            None if n == 0 => "None selected".to_owned(),
-            None => format!("{n} selected"),
+        // An empty selection reads the same whether or not a noun is configured.
+        if n == 0 {
+            return "None selected".to_owned();
+        }
+        match (&self.item_noun, &self.item_noun_plural) {
+            (Some(noun), _) if n == 1 => format!("1 {noun}"),
+            // Plurals come from the caller; appending an `s` would produce
+            // `"entrys"` / `"matchs"`.
+            (_, Some(plural)) => format!("{n} {plural}"),
+            _ => format!("{n} selected"),
         }
     }
 }
@@ -155,6 +164,16 @@ fn row(
         if resp.hovered() {
             ui.painter()
                 .rect_filled(rect, RADIUS_CHIP, with_alpha(colors.fg, HOVER_ALPHA));
+        }
+        // Keyboard focus gets the same ring the fields use, drawn inside the row so
+        // it isn't clipped by the popover's padding.
+        if resp.has_focus() {
+            ui.painter().rect_stroke(
+                rect,
+                RADIUS_CHIP,
+                focus_stroke(colors),
+                egui::StrokeKind::Inside,
+            );
         }
 
         // ── Checkbox — design `.cb` / `.cb.on` ────────────────────────────────

--- a/thoth-plugin-sdk/src/components/number_input/mod.rs
+++ b/thoth-plugin-sdk/src/components/number_input/mod.rs
@@ -32,7 +32,9 @@ pub struct NumberInput {
     /// Optional maximum.
     #[serde(default)]
     pub max: Option<f64>,
-    /// Amount the `−` / `+` spin buttons add or subtract. Defaults to `1`.
+    /// Amount the `−` / `+` spin buttons add or subtract. Defaults to `1`; a
+    /// value that isn't finite and positive (zero, negative, NaN, infinite) is
+    /// normalised to `1` rather than making the buttons inert or reversed.
     #[serde(default)]
     pub step: Option<f64>,
     /// Optional unit suffix shown inside the control, e.g. `"rows"` — design

--- a/thoth-plugin-sdk/src/components/number_input/mod.rs
+++ b/thoth-plugin-sdk/src/components/number_input/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "egui")]
+mod ui;
+
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
@@ -29,21 +32,15 @@ pub struct NumberInput {
     /// Optional maximum.
     #[serde(default)]
     pub max: Option<f64>,
+    /// Amount the `−` / `+` spin buttons add or subtract. Defaults to `1`.
+    #[serde(default)]
+    pub step: Option<f64>,
+    /// Optional unit suffix shown inside the control, e.g. `"rows"` — design
+    /// `.num .unit`.
+    #[serde(default)]
+    pub unit: Option<String>,
     /// Disable interaction.
     #[builder(default)]
     #[serde(default)]
     pub disabled: bool,
-}
-
-#[cfg(feature = "egui")]
-impl NumberInput {
-    /// Render the input, editing [`value`](NumberInput::value) in place.
-    pub fn show(&mut self, ui: &mut egui::Ui) -> egui::Response {
-        if !self.label.is_empty() {
-            ui.label(&self.label);
-        }
-        let range = self.min.unwrap_or(f64::NEG_INFINITY)..=self.max.unwrap_or(f64::INFINITY);
-        let drag = egui::DragValue::new(&mut self.value).range(range);
-        ui.add_enabled(!self.disabled, drag)
-    }
 }

--- a/thoth-plugin-sdk/src/components/number_input/ui.rs
+++ b/thoth-plugin-sdk/src/components/number_input/ui.rs
@@ -29,7 +29,19 @@ impl NumberInput {
 
         let min = self.min.unwrap_or(f64::NEG_INFINITY);
         let max = self.max.unwrap_or(f64::INFINITY);
-        let step = self.step.unwrap_or(1.0);
+        // The bounds and the step arrive from plugin-supplied JSON, so they're
+        // normalised once here: `f64::clamp` panics on an inverted or NaN range,
+        // and a zero / negative / non-finite step would make the spin buttons
+        // inert or reverse them.
+        let (min, max) = match (min, max) {
+            (a, b) if a.is_nan() || b.is_nan() => (f64::NEG_INFINITY, f64::INFINITY),
+            (a, b) if a > b => (b, a),
+            pair => pair,
+        };
+        let step = match self.step {
+            Some(s) if s.is_finite() && s > 0.0 => s,
+            _ => 1.0,
+        };
 
         // The unit is laid out up front so the control is exactly as wide as its
         // content (design `.num` is an inline-flex box).
@@ -61,7 +73,13 @@ impl NumberInput {
             egui::vec2(SPIN_W, rect.height()),
         );
 
-        let id = ui.make_persistent_id((self.id.as_str(), "num"));
+        // An id-less input falls back to this `ui`'s auto id, so sibling anonymous
+        // inputs don't share their spin-button interactions (or the value's state).
+        let id = if self.id.is_empty() {
+            ui.next_auto_id().with("num")
+        } else {
+            ui.make_persistent_id((self.id.as_str(), "num"))
+        };
         let mut spun = false;
 
         let inner = ui.scope(|ui| {
@@ -108,19 +126,28 @@ impl NumberInput {
                     if hovered { colors.fg } else { colors.fg_muted },
                 );
             }
+            // A click at a bound leaves the value where it is, so `changed()` is
+            // only reported when the clamped result actually moved.
             if dec.clicked() {
-                self.value = (self.value - step).clamp(min, max);
-                spun = true;
+                let next = (self.value - step).clamp(min, max);
+                spun |= next != self.value;
+                self.value = next;
             }
             if inc.clicked() {
-                self.value = (self.value + step).clamp(min, max);
-                spun = true;
+                let next = (self.value + step).clamp(min, max);
+                spun |= next != self.value;
+                self.value = next;
             }
 
             // ── Value ─────────────────────────────────────────────────────────
-            let builder = egui::UiBuilder::new().max_rect(value_rect).layout(
-                egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
-            );
+            let builder = egui::UiBuilder::new()
+                .max_rect(value_rect)
+                .layout(egui::Layout::centered_and_justified(
+                    egui::Direction::LeftToRight,
+                ))
+                // Same salt as the spin buttons, so the `DragValue` is unique per
+                // control even when no explicit id was given.
+                .id_salt(id);
             let drag = ui
                 .scope_builder(builder, |ui| {
                     let style = ui.style_mut();

--- a/thoth-plugin-sdk/src/components/number_input/ui.rs
+++ b/thoth-plugin-sdk/src/components/number_input/ui.rs
@@ -1,0 +1,166 @@
+use egui::{Align2, Color32, CornerRadius, Rect, Sense, Stroke, TextStyle, Vec2};
+
+use crate::theme::{
+    FIELD_HEIGHT, FONT_BODY, FONT_CAPTION, RADIUS_CONTROL, ThemeColors, edge_stroke,
+    phosphor_font_id, with_alpha,
+};
+
+use super::NumberInput;
+
+/// Width of each spin button — design `.num button{width:28px}`.
+const SPIN_W: f32 = 28.0;
+/// Width of the value area — design `.num input{width:50px}`.
+const VALUE_W: f32 = 50.0;
+/// Padding after the unit suffix — design `.num .unit{padding-right:10px}`.
+const UNIT_PAD: f32 = 10.0;
+/// Spin-button glyph size — design `.num button{font-size:16px}`.
+const SPIN_GLYPH: f32 = 16.0;
+
+impl NumberInput {
+    /// Render the input, editing [`value`](NumberInput::value) in place.
+    ///
+    /// The returned response reports `changed()` for both spin-button clicks and
+    /// drag/keyboard edits of the value.
+    pub fn show(&mut self, ui: &mut egui::Ui) -> egui::Response {
+        let colors = ThemeColors::from_ctx(ui.ctx());
+        if !self.label.is_empty() {
+            ui.label(&self.label);
+        }
+
+        let min = self.min.unwrap_or(f64::NEG_INFINITY);
+        let max = self.max.unwrap_or(f64::INFINITY);
+        let step = self.step.unwrap_or(1.0);
+
+        // The unit is laid out up front so the control is exactly as wide as its
+        // content (design `.num` is an inline-flex box).
+        let unit = self.unit.as_deref().filter(|u| !u.is_empty()).map(|u| {
+            ui.painter().layout_no_wrap(
+                u.to_owned(),
+                egui::FontId::proportional(FONT_CAPTION),
+                colors.fg_faint(),
+            )
+        });
+        let unit_w = unit.as_ref().map_or(0.0, |g| g.size().x + UNIT_PAD);
+        let total_w = 2.0 * SPIN_W + VALUE_W + unit_w;
+
+        let (rect, _) = ui.allocate_exact_size(egui::vec2(total_w, FIELD_HEIGHT), Sense::hover());
+        // `overflow:hidden` in the design — the spin hover fills below are given
+        // matching outer corners so nothing pokes past the rounded box.
+        let radius = CornerRadius::from(RADIUS_CONTROL);
+        if ui.is_rect_visible(rect) {
+            ui.painter().rect_filled(rect, radius, colors.surface);
+            ui.painter()
+                .rect_stroke(rect, radius, edge_stroke(&colors), egui::StrokeKind::Inside);
+        }
+
+        let dec_rect = Rect::from_min_size(rect.min, egui::vec2(SPIN_W, rect.height()));
+        let value_rect =
+            Rect::from_min_size(dec_rect.right_top(), egui::vec2(VALUE_W, rect.height()));
+        let inc_rect = Rect::from_min_size(
+            egui::pos2(rect.max.x - SPIN_W, rect.min.y),
+            egui::vec2(SPIN_W, rect.height()),
+        );
+
+        let id = ui.make_persistent_id((self.id.as_str(), "num"));
+        let mut spun = false;
+
+        let inner = ui.scope(|ui| {
+            if self.disabled {
+                ui.disable();
+            }
+
+            // ── Spin buttons ──────────────────────────────────────────────────
+            let dec = ui.interact(dec_rect, id.with("dec"), Sense::click());
+            let inc = ui.interact(inc_rect, id.with("inc"), Sense::click());
+            for (resp, glyph, corners) in [
+                (
+                    &dec,
+                    egui_phosphor::regular::MINUS,
+                    CornerRadius {
+                        nw: radius.nw,
+                        sw: radius.sw,
+                        ne: 0,
+                        se: 0,
+                    },
+                ),
+                (
+                    &inc,
+                    egui_phosphor::regular::PLUS,
+                    CornerRadius {
+                        nw: 0,
+                        sw: 0,
+                        ne: radius.ne,
+                        se: radius.se,
+                    },
+                ),
+            ] {
+                let hovered = resp.hovered();
+                if hovered {
+                    ui.painter()
+                        .rect_filled(resp.rect, corners, with_alpha(colors.fg, 20)); // text@8%
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                }
+                ui.painter().text(
+                    resp.rect.center(),
+                    Align2::CENTER_CENTER,
+                    glyph,
+                    phosphor_font_id(SPIN_GLYPH),
+                    if hovered { colors.fg } else { colors.fg_muted },
+                );
+            }
+            if dec.clicked() {
+                self.value = (self.value - step).clamp(min, max);
+                spun = true;
+            }
+            if inc.clicked() {
+                self.value = (self.value + step).clamp(min, max);
+                spun = true;
+            }
+
+            // ── Value ─────────────────────────────────────────────────────────
+            let builder = egui::UiBuilder::new().max_rect(value_rect).layout(
+                egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
+            );
+            let drag = ui
+                .scope_builder(builder, |ui| {
+                    let style = ui.style_mut();
+                    style.spacing.button_padding = Vec2::ZERO;
+                    style.spacing.interact_size = egui::vec2(VALUE_W, FIELD_HEIGHT);
+                    // Design `.num input{font:500 13px/1 var(--mono)}`.
+                    style
+                        .text_styles
+                        .insert(TextStyle::Monospace, egui::FontId::monospace(FONT_BODY));
+                    style.drag_value_text_style = TextStyle::Monospace;
+                    // The value carries no chrome of its own; the box behind it is
+                    // already painted.
+                    for w in [
+                        &mut style.visuals.widgets.inactive,
+                        &mut style.visuals.widgets.hovered,
+                        &mut style.visuals.widgets.active,
+                    ] {
+                        w.weak_bg_fill = Color32::TRANSPARENT;
+                        w.bg_fill = Color32::TRANSPARENT;
+                        w.bg_stroke = Stroke::NONE;
+                        w.fg_stroke.color = colors.fg;
+                        w.expansion = 0.0;
+                    }
+                    ui.add(egui::DragValue::new(&mut self.value).range(min..=max))
+                })
+                .inner;
+
+            // ── Unit suffix ───────────────────────────────────────────────────
+            if let Some(galley) = unit {
+                let pos = egui::pos2(value_rect.max.x, rect.center().y - galley.size().y * 0.5);
+                ui.painter().galley(pos, galley, colors.fg_faint());
+            }
+
+            drag | dec | inc
+        });
+
+        let mut response = inner.inner;
+        if spun {
+            response.mark_changed();
+        }
+        response
+    }
+}

--- a/thoth-plugin-sdk/src/components/progress/mod.rs
+++ b/thoth-plugin-sdk/src/components/progress/mod.rs
@@ -1,6 +1,17 @@
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
+/// Track height — design `.track{height:6px}`.
+#[cfg(feature = "egui")]
+const TRACK_HEIGHT: f32 = 6.0;
+/// Fixed width of the value readout column — design `.pv{width:34px}`. Fixed so
+/// stacked bars line up no matter how wide their readout text is.
+#[cfg(feature = "egui")]
+const READOUT_WIDTH: f32 = 34.0;
+/// Gap between the track and its readout — design `.prow{gap:10px}`.
+#[cfg(feature = "egui")]
+const READOUT_GAP: f32 = 10.0;
+
 /// A horizontal progress bar.
 ///
 /// ```
@@ -21,21 +32,73 @@ pub struct Progress {
     /// Optional fixed bar height in points.
     #[serde(default)]
     pub height: Option<f32>,
+    /// Optional value readout shown to the right of the track (e.g. `"62%"` or
+    /// `"done"`) — design `.pv`. The text is composed by the caller; the
+    /// component only positions it.
+    #[serde(default)]
+    pub readout: Option<String>,
 }
 
 #[cfg(feature = "egui")]
 impl egui::Widget for Progress {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
-        let mut bar = egui::ProgressBar::new(self.value.clamp(0.0, 1.0) as f32);
-        if let Some(token) = &self.color {
-            let colors = crate::theme::ThemeColors::from_ctx(ui.ctx());
-            if let Some(c) = crate::theme::resolve_color(token, &colors) {
-                bar = bar.fill(c);
+        use crate::theme::{FONT_CAPTION, RADIUS_PILL, ThemeColors};
+
+        let colors = ThemeColors::from_ctx(ui.ctx());
+        // The fill colour is semantic (green for done, yellow for a warning …),
+        // so it stays whatever the caller asked for; the accent is only a default.
+        let fill = self
+            .color
+            .as_deref()
+            .and_then(|token| crate::theme::resolve_color(token, &colors))
+            .unwrap_or(colors.accent);
+        let track_h = self.height.unwrap_or(TRACK_HEIGHT);
+
+        // Lay the readout out first: it fixes the row's height as well as the
+        // width left over for the track (design `.track{flex:1}`).
+        let readout = self.readout.as_deref().filter(|t| !t.is_empty()).map(|t| {
+            ui.painter().layout_no_wrap(
+                t.to_owned(),
+                egui::FontId::monospace(FONT_CAPTION),
+                colors.fg_muted,
+            )
+        });
+        let reserved = match &readout {
+            Some(_) => READOUT_WIDTH + READOUT_GAP,
+            None => 0.0,
+        };
+        let row_h = readout
+            .as_ref()
+            .map_or(track_h, |g| g.size().y.max(track_h));
+        let track_w = (ui.available_width() - reserved).max(0.0);
+
+        let (rect, response) =
+            ui.allocate_exact_size(egui::vec2(track_w + reserved, row_h), egui::Sense::hover());
+
+        if ui.is_rect_visible(rect) {
+            // Fully-round track and fill — design `border-radius:999px` on both,
+            // with the fill kept inside the track's bounds.
+            let pill = egui::CornerRadius::same(RADIUS_PILL as u8);
+            let track = egui::Rect::from_min_size(
+                egui::pos2(rect.left(), rect.center().y - track_h / 2.0),
+                egui::vec2(track_w, track_h),
+            );
+            ui.painter().rect_filled(track, pill, colors.surface_raised);
+            let filled = track_w * self.value.clamp(0.0, 1.0) as f32;
+            if filled > 0.0 {
+                let bar = egui::Rect::from_min_size(track.min, egui::vec2(filled, track_h));
+                ui.painter().rect_filled(bar, pill, fill);
+            }
+            if let Some(galley) = readout {
+                // Right-aligned in its fixed column — design `.pv{text-align:right}`.
+                let pos = egui::pos2(
+                    rect.right() - galley.size().x,
+                    rect.center().y - galley.size().y / 2.0,
+                );
+                ui.painter().galley(pos, galley, colors.fg_muted);
             }
         }
-        if let Some(h) = self.height {
-            bar = bar.desired_height(h);
-        }
-        ui.add(bar)
+
+        response
     }
 }

--- a/thoth-plugin-sdk/src/components/radio/mod.rs
+++ b/thoth-plugin-sdk/src/components/radio/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "egui")]
+mod ui;
+
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
@@ -41,31 +44,4 @@ pub struct Radio {
     #[builder(default)]
     #[serde(default)]
     pub disabled: bool,
-}
-
-#[cfg(feature = "egui")]
-impl Radio {
-    /// Render the radio group, updating [`value`](Radio::value) in place.
-    /// Returns `Some(value)` when the selection changed this frame.
-    pub fn show(&mut self, ui: &mut egui::Ui) -> Option<String> {
-        let mut changed = None;
-        ui.add_enabled_ui(!self.disabled, |ui| {
-            if !self.label.is_empty() {
-                ui.label(&self.label);
-            }
-            ui.horizontal(|ui| {
-                for opt in &self.options {
-                    if ui.radio(self.value == opt.value, &opt.label).clicked()
-                        && self.value != opt.value
-                    {
-                        changed = Some(opt.value.clone());
-                    }
-                }
-            });
-        });
-        if let Some(v) = &changed {
-            self.value = v.clone();
-        }
-        changed
-    }
 }

--- a/thoth-plugin-sdk/src/components/radio/ui.rs
+++ b/thoth-plugin-sdk/src/components/radio/ui.rs
@@ -1,0 +1,115 @@
+use egui::{Sense, Stroke, Vec2};
+
+use crate::theme::{FONT_CONTROL, ThemeColors};
+
+use super::Radio;
+
+/// Circle side — design `.rd { width:16px; height:16px }`.
+const CIRCLE_SIZE: f32 = 16.0;
+/// Ring thickness — design `.rd { box-shadow: inset 0 0 0 2px … }`. The ring is
+/// *inset*, so it must not grow the 16px control.
+const RING_WIDTH: f32 = 2.0;
+/// Selected-dot diameter — design `.rd.on::after { width:7px; height:7px }`.
+const DOT_DIAMETER: f32 = 7.0;
+/// Gap between the circle and its label — design `.opt-lbl { gap:8px }`.
+const LABEL_GAP: f32 = 8.0;
+/// Opacity of a disabled group. The design sheet has no disabled radio variant;
+/// match the switch (`.switch.dis { opacity:.4 }`).
+const DISABLED_OPACITY: f32 = 0.4;
+
+impl Radio {
+    /// Render the radio group, updating [`value`](Radio::value) in place.
+    /// Returns `Some(value)` when the selection changed this frame.
+    pub fn show(&mut self, ui: &mut egui::Ui) -> Option<String> {
+        let colors = ThemeColors::from_ctx(ui.ctx());
+        let interactive = !self.disabled && ui.is_enabled();
+
+        let mut changed = None;
+        ui.vertical(|ui| {
+            if !self.label.is_empty() {
+                ui.label(&self.label);
+            }
+            ui.horizontal(|ui| {
+                for opt in &self.options {
+                    let selected = self.value == opt.value;
+                    let response = option(ui, &opt.label, selected, &colors, interactive);
+                    if response.clicked() && !selected {
+                        changed = Some(opt.value.clone());
+                    }
+                }
+            });
+        });
+        if let Some(v) = &changed {
+            self.value = v.clone();
+        }
+        changed
+    }
+}
+
+/// Paint one `circle + label` option and return its response.
+fn option(
+    ui: &mut egui::Ui,
+    label: &str,
+    selected: bool,
+    colors: &ThemeColors,
+    interactive: bool,
+) -> egui::Response {
+    let galley = ui.painter().layout_no_wrap(
+        label.to_owned(),
+        egui::FontId::proportional(FONT_CONTROL),
+        colors.fg,
+    );
+    let label_w = if label.is_empty() {
+        0.0
+    } else {
+        LABEL_GAP + galley.size().x
+    };
+    let desired = Vec2::new(CIRCLE_SIZE + label_w, galley.size().y.max(CIRCLE_SIZE));
+
+    // The label is part of the hit area — design wraps both in one `.opt-lbl`.
+    let (rect, mut response) = ui.allocate_exact_size(
+        desired,
+        if interactive {
+            Sense::click()
+        } else {
+            Sense::hover()
+        },
+    );
+
+    if ui.is_rect_visible(rect) {
+        // Disabled groups fade through a *cloned* painter so the opacity never
+        // leaks into the widgets painted after this one.
+        let mut painter = ui.painter().clone();
+        if !interactive {
+            painter.multiply_opacity(DISABLED_OPACITY);
+        }
+
+        let center = egui::pos2(rect.left() + CIRCLE_SIZE / 2.0, rect.center().y);
+        // Stroke centre-line pulled in by half the ring width keeps the ring
+        // wholly inside the 16px bounds, matching the CSS inset shadow.
+        let ring_radius = CIRCLE_SIZE / 2.0 - RING_WIDTH / 2.0;
+        let ring = if selected {
+            colors.accent
+        } else {
+            colors.surface_raised
+        };
+        painter.circle_stroke(center, ring_radius, Stroke::new(RING_WIDTH, ring));
+        if selected {
+            painter.circle_filled(center, DOT_DIAMETER / 2.0, colors.accent);
+        }
+
+        if !label.is_empty() {
+            let text_pos = egui::pos2(
+                center.x + CIRCLE_SIZE / 2.0 + LABEL_GAP,
+                rect.center().y - galley.size().y / 2.0,
+            );
+            painter.galley(text_pos, galley, colors.fg);
+        }
+    }
+
+    if interactive {
+        response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
+    }
+
+    response
+}

--- a/thoth-plugin-sdk/src/components/radio/ui.rs
+++ b/thoth-plugin-sdk/src/components/radio/ui.rs
@@ -30,12 +30,40 @@ impl Radio {
                 ui.label(&self.label);
             }
             ui.horizontal(|ui| {
-                for opt in &self.options {
+                // Which option holds focus is tracked across frames: egui applies
+                // an arrow key's focus move on the *next* pass, so the move can
+                // only be spotted by comparing indices.
+                let focus_id = ui.make_persistent_id((self.id.as_str(), "radio_focus"));
+                let was_focused: Option<usize> = ui.ctx().data(|d| d.get_temp(focus_id)).flatten();
+                let mut focused: Option<usize> = None;
+                // Tab hands focus on within this same pass; it walks *out* of the
+                // group rather than choosing inside it, so it must not select.
+                let tab_nav = ui.input(|i| i.key_pressed(egui::Key::Tab));
+
+                for (i, opt) in self.options.iter().enumerate() {
                     let selected = self.value == opt.value;
                     let response = option(ui, &opt.label, selected, &colors, interactive);
                     if response.clicked() && !selected {
                         changed = Some(opt.value.clone());
                     }
+                    if response.has_focus() {
+                        focused = Some(i);
+                    }
+                    // Arrow keys move focus *within* the group, and a radio group
+                    // carries its selection along with it. Focus arriving from
+                    // outside (Tab) leaves the selection alone, hence the check
+                    // that focus was already on another option.
+                    if response.gained_focus()
+                        && !selected
+                        && !tab_nav
+                        && was_focused.is_some_and(|prev| prev != i)
+                    {
+                        changed = Some(opt.value.clone());
+                    }
+                }
+
+                if focused != was_focused {
+                    ui.ctx().data_mut(|d| d.insert_temp(focus_id, focused));
                 }
             });
         });
@@ -54,17 +82,18 @@ fn option(
     colors: &ThemeColors,
     interactive: bool,
 ) -> egui::Response {
-    let galley = ui.painter().layout_no_wrap(
-        label.to_owned(),
-        egui::FontId::proportional(FONT_CONTROL),
-        colors.fg,
-    );
-    let label_w = if label.is_empty() {
-        0.0
-    } else {
-        LABEL_GAP + galley.size().x
-    };
-    let desired = Vec2::new(CIRCLE_SIZE + label_w, galley.size().y.max(CIRCLE_SIZE));
+    // Laid out only when there's something to lay out; an icon-only option is
+    // sized by its circle alone.
+    let galley = (!label.is_empty()).then(|| {
+        ui.painter().layout_no_wrap(
+            label.to_owned(),
+            egui::FontId::proportional(FONT_CONTROL),
+            colors.fg,
+        )
+    });
+    let label_w = galley.as_ref().map_or(0.0, |g| LABEL_GAP + g.size().x);
+    let text_h = galley.as_ref().map_or(CIRCLE_SIZE, |g| g.size().y);
+    let desired = Vec2::new(CIRCLE_SIZE + label_w, text_h.max(CIRCLE_SIZE));
 
     // The label is part of the hit area — design wraps both in one `.opt-lbl`.
     let (rect, mut response) = ui.allocate_exact_size(
@@ -98,7 +127,7 @@ fn option(
             painter.circle_filled(center, DOT_DIAMETER / 2.0, colors.accent);
         }
 
-        if !label.is_empty() {
+        if let Some(galley) = galley {
             let text_pos = egui::pos2(
                 center.x + CIRCLE_SIZE / 2.0 + LABEL_GAP,
                 rect.center().y - galley.size().y / 2.0,

--- a/thoth-plugin-sdk/src/components/select/mod.rs
+++ b/thoth-plugin-sdk/src/components/select/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "egui")]
-mod ui;
+pub(crate) mod ui;
 
 use bon::Builder;
 use serde::{Deserialize, Serialize};
@@ -66,6 +66,14 @@ pub struct Select {
     /// Optional static prefix shown before the selected label, e.g. `"Sort: "`.
     #[serde(default)]
     pub prefix_label: Option<String>,
+    /// Optional leading glyph in the trigger, before the label — design
+    /// `.viewsel`/`.selbox`, which lead with a table, database or plug icon.
+    #[serde(default)]
+    pub icon: Option<String>,
+    /// Colour for [`icon`](Select::icon) as a theme token name (e.g. `"accent"`).
+    /// Defaults to the muted foreground, like the trailing caret.
+    #[serde(default, rename = "icon-color")]
+    pub icon_color: Option<String>,
     /// Trigger size. Defaults to [`Size::Medium`].
     #[builder(default)]
     #[serde(default)]

--- a/thoth-plugin-sdk/src/components/select/ui.rs
+++ b/thoth-plugin-sdk/src/components/select/ui.rs
@@ -279,7 +279,8 @@ pub(crate) fn paint_trigger(
             edge_stroke(colors),
             egui::StrokeKind::Inside,
         );
-        if is_open {
+        // Open *or* merely focused: a closed trigger still shows keyboard focus.
+        if is_open || resp.has_focus() {
             ui.painter().rect_stroke(
                 rect,
                 RADIUS_CONTROL,
@@ -287,18 +288,18 @@ pub(crate) fn paint_trigger(
                 egui::StrokeKind::Outside,
             );
         }
-        // A leading glyph shifts the label right by its width plus the gap
-        // (design `.viewsel` leads with an icon before the value).
+        // A leading glyph shifts the label right by the width it actually painted
+        // plus the gap (design `.viewsel` leads with an icon before the value).
         let icon_advance = match icon {
             Some((glyph, tint)) => {
-                ui.painter().text(
+                let painted = ui.painter().text(
                     egui::pos2(rect.min.x + TRIGGER_PAD_X, rect.center().y),
                     egui::Align2::LEFT_CENTER,
                     glyph,
                     phosphor_font_id(CARET_SIZE + 2.0),
                     tint,
                 );
-                CARET_SIZE + 2.0 + TRIGGER_GAP
+                painted.width() + TRIGGER_GAP
             }
             None => 0.0,
         };

--- a/thoth-plugin-sdk/src/components/select/ui.rs
+++ b/thoth-plugin-sdk/src/components/select/ui.rs
@@ -1,9 +1,40 @@
 use egui::{InnerResponse, Response};
 
-use crate::theme::{ThemeColors, phosphor_font_id};
+use crate::theme::{
+    RADIUS_CHIP, RADIUS_CONTROL, RADIUS_POPOVER, ThemeColors, edge_stroke, focus_stroke,
+    phosphor_font_id, popover_shadow, with_alpha,
+};
 
 use super::{Select, SelectResponse};
-use crate::components::Size;
+
+// ── Design metrics ────────────────────────────────────────────────────────────
+
+/// Horizontal padding inside the trigger — design `.trigger{padding:0 10px}`.
+const TRIGGER_PAD_X: f32 = 10.0;
+/// Gap between the trigger label and its caret — design `.trigger{gap:7px}`.
+const TRIGGER_GAP: f32 = 7.0;
+/// Caret glyph size — design `.trigger .car{font-size:12px}`.
+const CARET_SIZE: f32 = 12.0;
+/// Popover inner padding — design `.popover{padding:5px}`.
+const POPOVER_PAD: i8 = 5;
+/// Distance from the trigger's bottom edge to the popover — design
+/// `.popover{top:calc(100% + 6px)}`.
+const POPOVER_GAP: f32 = 6.0;
+/// Option row height for a given field height. The design pairs a 27px `.opt`
+/// with a 28px `.field`, so rows sit one point inside the trigger — derived
+/// rather than pinned to 27 so `Size::Small`/`Large` still scale the popover.
+fn option_height(field_h: f32) -> f32 {
+    field_h - 1.0
+}
+/// Option row horizontal padding — design `.opt{padding:0 9px}`.
+const OPT_PAD_X: f32 = 9.0;
+/// Gap between an option's leading content and its trailing tick — design
+/// `.opt{gap:9px}`.
+const OPT_GAP: f32 = 9.0;
+/// Trailing tick glyph size — design `.opt .tick{font-size:14px}`.
+const TICK_SIZE: f32 = 14.0;
+/// Row-hover wash — design `.opt:hover{background:text@7%}`.
+const HOVER_ALPHA: u8 = 18; // 7% of 255
 
 impl Select {
     /// Render the select, updating [`value`](Select::value) on selection.
@@ -14,12 +45,7 @@ impl Select {
     /// [`InnerResponse::response`] is the trigger's response.
     pub fn show(&mut self, ui: &mut egui::Ui) -> InnerResponse<SelectResponse> {
         let colors = ThemeColors::from_ctx(ui.ctx());
-
-        let (trigger_h, font_size) = match self.size {
-            Size::Small => (24.0_f32, 10.0_f32),
-            Size::Medium => (28.0_f32, 11.0_f32),
-            Size::Large => (32.0_f32, 12.0_f32),
-        };
+        let (font_size, trigger_h) = self.size.field_metrics();
 
         // Derived from the `ui` (not a global `Id::new`) so two selects sharing
         // a string id — e.g. the same plugin open in two tabs — get distinct
@@ -42,34 +68,22 @@ impl Select {
 
         // ── Trigger ───────────────────────────────────────────────────────────
         let trigger_w = self.width.unwrap_or_else(|| ui.available_width());
-        let (trigger_rect, trigger_resp) =
-            ui.allocate_exact_size(egui::vec2(trigger_w, trigger_h), egui::Sense::click());
-
-        if ui.is_rect_visible(trigger_rect) {
-            let bg = if is_open || trigger_resp.hovered() {
-                colors.surface_raised
-            } else {
-                colors.surface
-            };
-            ui.painter().rect_filled(trigger_rect, 4.0, bg);
-            // Leave room for the caret on the right so the label never runs under it.
-            let label_max_w = (trigger_rect.width() - 8.0 - 22.0).max(0.0);
-            paint_truncated(
-                ui.painter(),
-                egui::pos2(trigger_rect.min.x + 8.0, trigger_rect.center().y),
-                &display,
-                egui::FontId::proportional(font_size),
-                colors.fg,
-                label_max_w,
-            );
-            ui.painter().text(
-                egui::pos2(trigger_rect.max.x - 8.0, trigger_rect.center().y),
-                egui::Align2::RIGHT_CENTER,
-                egui_phosphor::regular::CARET_DOWN,
-                phosphor_font_id(font_size - 1.0),
-                if is_open { colors.fg } else { colors.fg_muted },
-            );
-        }
+        let (trigger_rect, trigger_resp) = paint_trigger(
+            ui,
+            &colors,
+            egui::vec2(trigger_w, trigger_h),
+            font_size,
+            &display,
+            is_open,
+            self.icon.as_deref().filter(|g| !g.is_empty()).map(|g| {
+                let tint = self
+                    .icon_color
+                    .as_deref()
+                    .and_then(|t| crate::theme::resolve_color(t, &colors))
+                    .unwrap_or(colors.fg_muted);
+                (g, tint)
+            }),
+        );
 
         if trigger_resp.clicked() {
             is_open = !is_open;
@@ -79,17 +93,11 @@ impl Select {
                 ui.ctx().data_mut(|d| d.insert_temp(focus_id, true));
             }
         }
-        if trigger_resp.hovered() {
-            ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
-        }
 
         // ── Dropdown ──────────────────────────────────────────────────────────
         let mut out = SelectResponse::default();
 
         if is_open {
-            let inner_pad = 4_i8;
-            let inner_padf = inner_pad as f32;
-            let item_h = trigger_h;
             let max_visible = 8_usize;
 
             // Current search query (client state, kept in egui temp memory).
@@ -108,116 +116,105 @@ impl Select {
                 .map(|(i, _)| i)
                 .collect();
 
-            let scroll_h = (item_h * max_visible.min(filtered.len().max(1)) as f32) + inner_padf;
+            let opt_h = option_height(trigger_h);
+            let scroll_h = opt_h * max_visible.min(filtered.len().max(1)) as f32;
 
-            let area_resp = egui::Area::new(id.with("_area"))
-                .order(egui::Order::Foreground)
-                .fixed_pos(trigger_rect.left_bottom() + egui::vec2(0.0, 3.0))
-                .constrain(true)
-                .interactable(true)
-                .show(ui.ctx(), |ui| {
-                    egui::Frame::NONE
-                        .fill(colors.bg_panel)
-                        .stroke(egui::Stroke::new(1.0, colors.surface))
-                        .corner_radius(4)
-                        .inner_margin(egui::Margin::same(inner_pad))
-                        .show(ui, |ui| {
-                            let popup_w = trigger_rect.width() - inner_padf * 2.0;
+            let (popover_resp, ()) = show_popover(
+                ui,
+                id.with("_area"),
+                trigger_rect,
+                &colors,
+                |ui, popup_w| {
+                    ui.spacing_mut().item_spacing.y = 2.0;
+
+                    // ── Search box ─────────────────────────────────────────
+                    if self.searchable {
+                        let edit = egui::TextEdit::singleline(&mut query)
+                            .hint_text("Search…")
+                            .desired_width(popup_w)
+                            .font(egui::FontId::proportional(font_size));
+                        let resp = ui.add_sized([popup_w, trigger_h], edit);
+                        let want_focus = ui
+                            .ctx()
+                            .data(|d| d.get_temp::<bool>(focus_id).unwrap_or(false));
+                        if want_focus {
+                            resp.request_focus();
+                            ui.ctx().data_mut(|d| d.remove::<bool>(focus_id));
+                        }
+                        if resp.changed() {
+                            out.search = Some(query.clone());
+                            ui.ctx()
+                                .data_mut(|d| d.insert_temp(query_id, query.clone()));
+                        }
+                    }
+
+                    // ── Virtualized option list ────────────────────────────
+                    egui::ScrollArea::vertical()
+                        .max_height(scroll_h)
+                        .auto_shrink([false, true])
+                        .show_rows(ui, opt_h, filtered.len(), |ui, range| {
                             ui.set_min_width(popup_w);
-                            ui.set_max_width(popup_w);
-                            ui.spacing_mut().item_spacing.y = 2.0;
+                            ui.spacing_mut().item_spacing.y = 0.0;
+                            for row in range {
+                                let opt = &self.options[filtered[row]];
+                                let is_sel = opt.value == self.value;
+                                let item_w = ui.available_width();
+                                let (item_rect, item_resp) = ui.allocate_exact_size(
+                                    egui::vec2(item_w, opt_h),
+                                    egui::Sense::click(),
+                                );
 
-                            // ── Search box ─────────────────────────────────────
-                            if self.searchable {
-                                let edit = egui::TextEdit::singleline(&mut query)
-                                    .hint_text("Search…")
-                                    .desired_width(popup_w)
-                                    .font(egui::FontId::proportional(font_size));
-                                let resp = ui.add_sized([popup_w, item_h], edit);
-                                let want_focus = ui
-                                    .ctx()
-                                    .data(|d| d.get_temp::<bool>(focus_id).unwrap_or(false));
-                                if want_focus {
-                                    resp.request_focus();
-                                    ui.ctx().data_mut(|d| d.remove::<bool>(focus_id));
+                                if ui.is_rect_visible(item_rect) {
+                                    // Design `.opt` has no selected fill — only a
+                                    // hover wash; selection reads as mauve text.
+                                    if item_resp.hovered() {
+                                        ui.painter().rect_filled(
+                                            item_rect,
+                                            RADIUS_CHIP,
+                                            with_alpha(colors.fg, HOVER_ALPHA),
+                                        );
+                                    }
+                                    // Reserve room on the right for the ✓ on the selected row.
+                                    let label_max_w = (item_rect.width()
+                                        - OPT_PAD_X * 2.0
+                                        - if is_sel { TICK_SIZE + OPT_GAP } else { 0.0 })
+                                    .max(0.0);
+                                    paint_truncated(
+                                        ui.painter(),
+                                        egui::pos2(
+                                            item_rect.min.x + OPT_PAD_X,
+                                            item_rect.center().y,
+                                        ),
+                                        &opt.label,
+                                        egui::FontId::proportional(font_size),
+                                        if is_sel { colors.accent } else { colors.fg },
+                                        label_max_w,
+                                    );
+                                    if is_sel {
+                                        ui.painter().text(
+                                            egui::pos2(
+                                                item_rect.max.x - OPT_PAD_X,
+                                                item_rect.center().y,
+                                            ),
+                                            egui::Align2::RIGHT_CENTER,
+                                            egui_phosphor::regular::CHECK,
+                                            phosphor_font_id(TICK_SIZE),
+                                            colors.accent,
+                                        );
+                                    }
+                                    if item_resp.hovered() {
+                                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                                    }
                                 }
-                                if resp.changed() {
-                                    out.search = Some(query.clone());
-                                    ui.ctx()
-                                        .data_mut(|d| d.insert_temp(query_id, query.clone()));
+
+                                if item_resp.clicked() {
+                                    out.selected = Some(opt.value.clone());
+                                    close(ui.ctx(), id, query_id);
                                 }
                             }
-
-                            // ── Virtualized option list ────────────────────────
-                            egui::ScrollArea::vertical()
-                                .max_height(scroll_h)
-                                .auto_shrink([false, true])
-                                .show_rows(ui, item_h, filtered.len(), |ui, range| {
-                                    ui.set_min_width(popup_w);
-                                    ui.spacing_mut().item_spacing.y = 0.0;
-                                    for row in range {
-                                        let opt = &self.options[filtered[row]];
-                                        let is_sel = opt.value == self.value;
-                                        let item_w = ui.available_width();
-                                        let (item_rect, item_resp) = ui.allocate_exact_size(
-                                            egui::vec2(item_w, item_h),
-                                            egui::Sense::click(),
-                                        );
-
-                                        if ui.is_rect_visible(item_rect) {
-                                            let bg = if item_resp.hovered() {
-                                                Some(colors.sidebar_hover)
-                                            } else if is_sel {
-                                                Some(colors.surface_active)
-                                            } else {
-                                                None
-                                            };
-                                            if let Some(bg) = bg {
-                                                ui.painter().rect_filled(item_rect, 3.0, bg);
-                                            }
-                                            // Reserve room on the right for the ✓ on the selected row.
-                                            let label_max_w = (item_rect.width()
-                                                - 8.0
-                                                - if is_sel { 22.0 } else { 8.0 })
-                                            .max(0.0);
-                                            paint_truncated(
-                                                ui.painter(),
-                                                egui::pos2(
-                                                    item_rect.min.x + 8.0,
-                                                    item_rect.center().y,
-                                                ),
-                                                &opt.label,
-                                                egui::FontId::proportional(font_size),
-                                                colors.fg,
-                                                label_max_w,
-                                            );
-                                            if is_sel {
-                                                ui.painter().text(
-                                                    egui::pos2(
-                                                        item_rect.max.x - 8.0,
-                                                        item_rect.center().y,
-                                                    ),
-                                                    egui::Align2::RIGHT_CENTER,
-                                                    egui_phosphor::regular::CHECK,
-                                                    phosphor_font_id(font_size),
-                                                    colors.accent,
-                                                );
-                                            }
-                                            if item_resp.hovered() {
-                                                ui.ctx().set_cursor_icon(
-                                                    egui::CursorIcon::PointingHand,
-                                                );
-                                            }
-                                        }
-
-                                        if item_resp.clicked() {
-                                            out.selected = Some(opt.value.clone());
-                                            close(ui.ctx(), id, query_id);
-                                        }
-                                    }
-                                });
                         });
-                });
+                },
+            );
 
             let escape = ui.ctx().input(|i| i.key_pressed(egui::Key::Escape));
             let interact_pos = ui
@@ -227,7 +224,7 @@ impl Select {
             // Close on a click that lands outside both the popup and the trigger
             // (clicks inside the popup — search box, items, scrollbar — are kept).
             let click_outside =
-                area_resp.response.clicked_elsewhere() && !trigger_rect.contains(interact_pos);
+                popover_resp.clicked_elsewhere() && !trigger_rect.contains(interact_pos);
             if escape || click_outside {
                 close(ui.ctx(), id, query_id);
             }
@@ -248,9 +245,138 @@ fn close(ctx: &egui::Context, id: egui::Id, query_id: egui::Id) {
     });
 }
 
+// ── Shared dropdown chrome ────────────────────────────────────────────────────
+//
+// `Select` and `MultiSelect` are the same control with a different popover body,
+// so the trigger and the popover shell live here and both render through them.
+
+/// Allocate and paint a dropdown trigger — design `.trigger`: a `surface` field
+/// with `RADIUS_CONTROL` corners, a hairline `edge_stroke`, the label on the
+/// left and a caret pushed to the right edge (`margin-left:auto`). While open it
+/// also gets a focus ring *outside* the edge (design
+/// `box-shadow: var(--edge), var(--focus)`).
+///
+/// Design rotates the caret 180° when open; egui can only rotate a galley about
+/// its first glyph, so the down caret is swapped for an up caret instead — the
+/// same picture without the off-centre pivot.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn paint_trigger(
+    ui: &mut egui::Ui,
+    colors: &ThemeColors,
+    size: egui::Vec2,
+    font_size: f32,
+    label: &str,
+    is_open: bool,
+    icon: Option<(&str, egui::Color32)>,
+) -> (egui::Rect, Response) {
+    let (rect, resp) = ui.allocate_exact_size(size, egui::Sense::click());
+
+    if ui.is_rect_visible(rect) {
+        ui.painter().rect(
+            rect,
+            RADIUS_CONTROL,
+            colors.surface,
+            edge_stroke(colors),
+            egui::StrokeKind::Inside,
+        );
+        if is_open {
+            ui.painter().rect_stroke(
+                rect,
+                RADIUS_CONTROL,
+                focus_stroke(colors),
+                egui::StrokeKind::Outside,
+            );
+        }
+        // A leading glyph shifts the label right by its width plus the gap
+        // (design `.viewsel` leads with an icon before the value).
+        let icon_advance = match icon {
+            Some((glyph, tint)) => {
+                ui.painter().text(
+                    egui::pos2(rect.min.x + TRIGGER_PAD_X, rect.center().y),
+                    egui::Align2::LEFT_CENTER,
+                    glyph,
+                    phosphor_font_id(CARET_SIZE + 2.0),
+                    tint,
+                );
+                CARET_SIZE + 2.0 + TRIGGER_GAP
+            }
+            None => 0.0,
+        };
+        // Leave room for the caret on the right so the label never runs under it.
+        let label_max_w =
+            (rect.width() - TRIGGER_PAD_X * 2.0 - CARET_SIZE - TRIGGER_GAP - icon_advance).max(0.0);
+        paint_truncated(
+            ui.painter(),
+            egui::pos2(rect.min.x + TRIGGER_PAD_X + icon_advance, rect.center().y),
+            label,
+            egui::FontId::proportional(font_size),
+            if ui.is_enabled() {
+                colors.fg
+            } else {
+                colors.fg_faint()
+            },
+            label_max_w,
+        );
+        ui.painter().text(
+            egui::pos2(rect.max.x - TRIGGER_PAD_X, rect.center().y),
+            egui::Align2::RIGHT_CENTER,
+            if is_open {
+                egui_phosphor::regular::CARET_UP
+            } else {
+                egui_phosphor::regular::CARET_DOWN
+            },
+            phosphor_font_id(CARET_SIZE),
+            colors.fg_muted,
+        );
+    }
+    if resp.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+    (rect, resp)
+}
+
+/// Show a dropdown popover under `trigger_rect` — design `.popover`: a `mantle`
+/// sheet 6px below the trigger, as wide as the trigger, with `RADIUS_POPOVER`
+/// corners, 5px inner padding, a drop shadow and the hairline edge.
+///
+/// `add_contents` receives the usable content width (the popover width minus its
+/// padding). Returns the popover area's response — for click-outside detection —
+/// alongside whatever `add_contents` produced.
+pub(crate) fn show_popover<R>(
+    ui: &egui::Ui,
+    id: egui::Id,
+    trigger_rect: egui::Rect,
+    colors: &ThemeColors,
+    add_contents: impl FnOnce(&mut egui::Ui, f32) -> R,
+) -> (Response, R) {
+    let content_w = trigger_rect.width() - f32::from(POPOVER_PAD) * 2.0;
+
+    let area = egui::Area::new(id)
+        .order(egui::Order::Foreground)
+        .fixed_pos(trigger_rect.left_bottom() + egui::vec2(0.0, POPOVER_GAP))
+        .constrain(true)
+        .interactable(true)
+        .show(ui.ctx(), |ui| {
+            egui::Frame::NONE
+                .fill(colors.bg_panel)
+                .stroke(edge_stroke(colors))
+                .corner_radius(RADIUS_POPOVER)
+                .shadow(popover_shadow(ui.visuals().dark_mode))
+                .inner_margin(egui::Margin::same(POPOVER_PAD))
+                .show(ui, |ui| {
+                    ui.set_min_width(content_w);
+                    ui.set_max_width(content_w);
+                    add_contents(ui, content_w)
+                })
+                .inner
+        });
+
+    (area.response, area.inner)
+}
+
 /// Paint a single line of text at a left-centered position, truncating with an
 /// ellipsis if it would exceed `max_w` (so labels never overflow their column).
-fn paint_truncated(
+pub(crate) fn paint_truncated(
     painter: &egui::Painter,
     left_center: egui::Pos2,
     text: &str,

--- a/thoth-plugin-sdk/src/components/separator/mod.rs
+++ b/thoth-plugin-sdk/src/components/separator/mod.rs
@@ -1,14 +1,28 @@
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
+/// egui's own `Separator` reserves this much space around the line; the SDK
+/// keeps it as the default so untouched call sites lay out exactly as before.
+#[cfg(feature = "egui")]
+const DEFAULT_SPACING: f32 = 6.0;
+
 /// A horizontal divider line with optional vertical margins.
+///
+/// By default this is egui's separator: the theme's hairline stroke inside 6pt
+/// of breathing room. [`color`](Separator::color), [`thickness`](Separator::thickness)
+/// and [`spacing`](Separator::spacing) override that, which is what the design's
+/// band edges need — `box-shadow: inset 0 -1px 0 var(--surface)` is a 1px rule
+/// in a *specific* colour that occupies no space of its own.
 ///
 /// ```
 /// use thoth_plugin_sdk::components::Separator;
 ///
 /// let sep = Separator::with_margin(8.0);
+/// // …or a flush 1px band edge in a theme colour:
+/// let rule = Separator::rule("fg-faint");
 /// ```
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, Builder)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Builder)]
+#[builder(on(String, into))]
 #[non_exhaustive]
 pub struct Separator {
     /// Space added above the line, in points.
@@ -19,6 +33,19 @@ pub struct Separator {
     #[builder(default)]
     #[serde(default, rename = "margin-bottom")]
     pub margin_bottom: f32,
+    /// Line colour as a `#rrggbb(aa)` hex string or a theme token. When unset,
+    /// the theme's own separator stroke colour is used.
+    #[serde(default)]
+    pub color: Option<String>,
+    /// Line thickness in points. When unset, the theme's separator stroke width
+    /// is used (1pt).
+    #[serde(default)]
+    pub thickness: Option<f32>,
+    /// Total vertical space the separator occupies, in points — the line is
+    /// centred in it. Defaults to egui's 6pt; pass `0.0` for a flush band edge
+    /// that takes no more room than its own thickness.
+    #[serde(default)]
+    pub spacing: Option<f32>,
 }
 
 impl Separator {
@@ -32,6 +59,7 @@ impl Separator {
         Self {
             margin_top: margin,
             margin_bottom: margin,
+            ..Self::default()
         }
     }
 
@@ -40,7 +68,53 @@ impl Separator {
         Self {
             margin_top: top,
             margin_bottom: bottom,
+            ..Self::default()
         }
+    }
+
+    /// A flush 1pt rule in `color` (hex or theme token) that occupies nothing
+    /// but its own thickness — the design's `box-shadow: inset 0 ±1px 0 …` band
+    /// edge, which parts two sections without adding a gap between them.
+    pub fn rule(color: impl Into<String>) -> Self {
+        Self {
+            color: Some(color.into()),
+            thickness: Some(1.0),
+            spacing: Some(0.0),
+            ..Self::default()
+        }
+    }
+
+    /// Whether any of the paint overrides are set — if not, this is egui's own
+    /// separator and is drawn by it, unchanged.
+    #[cfg_attr(not(any(feature = "egui", test)), allow(dead_code))]
+    fn is_styled(&self) -> bool {
+        self.color.is_some() || self.thickness.is_some() || self.spacing.is_some()
+    }
+}
+
+#[cfg(feature = "egui")]
+impl Separator {
+    /// This separator's resolved line stroke against the active theme.
+    pub fn stroke(&self, ui: &egui::Ui) -> egui::Stroke {
+        let base = ui.visuals().widgets.noninteractive.bg_stroke;
+        let colors = crate::theme::ThemeColors::from_ctx(ui.ctx());
+        egui::Stroke::new(
+            self.thickness.unwrap_or(base.width),
+            self.color
+                .as_deref()
+                .and_then(|c| crate::theme::resolve_color(c, &colors))
+                .unwrap_or(base.color),
+        )
+    }
+
+    /// Paint this separator's line along `x_range` at `y` **without allocating**
+    /// any layout space.
+    ///
+    /// For the rules that are an edge of something already laid out — a row's
+    /// bottom hairline, the divider along a list row's top — where consuming a
+    /// point of height would push the very thing being underlined.
+    pub fn paint_at(&self, ui: &egui::Ui, x_range: egui::Rangef, y: f32) {
+        ui.painter().hline(x_range, y, self.stroke(ui));
     }
 }
 
@@ -50,7 +124,27 @@ impl egui::Widget for Separator {
         if self.margin_top > 0.0 {
             ui.add_space(self.margin_top);
         }
-        let response = ui.separator();
+        let response = if self.is_styled() {
+            let stroke = self.stroke(ui);
+            // The line is centred in its slot, as egui's separator centres in
+            // its 6pt. A slot can never be thinner than the line it carries, so
+            // `spacing(0.0)` yields a rule exactly `thickness` tall.
+            let height = self.spacing.unwrap_or(DEFAULT_SPACING).max(stroke.width);
+            let (rect, response) = ui.allocate_exact_size(
+                egui::vec2(ui.available_width(), height),
+                egui::Sense::hover(),
+            );
+            if ui.is_rect_visible(rect) {
+                let line = egui::Rect::from_min_size(
+                    egui::pos2(rect.left(), rect.center().y - stroke.width / 2.0),
+                    egui::vec2(rect.width(), stroke.width),
+                );
+                ui.painter().rect_filled(line, 0.0, stroke.color);
+            }
+            response
+        } else {
+            ui.separator()
+        };
         if self.margin_bottom > 0.0 {
             ui.add_space(self.margin_bottom);
         }
@@ -61,7 +155,7 @@ impl egui::Widget for Separator {
 #[cfg(test)]
 mod tests {
     use super::Separator;
-    use serde_json::Value;
+    use serde_json::{Value, json};
 
     #[test]
     fn plain_has_zero_margins() {
@@ -118,5 +212,44 @@ mod tests {
         let restored: Separator = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.margin_top, original.margin_top);
         assert_eq!(restored.margin_bottom, original.margin_bottom);
+    }
+
+    // ── paint overrides ───────────────────────────────────────────────────────
+
+    #[test]
+    fn constructors_leave_the_paint_overrides_unset() {
+        // Every existing call site goes through these, so all three must stay
+        // `None` — that is what keeps them on egui's own separator.
+        for sep in [
+            Separator::plain(),
+            Separator::with_margin(6.0),
+            Separator::with_margins(1.0, 2.0),
+            Separator::builder().build(),
+        ] {
+            assert!(sep.color.is_none());
+            assert!(sep.thickness.is_none());
+            assert!(sep.spacing.is_none());
+            assert!(!sep.is_styled());
+        }
+    }
+
+    #[test]
+    fn rule_is_a_flush_one_point_line() {
+        let sep = Separator::rule("fg-faint");
+        assert_eq!(sep.color.as_deref(), Some("fg-faint"));
+        assert_eq!(sep.thickness, Some(1.0));
+        assert_eq!(sep.spacing, Some(0.0));
+        assert_eq!(sep.margin_top, 0.0);
+        assert_eq!(sep.margin_bottom, 0.0);
+        assert!(sep.is_styled());
+    }
+
+    #[test]
+    fn deserialises_without_the_paint_overrides() {
+        let sep: Separator = serde_json::from_value(json!({ "margin-top": 4.0 })).unwrap();
+        assert_eq!(sep.margin_top, 4.0);
+        assert!(sep.color.is_none());
+        assert!(sep.thickness.is_none());
+        assert!(sep.spacing.is_none());
     }
 }

--- a/thoth-plugin-sdk/src/components/separator/mod.rs
+++ b/thoth-plugin-sdk/src/components/separator/mod.rs
@@ -129,16 +129,30 @@ impl egui::Widget for Separator {
             // The line is centred in its slot, as egui's separator centres in
             // its 6pt. A slot can never be thinner than the line it carries, so
             // `spacing(0.0)` yields a rule exactly `thickness` tall.
-            let height = self.spacing.unwrap_or(DEFAULT_SPACING).max(stroke.width);
-            let (rect, response) = ui.allocate_exact_size(
-                egui::vec2(ui.available_width(), height),
-                egui::Sense::hover(),
-            );
+            let thickness = self.spacing.unwrap_or(DEFAULT_SPACING).max(stroke.width);
+            // Orientation comes from the layout, exactly as `ui.separator()` picks
+            // it: a rule across a top-down column, a rule *down* a left-to-right
+            // row. Without this a styled separator in a `ui.horizontal` would claim
+            // the whole row's width and paint over its neighbours.
+            let horizontal_line = !ui.layout().main_dir().is_horizontal();
+            let size = if horizontal_line {
+                egui::vec2(ui.available_width(), thickness)
+            } else {
+                egui::vec2(thickness, ui.available_height())
+            };
+            let (rect, response) = ui.allocate_exact_size(size, egui::Sense::hover());
             if ui.is_rect_visible(rect) {
-                let line = egui::Rect::from_min_size(
-                    egui::pos2(rect.left(), rect.center().y - stroke.width / 2.0),
-                    egui::vec2(rect.width(), stroke.width),
-                );
+                let line = if horizontal_line {
+                    egui::Rect::from_min_size(
+                        egui::pos2(rect.left(), rect.center().y - stroke.width / 2.0),
+                        egui::vec2(rect.width(), stroke.width),
+                    )
+                } else {
+                    egui::Rect::from_min_size(
+                        egui::pos2(rect.center().x - stroke.width / 2.0, rect.top()),
+                        egui::vec2(stroke.width, rect.height()),
+                    )
+                };
                 ui.painter().rect_filled(line, 0.0, stroke.color);
             }
             response

--- a/thoth-plugin-sdk/src/components/sidebar_header/ui.rs
+++ b/thoth-plugin-sdk/src/components/sidebar_header/ui.rs
@@ -1,15 +1,30 @@
-use egui::{InnerResponse, Response, RichText, Widget};
+use egui::{InnerResponse, Response, RichText, Stroke, Widget};
 
-use crate::components::{IconButton, Separator, Typography, TypographyVariant};
-use crate::theme::ThemeColors;
+use crate::components::{IconButton, Typography, TypographyVariant};
+use crate::theme::{ThemeColors, with_alpha};
 
 use super::SidebarHeader;
 
-/// Fixed height of the header content row — sized to fit a frameless icon
-/// button so action-bearing headers match text-only ones.
+/// Fixed height of the header content row — design `.shrow{height:32px}`. Sized
+/// to fit a ghost icon button, so action-bearing headers match text-only ones.
 const HEADER_H: f32 = 32.0;
-/// Horizontal inset matching the list rows' left padding.
+/// Horizontal inset matching the list rows' left padding — design `.sh{padding:0 8px}`.
 const PAD_X: f32 = 8.0;
+/// Gap between the title and what follows it — design `.shrow{gap:8px}`.
+const GAP: f32 = 8.0;
+/// Trailing count text — design `.shtrail{font-size:10px}`.
+const FONT_TRAILING: f32 = 10.0;
+/// Gap between trailing icon buttons — design `.shacts{gap:1px}`.
+const ACTION_GAP: f32 = 1.0;
+/// Ghost `.ib` metrics: a 24px square with a 14px glyph.
+const ACTION_SIZE: f32 = 24.0;
+/// …glyph size inside it.
+const ACTION_GLYPH: f32 = 14.0;
+/// Separator beneath the row — design
+/// `.shsep{height:1px;background:surface1@30%;margin-top:2px}`.
+const SEP_ALPHA: u8 = 77; // 30% of 255
+/// …and its offset below the row.
+const SEP_GAP: f32 = 2.0;
 
 impl SidebarHeader {
     /// Render the header and report which action (if any) was clicked this
@@ -21,23 +36,32 @@ impl SidebarHeader {
         let inner = ui.allocate_ui(egui::vec2(ui.available_width(), HEADER_H), |ui| {
             ui.horizontal(|ui| {
                 ui.set_min_height(HEADER_H);
+                // Every gap in the row is explicit — design `.shrow{gap:8px}`.
+                ui.spacing_mut().item_spacing.x = 0.0;
                 ui.add_space(PAD_X);
+                // `.sht` — 11px bold in the section-header colour (`--overlay2`).
                 ui.add(
                     Typography::builder()
                         .text(self.title.as_str())
                         .variant(TypographyVariant::PanelHeader)
                         .build(),
                 );
+                ui.add_space(GAP);
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     ui.add_space(PAD_X);
                     // Right-to-left: iterate reversed so actions[0] is leftmost.
                     for (idx, action) in self.actions.iter().enumerate().rev() {
+                        if idx + 1 < self.actions.len() {
+                            ui.add_space(ACTION_GAP);
+                        }
                         let clicked = ui
                             .add(
                                 IconButton::builder()
                                     .icon(action.icon.as_str())
                                     .tooltip(action.tooltip.as_str())
+                                    .size_px(ACTION_SIZE)
+                                    .icon_size(ACTION_GLYPH)
                                     .build(),
                             )
                             .clicked();
@@ -46,13 +70,28 @@ impl SidebarHeader {
                         }
                     }
                     if let Some(text) = self.trailing_text.as_deref() {
-                        ui.label(RichText::new(text).color(colors.fg_muted).size(10.0));
+                        if !self.actions.is_empty() {
+                            ui.add_space(GAP);
+                        }
+                        ui.label(
+                            RichText::new(text)
+                                .color(colors.fg_muted)
+                                .size(FONT_TRAILING),
+                        );
                     }
                 });
             });
         });
 
-        ui.add(Separator::plain());
+        // `.shsep` — a 1px tinted rule 2px under the row, full panel width.
+        ui.add_space(SEP_GAP);
+        let (rect, _) =
+            ui.allocate_exact_size(egui::vec2(ui.available_width(), 1.0), egui::Sense::hover());
+        ui.painter().hline(
+            rect.x_range(),
+            rect.center().y,
+            Stroke::new(1.0, with_alpha(colors.surface_raised, SEP_ALPHA)),
+        );
 
         InnerResponse::new(action_clicked, inner.response)
     }

--- a/thoth-plugin-sdk/src/components/size.rs
+++ b/thoth-plugin-sdk/src/components/size.rs
@@ -15,13 +15,27 @@ pub enum Size {
 }
 
 impl Size {
-    /// This size's `(font_size, height)` in points/pixels for text controls
-    /// like buttons and selects.
+    /// This size's `(font_size, height)` for buttons and icon buttons — design
+    /// `.btn` (26px / 12.5px) and `.btn.sm` (22px / 11.5px).
+    ///
+    /// Note this is deliberately *shorter* than [`Self::field_metrics`]: the
+    /// design sheet sizes buttons at 26px and text-entry controls at 28px, so a
+    /// button never looks taller than the input it sits beside.
     pub fn metrics(self) -> (f32, f32) {
         match self {
-            Size::Small => (11.0, 24.0),
-            Size::Medium => (13.0, 28.0),
-            Size::Large => (15.0, 32.0),
+            Size::Small => (11.5, 22.0),
+            Size::Medium => (12.5, 26.0),
+            Size::Large => (14.0, 30.0),
+        }
+    }
+
+    /// This size's `(font_size, height)` for text-entry controls — inputs,
+    /// select triggers, number inputs. Design `.field` / `.trigger` / `.num`.
+    pub fn field_metrics(self) -> (f32, f32) {
+        match self {
+            Size::Small => (11.5, 24.0),
+            Size::Medium => (12.5, 28.0),
+            Size::Large => (14.0, 32.0),
         }
     }
 }

--- a/thoth-plugin-sdk/src/components/slider/mod.rs
+++ b/thoth-plugin-sdk/src/components/slider/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "egui")]
+mod ui;
+
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
@@ -31,18 +34,4 @@ pub struct Slider {
     #[builder(default)]
     #[serde(default)]
     pub disabled: bool,
-}
-
-#[cfg(feature = "egui")]
-impl Slider {
-    /// Render the slider, editing [`value`](Slider::value) in place.
-    pub fn show(&mut self, ui: &mut egui::Ui) -> egui::Response {
-        if !self.label.is_empty() {
-            ui.label(&self.label);
-        }
-        ui.add_enabled(
-            !self.disabled,
-            egui::Slider::new(&mut self.value, self.min..=self.max),
-        )
-    }
 }

--- a/thoth-plugin-sdk/src/components/slider/ui.rs
+++ b/thoth-plugin-sdk/src/components/slider/ui.rs
@@ -37,12 +37,26 @@ impl Slider {
             // layout's own item spacing and keep the geometry exact.
             ui.spacing_mut().item_spacing.x = 0.0;
 
-            let readout = ui.painter().layout_no_wrap(
-                format_value(self.value, self.max - self.min),
-                egui::FontId::monospace(READOUT_FONT),
-                colors.fg_subtle(),
-            );
-            let readout_w = readout.size().x.max(READOUT_MIN_WIDTH);
+            // Only the readout's *slot* is measured up front — the galley itself is
+            // laid out at paint time, after the drag handler below has moved
+            // `self.value`, so the number never lags a frame behind the thumb. The
+            // slot is measured from the range's endpoints (the widest the readout
+            // can get) rather than the current value, so the track keeps a stable
+            // width as digits come and go.
+            let span = self.max - self.min;
+            let readout_w = [self.min, self.max]
+                .into_iter()
+                .map(|v| {
+                    ui.painter()
+                        .layout_no_wrap(
+                            format_value(v, span),
+                            egui::FontId::monospace(READOUT_FONT),
+                            colors.fg_subtle(),
+                        )
+                        .size()
+                        .x
+                })
+                .fold(READOUT_MIN_WIDTH, f32::max);
             // The halo sits outside the thumb, so the row must be tall enough for both.
             let row_h = THUMB_DIAMETER + 2.0 * HALO_WIDTH;
             let track_w = (ui.available_width() - readout_w - READOUT_GAP).max(THUMB_DIAMETER);
@@ -60,18 +74,58 @@ impl Slider {
             // travel is narrower than the track itself.
             let half = THUMB_DIAMETER / 2.0;
             let (x0, x1) = (rect.left() + half, rect.right() - half);
-            let span = self.max - self.min;
 
             if (response.clicked() || response.dragged())
                 && let Some(pos) = response.interact_pointer_pos()
             {
                 let t = ((pos.x - x0) / (x1 - x0).max(1.0)).clamp(0.0, 1.0);
-                let value = self.min + t as f64 * span;
+                // Snap to the precision the readout shows, so the value the plugin
+                // receives is the number the user read off the slider.
+                let scale = 10f64.powi(decimals_for(span) as i32);
+                let value = ((self.min + t as f64 * span) * scale).round() / scale;
                 if value != self.value {
                     self.value = value;
                     response.mark_changed();
                 }
             }
+
+            // Keyboard control. `Sense::click_and_drag` already makes the track
+            // focusable, so without this a keyboard user can tab to the slider but
+            // never move it. One arrow press steps by the readout's own precision;
+            // Home/End jump to the ends.
+            if interactive && response.has_focus() {
+                let step = span.signum() * 10f64.powi(-(decimals_for(span) as i32));
+                let (lo, hi) = if self.min <= self.max {
+                    (self.min, self.max)
+                } else {
+                    (self.max, self.min)
+                };
+                let target = ui.input(|i| {
+                    use egui::Key;
+                    if i.key_pressed(Key::ArrowLeft) || i.key_pressed(Key::ArrowDown) {
+                        Some(self.value - step)
+                    } else if i.key_pressed(Key::ArrowRight) || i.key_pressed(Key::ArrowUp) {
+                        Some(self.value + step)
+                    } else if i.key_pressed(Key::Home) {
+                        Some(self.min)
+                    } else if i.key_pressed(Key::End) {
+                        Some(self.max)
+                    } else {
+                        None
+                    }
+                });
+                if let Some(value) = target {
+                    let value = value.clamp(lo, hi);
+                    if value != self.value {
+                        self.value = value;
+                        response.mark_changed();
+                    }
+                }
+            }
+            // Assistive technologies read the value and label from here.
+            response.widget_info(|| {
+                egui::WidgetInfo::slider(interactive, self.value, self.label.as_str())
+            });
 
             // Right-aligned readout in its own slot, so the track keeps a stable
             // width regardless of the value's digit count.
@@ -93,6 +147,12 @@ impl Slider {
                     0.0
                 };
                 let thumb_center = egui::pos2(egui::lerp(x0..=x1, t), rect.center().y);
+                // Laid out here, from the value the drag handler just wrote.
+                let readout = painter.layout_no_wrap(
+                    format_value(self.value, span),
+                    egui::FontId::monospace(READOUT_FONT),
+                    colors.fg_subtle(),
+                );
 
                 // `RADIUS_PILL` saturates to `u8::MAX`; the tessellator clamps the
                 // corner radius to half the height, which is the full pill we want.
@@ -139,15 +199,21 @@ impl Slider {
     }
 }
 
-/// Format the readout with a precision that suits the range: wide ranges read as
-/// whole numbers, narrow ones keep the decimals that make dragging legible.
-fn format_value(value: f64, span: f64) -> String {
-    let decimals = if span.abs() >= 10.0 {
+/// Decimal places the readout shows for a range of `span`: wide ranges read as
+/// whole numbers, narrow ones keep the decimals that make dragging legible. Also
+/// the precision the dragged value is snapped to, so the two can't disagree.
+fn decimals_for(span: f64) -> usize {
+    if span.abs() >= 10.0 {
         0
     } else if span.abs() >= 1.0 {
         2
     } else {
         3
-    };
+    }
+}
+
+/// Format the readout at [`decimals_for`]'s precision.
+fn format_value(value: f64, span: f64) -> String {
+    let decimals = decimals_for(span);
     format!("{value:.decimals$}")
 }

--- a/thoth-plugin-sdk/src/components/slider/ui.rs
+++ b/thoth-plugin-sdk/src/components/slider/ui.rs
@@ -1,0 +1,153 @@
+use egui::{CornerRadius, Rect, Sense, Stroke, Vec2};
+
+use crate::theme::{RADIUS_PILL, ThemeColors, slider_thumb_shadow, with_alpha};
+
+use super::Slider;
+
+/// Track thickness — design `input[type=range] { height:5px }`.
+const TRACK_HEIGHT: f32 = 5.0;
+/// Thumb diameter — design `::-webkit-slider-thumb { width:15px; height:15px }`.
+const THUMB_DIAMETER: f32 = 15.0;
+/// Halo ring around the thumb — design thumb `box-shadow: 0 0 0 3px mauve@30%`.
+const HALO_WIDTH: f32 = 3.0;
+/// 30% of 255 — the halo's accent alpha.
+const HALO_ALPHA: u8 = 77;
+/// Value readout — design `.sval { font:500 12px mono; min-width:34px }`.
+const READOUT_FONT: f32 = 12.0;
+/// Minimum readout width, so the track doesn't twitch as digits change.
+const READOUT_MIN_WIDTH: f32 = 34.0;
+/// Gap between track and readout — design `.row { gap:12px }` on the slider row.
+const READOUT_GAP: f32 = 12.0;
+/// Opacity of a disabled slider. The design sheet has no disabled slider
+/// variant; match the switch (`.switch.dis { opacity:.4 }`).
+const DISABLED_OPACITY: f32 = 0.4;
+
+impl Slider {
+    /// Render the slider, editing [`value`](Slider::value) in place.
+    pub fn show(&mut self, ui: &mut egui::Ui) -> egui::Response {
+        let colors = ThemeColors::from_ctx(ui.ctx());
+        let interactive = !self.disabled && ui.is_enabled();
+
+        if !self.label.is_empty() {
+            ui.label(&self.label);
+        }
+
+        ui.horizontal(|ui| {
+            // The 12px track↔readout gap is spaced explicitly, so drop the
+            // layout's own item spacing and keep the geometry exact.
+            ui.spacing_mut().item_spacing.x = 0.0;
+
+            let readout = ui.painter().layout_no_wrap(
+                format_value(self.value, self.max - self.min),
+                egui::FontId::monospace(READOUT_FONT),
+                colors.fg_subtle(),
+            );
+            let readout_w = readout.size().x.max(READOUT_MIN_WIDTH);
+            // The halo sits outside the thumb, so the row must be tall enough for both.
+            let row_h = THUMB_DIAMETER + 2.0 * HALO_WIDTH;
+            let track_w = (ui.available_width() - readout_w - READOUT_GAP).max(THUMB_DIAMETER);
+
+            let (rect, mut response) = ui.allocate_exact_size(
+                Vec2::new(track_w, row_h),
+                if interactive {
+                    Sense::click_and_drag()
+                } else {
+                    Sense::hover()
+                },
+            );
+
+            // The thumb centre stays a half-thumb inside each end, so the usable
+            // travel is narrower than the track itself.
+            let half = THUMB_DIAMETER / 2.0;
+            let (x0, x1) = (rect.left() + half, rect.right() - half);
+            let span = self.max - self.min;
+
+            if (response.clicked() || response.dragged())
+                && let Some(pos) = response.interact_pointer_pos()
+            {
+                let t = ((pos.x - x0) / (x1 - x0).max(1.0)).clamp(0.0, 1.0);
+                let value = self.min + t as f64 * span;
+                if value != self.value {
+                    self.value = value;
+                    response.mark_changed();
+                }
+            }
+
+            // Right-aligned readout in its own slot, so the track keeps a stable
+            // width regardless of the value's digit count.
+            ui.add_space(READOUT_GAP);
+            let (readout_rect, _) =
+                ui.allocate_exact_size(Vec2::new(readout_w, row_h), Sense::hover());
+
+            if ui.is_rect_visible(rect) {
+                // Disabled sliders fade through a *cloned* painter so the opacity
+                // never leaks into the widgets painted after this one.
+                let mut painter = ui.painter().clone();
+                if !interactive {
+                    painter.multiply_opacity(DISABLED_OPACITY);
+                }
+
+                let t = if span.abs() > f64::EPSILON {
+                    ((self.value - self.min) / span).clamp(0.0, 1.0) as f32
+                } else {
+                    0.0
+                };
+                let thumb_center = egui::pos2(egui::lerp(x0..=x1, t), rect.center().y);
+
+                // `RADIUS_PILL` saturates to `u8::MAX`; the tessellator clamps the
+                // corner radius to half the height, which is the full pill we want.
+                let pill = CornerRadius::same(RADIUS_PILL as u8);
+                let track =
+                    Rect::from_center_size(rect.center(), Vec2::new(rect.width(), TRACK_HEIGHT));
+                painter.rect_filled(track, pill, colors.surface_raised);
+                let filled = Rect::from_min_max(track.min, egui::pos2(thumb_center.x, track.max.y));
+                painter.rect_filled(filled, pill, colors.accent);
+
+                // Thumb drop shadow — design `0 2px 6px black@45%`.
+                painter.add(slider_thumb_shadow().as_shape(
+                    Rect::from_center_size(thumb_center, Vec2::splat(THUMB_DIAMETER)),
+                    pill,
+                ));
+                painter.circle_stroke(
+                    thumb_center,
+                    half + HALO_WIDTH / 2.0,
+                    Stroke::new(HALO_WIDTH, with_alpha(colors.accent, HALO_ALPHA)),
+                );
+                painter.circle_filled(thumb_center, half, colors.fg);
+
+                let text_pos = egui::pos2(
+                    readout_rect.right() - readout.size().x,
+                    readout_rect.center().y - readout.size().y / 2.0,
+                );
+                // Faux medium weight: a second pass shifted 0.5px right thickens
+                // the vertical strokes (design `.sval { font-weight:500 }`).
+                painter.galley(
+                    text_pos + Vec2::new(0.5, 0.0),
+                    readout.clone(),
+                    colors.fg_subtle(),
+                );
+                painter.galley(text_pos, readout, colors.fg_subtle());
+            }
+
+            if interactive {
+                response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
+            }
+
+            response
+        })
+        .inner
+    }
+}
+
+/// Format the readout with a precision that suits the range: wide ranges read as
+/// whole numbers, narrow ones keep the decimals that make dragging legible.
+fn format_value(value: f64, span: f64) -> String {
+    let decimals = if span.abs() >= 10.0 {
+        0
+    } else if span.abs() >= 1.0 {
+        2
+    } else {
+        3
+    };
+    format!("{value:.decimals$}")
+}

--- a/thoth-plugin-sdk/src/components/spinner/mod.rs
+++ b/thoth-plugin-sdk/src/components/spinner/mod.rs
@@ -50,7 +50,9 @@ impl egui::Widget for Spinner {
         use std::f32::consts::TAU;
 
         let colors = ThemeColors::from_ctx(ui.ctx());
-        let diameter = self.size.unwrap_or(DEFAULT_SIZE);
+        // `size` arrives from plugin JSON, so keep it in a paintable range: a
+        // zero or negative diameter would derive a negative radius.
+        let diameter = self.size.unwrap_or(DEFAULT_SIZE).max(STROKE);
         let stroke_w = if diameter >= LARGE_SIZE {
             STROKE_LARGE
         } else {

--- a/thoth-plugin-sdk/src/components/spinner/mod.rs
+++ b/thoth-plugin-sdk/src/components/spinner/mod.rs
@@ -1,7 +1,34 @@
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
-/// An indeterminate loading spinner.
+/// Default diameter — the design sheet's smallest `.spin` (16px).
+#[cfg(feature = "egui")]
+const DEFAULT_SIZE: f32 = 16.0;
+/// Ring thickness — design `.spin{border:2.5px …}`.
+#[cfg(feature = "egui")]
+const STROKE: f32 = 2.5;
+/// …thickened on the largest size — design the 26px `.spin{border-width:3px}`.
+#[cfg(feature = "egui")]
+const STROKE_LARGE: f32 = 3.0;
+/// The size at which the thicker ring kicks in.
+#[cfg(feature = "egui")]
+const LARGE_SIZE: f32 = 26.0;
+/// One full turn, in seconds — design `animation:sp .7s linear infinite`.
+#[cfg(feature = "egui")]
+const PERIOD: f64 = 0.7;
+/// Fraction of the ring drawn solid: the CSS colours a single border side, i.e.
+/// a quarter turn.
+#[cfg(feature = "egui")]
+const ARC_FRACTION: f32 = 0.25;
+/// Line segments used to approximate the leading arc.
+#[cfg(feature = "egui")]
+const ARC_SEGMENTS: usize = 12;
+/// Alpha of the ring behind the arc — design `accent 26%`.
+#[cfg(feature = "egui")]
+const TRACK_ALPHA: u8 = 66;
+
+/// An indeterminate loading spinner: a faint accent ring with a solid accent arc
+/// sweeping around it. The design sheet uses 16 / 20 / 26 pt.
 ///
 /// ```
 /// use thoth_plugin_sdk::components::Spinner;
@@ -19,11 +46,50 @@ pub struct Spinner {
 #[cfg(feature = "egui")]
 impl egui::Widget for Spinner {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
-        use crate::theme::ThemeColors;
+        use crate::theme::{ThemeColors, with_alpha};
+        use std::f32::consts::TAU;
+
         let colors = ThemeColors::from_ctx(ui.ctx());
-        let spinner = egui::Spinner::new()
-            .color(colors.accent)
-            .size(self.size.unwrap_or(16.0));
-        ui.add(spinner)
+        let diameter = self.size.unwrap_or(DEFAULT_SIZE);
+        let stroke_w = if diameter >= LARGE_SIZE {
+            STROKE_LARGE
+        } else {
+            STROKE
+        };
+
+        let (rect, response) =
+            ui.allocate_exact_size(egui::Vec2::splat(diameter), egui::Sense::hover());
+
+        if ui.is_rect_visible(rect) {
+            // Hand-painted rather than `egui::Spinner`, which draws a single-colour
+            // arc: the design needs a two-tone ring (faint full circle + solid
+            // leading arc).
+            let center = rect.center();
+            let radius = (diameter - stroke_w) / 2.0;
+            let painter = ui.painter();
+            painter.circle_stroke(
+                center,
+                radius,
+                egui::Stroke::new(stroke_w, with_alpha(colors.accent, TRACK_ALPHA)),
+            );
+
+            let start = (ui.input(|i| i.time).rem_euclid(PERIOD) / PERIOD) as f32 * TAU;
+            let sweep = TAU * ARC_FRACTION;
+            let arc: Vec<egui::Pos2> = (0..=ARC_SEGMENTS)
+                .map(|i| {
+                    let angle = start + sweep * i as f32 / ARC_SEGMENTS as f32;
+                    center + egui::vec2(angle.cos(), angle.sin()) * radius
+                })
+                .collect();
+            ui.painter().add(egui::Shape::line(
+                arc,
+                egui::Stroke::new(stroke_w, colors.accent),
+            ));
+
+            // Keep the animation running.
+            ui.ctx().request_repaint();
+        }
+
+        response
     }
 }

--- a/thoth-plugin-sdk/src/components/table_view/mod.rs
+++ b/thoth-plugin-sdk/src/components/table_view/mod.rs
@@ -1,10 +1,14 @@
 #[cfg(feature = "egui")]
-mod ui;
+pub(crate) mod ui;
 
 use bon::Builder;
 use serde::{Deserialize, Serialize};
 
 use crate::render_node::RenderNode;
+
+fn default_true() -> bool {
+    true
+}
 
 /// A horizontally-scrollable, virtually-scrolled data grid with a sticky `#`
 /// row-number gutter, compact headers, zebra rows, and grid lines.
@@ -27,7 +31,7 @@ use crate::render_node::RenderNode;
 ///     .rows(vec![vec![cell("1"), cell("thoth")]])
 ///     .build();
 /// ```
-#[derive(Clone, Debug, Default, Serialize, Deserialize, Builder)]
+#[derive(Clone, Debug, Serialize, Deserialize, Builder)]
 #[builder(on(String, into))]
 #[non_exhaustive]
 pub struct TableView {
@@ -49,6 +53,22 @@ pub struct TableView {
     #[builder(default)]
     #[serde(default)]
     pub column_types: Vec<ColumnType>,
+    /// Draw the outer container (canvas fill + hairline edge + rounded corners,
+    /// rows clipped to them). Defaults to `true`; set `false` when the grid sits
+    /// inside a container that already owns those corners — [`DataView`] draws
+    /// the grid flush and border-less inside its own frame.
+    ///
+    /// [`DataView`]: crate::components::DataView
+    #[builder(default = true)]
+    #[serde(default = "default_true")]
+    pub framed: bool,
+}
+
+impl Default for TableView {
+    /// An empty, framed grid — mirrors the builder's defaults.
+    fn default() -> Self {
+        Self::builder().build()
+    }
 }
 
 /// The supported column formats a [`TableView`] styles cells by. Map a raw SQL

--- a/thoth-plugin-sdk/src/components/table_view/ui.rs
+++ b/thoth-plugin-sdk/src/components/table_view/ui.rs
@@ -2,14 +2,28 @@ use egui::{Color32, Stroke};
 use egui_extras::{Column, TableBuilder};
 
 use crate::render_node::UiEvent;
-use crate::theme::ThemeColors;
+use crate::theme::{FONT_CAPTION, RADIUS_PANEL, ThemeColors, edge_stroke, with_alpha};
 
 use super::TableView;
 
+/// Sticky header height — design `.tv thead th{height:28px}`.
 const HEADER_H: f32 = 28.0;
+/// Body row height — design `.tv tbody td{height:30px}`.
 const ROW_H: f32 = 30.0;
+/// Width of the `#` gutter — design `.tv th.num,.tv td.num{width:44px}`.
 const NUM_COL_W: f32 = 44.0;
+/// Horizontal cell padding — design `padding:0 10px`.
 const CELL_PAD: i8 = 10;
+/// Cell text size — design `.tv table{font-size:12px}`.
+const CELL_FONT: f32 = 12.0;
+/// `#` gutter text size — design `.tv td.num{font-size:10px}` (monospace).
+const NUM_FONT: f32 = 10.0;
+/// Column type suffix size — design `.tv thead th .ty{font-size:9px}` (monospace).
+const TYPE_FONT: f32 = 9.0;
+/// Gap before the type suffix — design `.ty{margin-left:5px}`.
+const TYPE_GAP: f32 = 5.0;
+/// Zebra wash — design `tbody tr:nth-child(even){background:text 3%}`.
+const ZEBRA_ALPHA: u8 = 8;
 
 impl TableView {
     /// Render the grid, drawing each cell node and collecting their events.
@@ -34,167 +48,105 @@ impl TableView {
         let copy_action = std::cell::Cell::new(None::<CopyAction>);
 
         let grid = colors.surface;
-        let header_border = colors.surface_raised;
-        let header_bg = colors.bg_panel;
-        let num_fg = colors.fg_muted;
-        let header_fg = colors.fg;
 
         let mut clicked_row: Option<usize> = None;
 
-        ui.set_min_width(ui.available_width());
+        container(ui, self.framed, &colors, |ui| {
+            ui.set_min_width(ui.available_width());
 
-        egui::ScrollArea::horizontal()
-            .auto_shrink([false, false])
-            .show(ui, |ui| {
-                ui.style_mut().visuals.widgets.noninteractive.bg_stroke = Stroke::NONE;
-                ui.style_mut().spacing.item_spacing.x = 0.0;
-                TableBuilder::new(ui)
-                    .striped(true)
-                    .sense(egui::Sense::click())
-                    .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                    .column(Column::exact(NUM_COL_W))
-                    .columns(
-                        Column::auto_with_initial_suggestion(min_col_width)
-                            .clip(true)
-                            .resizable(true),
-                        num_cols,
-                    )
-                    .header(HEADER_H, |mut header_row| {
-                        header_row.col(|ui| {
-                            let rect = ui.max_rect();
-                            ui.painter().rect_filled(rect, 0.0, header_bg);
-                            ui.painter().text(
-                                rect.center(),
-                                egui::Align2::CENTER_CENTER,
-                                "#",
-                                egui::FontId::monospace(10.0),
-                                num_fg,
-                            );
-                            paint_cell_borders(ui, grid, header_border);
-                        });
-                        for h in &headers {
-                            header_row.col(|ui| {
-                                ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
-                                let (name, ty) = h.split_once("  ·  ").unwrap_or((h.as_str(), ""));
-                                let r = egui::Frame::NONE
-                                    .inner_margin(egui::Margin::symmetric(CELL_PAD, 0))
-                                    .show(ui, |ui| {
-                                        ui.style_mut().wrap_mode =
-                                            Some(egui::TextWrapMode::Truncate);
-                                        let r = ui.label(
-                                            egui::RichText::new(name)
-                                                .size(11.0)
-                                                .strong()
-                                                .color(header_fg),
-                                        );
-                                        if !ty.is_empty() {
-                                            ui.add_space(4.0);
-                                            ui.label(
-                                                egui::RichText::new(ty)
-                                                    .size(9.0)
-                                                    .monospace()
-                                                    .color(num_fg),
-                                            );
-                                        }
-                                        r
-                                    })
-                                    .inner;
-                                let _ = crate::theme::hover_text(r, h.as_str());
-                                paint_cell_borders(ui, grid, header_border);
-                            });
-                        }
-                    })
-                    .body(|body| {
-                        body.rows(ROW_H, rows.len(), |mut row| {
-                            let idx = row.index();
+            egui::ScrollArea::horizontal()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    ui.style_mut().visuals.widgets.noninteractive.bg_stroke = Stroke::NONE;
+                    ui.style_mut().spacing.item_spacing.x = 0.0;
+                    // Zebra wash, painted *under* the hover/selection fills by
+                    // `egui_extras` (design `tbody tr:nth-child(even)`).
+                    ui.style_mut().visuals.faint_bg_color = with_alpha(colors.fg, ZEBRA_ALPHA);
+                    TableBuilder::new(ui)
+                        .striped(true)
+                        .sense(egui::Sense::click())
+                        .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
+                        .column(Column::exact(NUM_COL_W))
+                        .columns(
+                            Column::auto_with_initial_suggestion(min_col_width)
+                                .clip(true)
+                                .resizable(true),
+                            num_cols,
+                        )
+                        .header(HEADER_H, |header_row| {
+                            paint_header_row(header_row, &headers, &colors);
+                        })
+                        .body(|body| {
+                            body.rows(ROW_H, rows.len(), |mut row| {
+                                let idx = row.index();
 
-                            let mut row_clicked = false;
-                            let (_, number_resp) = row.col(|ui| {
-                                let rect = ui.max_rect();
-                                ui.painter().text(
-                                    rect.center(),
-                                    egui::Align2::CENTER_CENTER,
-                                    (idx + 1).to_string(),
-                                    egui::FontId::monospace(10.0),
-                                    num_fg,
-                                );
-                                paint_cell_borders(ui, grid, grid);
-                            });
-                            // The # gutter paints its text (no widget), so its
-                            // cell response catches the right-click directly.
-                            number_resp.context_menu(|ui| {
-                                copy_menu(ui, &copy_action, idx, None);
-                            });
-                            if number_resp.clicked() {
-                                row_clicked = true;
-                            }
-
-                            for col in 0..num_cols {
-                                let align_right = right_aligned.get(col).copied().unwrap_or(false);
-                                // Interactive JSON-tree cells handle their own clicks,
-                                // so we don't overlay a right-click target on them.
-                                let is_tree = matches!(
-                                    rows.get(idx).and_then(|r| r.get(col)),
-                                    Some(crate::render_node::RenderNode::JsonTree(_))
-                                );
-                                let (_, response) = row.col(|ui| {
-                                    egui::Frame::NONE
-                                        .inner_margin(egui::Margin::symmetric(CELL_PAD, 0))
-                                        .show(ui, |ui| {
-                                            ui.style_mut().wrap_mode =
-                                                Some(egui::TextWrapMode::Truncate);
-                                            ui.style_mut().text_styles.insert(
-                                                egui::TextStyle::Body,
-                                                egui::FontId::proportional(12.0),
-                                            );
-                                            let layout = if align_right {
-                                                egui::Layout::right_to_left(egui::Align::Center)
-                                            } else {
-                                                egui::Layout::left_to_right(egui::Align::Center)
-                                            };
-                                            ui.with_layout(layout, |ui| {
-                                                if let Some(cell) =
-                                                    rows.get_mut(idx).and_then(|r| r.get_mut(col))
-                                                {
-                                                    cell.show(ui, events);
-                                                }
-                                            });
-                                        });
+                                let mut row_clicked = false;
+                                let (_, number_resp) = row.col(|ui| {
+                                    paint_row_number(ui, &colors, &(idx + 1).to_string());
                                     paint_cell_borders(ui, grid, grid);
-                                    // The cell's text widget senses only hover but
-                                    // still swallows the right-click before the cell
-                                    // response sees it, so overlay a full-cell click
-                                    // target on top to catch it. Skipped for JSON-tree
-                                    // cells, which need their own clicks (their blank
-                                    // area is still covered by the outer menu below).
-                                    if !is_tree {
-                                        let menu_resp = ui.interact(
-                                            ui.max_rect(),
-                                            ui.id().with("cell-copy-menu"),
-                                            egui::Sense::click(),
-                                        );
-                                        menu_resp.context_menu(|ui| {
+                                });
+                                // The # gutter paints its text (no widget), so its
+                                // cell response catches the right-click directly.
+                                number_resp.context_menu(|ui| {
+                                    copy_menu(ui, &copy_action, idx, None);
+                                });
+                                if number_resp.clicked() {
+                                    row_clicked = true;
+                                }
+
+                                for col in 0..num_cols {
+                                    let align_right =
+                                        right_aligned.get(col).copied().unwrap_or(false);
+                                    // Interactive JSON-tree cells handle their own clicks,
+                                    // so we don't overlay a right-click target on them.
+                                    let is_tree = matches!(
+                                        rows.get(idx).and_then(|r| r.get(col)),
+                                        Some(crate::render_node::RenderNode::JsonTree(_))
+                                    );
+                                    let (_, response) = row.col(|ui| {
+                                        cell_frame(ui, align_right, |ui| {
+                                            if let Some(cell) =
+                                                rows.get_mut(idx).and_then(|r| r.get_mut(col))
+                                            {
+                                                cell.show(ui, events);
+                                            }
+                                        });
+                                        paint_cell_borders(ui, grid, grid);
+                                        // The cell's text widget senses only hover but
+                                        // still swallows the right-click before the cell
+                                        // response sees it, so overlay a full-cell click
+                                        // target on top to catch it. Skipped for JSON-tree
+                                        // cells, which need their own clicks (their blank
+                                        // area is still covered by the outer menu below).
+                                        if !is_tree {
+                                            let menu_resp = ui.interact(
+                                                ui.max_rect(),
+                                                ui.id().with("cell-copy-menu"),
+                                                egui::Sense::click(),
+                                            );
+                                            menu_resp.context_menu(|ui| {
+                                                copy_menu(ui, &copy_action, idx, Some(col));
+                                            });
+                                        }
+                                    });
+                                    // JSON-tree cells have no overlay; let the cell
+                                    // response catch right-clicks on their blank area.
+                                    if is_tree {
+                                        response.context_menu(|ui| {
                                             copy_menu(ui, &copy_action, idx, Some(col));
                                         });
                                     }
-                                });
-                                // JSON-tree cells have no overlay; let the cell
-                                // response catch right-clicks on their blank area.
-                                if is_tree {
-                                    response.context_menu(|ui| {
-                                        copy_menu(ui, &copy_action, idx, Some(col));
-                                    });
+                                    if response.clicked() {
+                                        row_clicked = true;
+                                    }
                                 }
-                                if response.clicked() {
-                                    row_clicked = true;
+                                if row_clicked {
+                                    clicked_row = Some(idx);
                                 }
-                            }
-                            if row_clicked {
-                                clicked_row = Some(idx);
-                            }
+                            });
                         });
-                    });
-            });
+                });
+        });
 
         // Resolve a requested copy to clipboard text, now that the grid is drawn
         // and `rows` is free to read. Row → cells tab-separated; column → the
@@ -252,126 +204,68 @@ impl TableView {
         let min_col_width = min_col_width.unwrap_or(150.0);
 
         let grid = colors.surface;
-        let header_border = colors.surface_raised;
-        let header_bg = colors.bg_panel;
-        let num_fg = colors.fg_muted;
-        let header_fg = colors.fg;
 
         let mut clicked_row: Option<usize> = None;
 
-        ui.set_min_width(ui.available_width());
+        container(ui, true, &colors, |ui| {
+            ui.set_min_width(ui.available_width());
 
-        egui::ScrollArea::horizontal()
-            .auto_shrink([false, false])
-            .show(ui, |ui| {
-                ui.style_mut().visuals.widgets.noninteractive.bg_stroke = Stroke::NONE;
-                ui.style_mut().spacing.item_spacing.x = 0.0;
-                TableBuilder::new(ui)
-                    .striped(true)
-                    .sense(egui::Sense::click())
-                    .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-                    .column(Column::exact(NUM_COL_W))
-                    .columns(
-                        Column::auto_with_initial_suggestion(min_col_width)
-                            .clip(true)
-                            .resizable(true),
-                        num_cols,
-                    )
-                    .header(HEADER_H, |mut header_row| {
-                        header_row.col(|ui| {
-                            let rect = ui.max_rect();
-                            ui.painter().rect_filled(rect, 0.0, header_bg);
-                            ui.painter().text(
-                                rect.center(),
-                                egui::Align2::CENTER_CENTER,
-                                "#",
-                                egui::FontId::monospace(10.0),
-                                num_fg,
-                            );
-                            paint_cell_borders(ui, grid, header_border);
-                        });
-                        for h in headers {
-                            header_row.col(|ui| {
-                                ui.painter().rect_filled(ui.max_rect(), 0.0, header_bg);
-                                let (name, ty) = h.split_once("  ·  ").unwrap_or((h.as_str(), ""));
-                                let r = egui::Frame::NONE
-                                    .inner_margin(egui::Margin::symmetric(CELL_PAD, 0))
-                                    .show(ui, |ui| {
-                                        ui.style_mut().wrap_mode =
-                                            Some(egui::TextWrapMode::Truncate);
-                                        let r = ui.label(
-                                            egui::RichText::new(name)
-                                                .size(11.0)
-                                                .strong()
-                                                .color(header_fg),
-                                        );
-                                        if !ty.is_empty() {
-                                            ui.add_space(4.0);
-                                            ui.label(
-                                                egui::RichText::new(ty)
-                                                    .size(9.0)
-                                                    .monospace()
-                                                    .color(num_fg),
-                                            );
-                                        }
-                                        r
-                                    })
-                                    .inner;
-                                let _ = crate::theme::hover_text(r, h.as_str());
-                                paint_cell_borders(ui, grid, header_border);
-                            });
-                        }
-                    })
-                    .body(|body| {
-                        body.rows(ROW_H, row_count, |mut row| {
-                            let idx = row.index();
-                            let mut cells = build_row(idx);
-                            cells.truncate(num_cols);
-                            while cells.len() < num_cols {
-                                cells.push(crate::render_node::RenderNode::text(""));
-                            }
+            egui::ScrollArea::horizontal()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    ui.style_mut().visuals.widgets.noninteractive.bg_stroke = Stroke::NONE;
+                    ui.style_mut().spacing.item_spacing.x = 0.0;
+                    ui.style_mut().visuals.faint_bg_color = with_alpha(colors.fg, ZEBRA_ALPHA);
+                    TableBuilder::new(ui)
+                        .striped(true)
+                        .sense(egui::Sense::click())
+                        .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
+                        .column(Column::exact(NUM_COL_W))
+                        .columns(
+                            Column::auto_with_initial_suggestion(min_col_width)
+                                .clip(true)
+                                .resizable(true),
+                            num_cols,
+                        )
+                        .header(HEADER_H, |header_row| {
+                            paint_header_row(header_row, headers, &colors);
+                        })
+                        .body(|body| {
+                            body.rows(ROW_H, row_count, |mut row| {
+                                let idx = row.index();
+                                let mut cells = build_row(idx);
+                                cells.truncate(num_cols);
+                                while cells.len() < num_cols {
+                                    cells.push(crate::render_node::RenderNode::text(""));
+                                }
 
-                            let mut row_clicked = false;
-                            let (_, number_resp) = row.col(|ui| {
-                                let rect = ui.max_rect();
-                                ui.painter().text(
-                                    rect.center(),
-                                    egui::Align2::CENTER_CENTER,
-                                    (idx + 1).to_string(),
-                                    egui::FontId::monospace(10.0),
-                                    num_fg,
-                                );
-                                paint_cell_borders(ui, grid, grid);
-                            });
-                            if number_resp.clicked() {
-                                row_clicked = true;
-                            }
-
-                            for cell in &mut cells {
-                                let (_, response) = row.col(|ui| {
-                                    egui::Frame::NONE
-                                        .inner_margin(egui::Margin::symmetric(CELL_PAD, 0))
-                                        .show(ui, |ui| {
-                                            ui.style_mut().wrap_mode =
-                                                Some(egui::TextWrapMode::Truncate);
-                                            ui.style_mut().text_styles.insert(
-                                                egui::TextStyle::Body,
-                                                egui::FontId::proportional(12.0),
-                                            );
-                                            cell.show(ui, events);
-                                        });
+                                let mut row_clicked = false;
+                                let (_, number_resp) = row.col(|ui| {
+                                    paint_row_number(ui, &colors, &(idx + 1).to_string());
                                     paint_cell_borders(ui, grid, grid);
                                 });
-                                if response.clicked() {
+                                if number_resp.clicked() {
                                     row_clicked = true;
                                 }
-                            }
-                            if row_clicked {
-                                clicked_row = Some(idx);
-                            }
+
+                                for cell in &mut cells {
+                                    let (_, response) = row.col(|ui| {
+                                        cell_frame(ui, false, |ui| {
+                                            cell.show(ui, events);
+                                        });
+                                        paint_cell_borders(ui, grid, grid);
+                                    });
+                                    if response.clicked() {
+                                        row_clicked = true;
+                                    }
+                                }
+                                if row_clicked {
+                                    clicked_row = Some(idx);
+                                }
+                            });
                         });
-                    });
-            });
+                });
+        });
 
         clicked_row
     }
@@ -444,4 +338,213 @@ fn paint_cell_borders(ui: &egui::Ui, right: Color32, bottom: Color32) {
         rect.bottom() - 0.5,
         Stroke::new(1.0, bottom),
     );
+}
+
+/// Draw the grid inside the design's outer container (`.tv`): a `bg` fill, a
+/// hairline [`edge_stroke`], and [`RADIUS_PANEL`] corners, with the rows clipped
+/// to it. `framed` is false when the grid is nested in a container that already
+/// owns those corners — [`DataView`], where the design draws the grid flush and
+/// border-less.
+///
+/// [`DataView`]: crate::components::DataView
+fn container<R>(
+    ui: &mut egui::Ui,
+    framed: bool,
+    colors: &ThemeColors,
+    content: impl FnOnce(&mut egui::Ui) -> R,
+) -> R {
+    if !framed {
+        return content(ui);
+    }
+    let inner = egui::Frame::NONE
+        .fill(colors.bg)
+        .corner_radius(RADIUS_PANEL)
+        .show(ui, |ui| {
+            ui.set_clip_rect(ui.clip_rect().intersect(ui.max_rect()));
+            content(ui)
+        });
+    let rect = inner.response.rect;
+    // Rows paint square corners over the container's, so mask the corners back
+    // to the fill and lay the edge over the topmost row divider.
+    paint_corner_mask(ui.painter(), rect, RADIUS_PANEL, colors.bg);
+    ui.painter().rect_stroke(
+        rect,
+        RADIUS_PANEL,
+        edge_stroke(colors),
+        egui::StrokeKind::Inside,
+    );
+    inner.inner
+}
+
+/// Mask the four corners of `rect` back to `fill`, so square-cornered content
+/// doesn't overrun a rounded container. egui has no rounded clip rect, so each
+/// corner's outside-the-arc wedge is filled as a triangle fan — one mesh rather
+/// than four polygons, which would leave anti-aliasing seams.
+pub(crate) fn paint_corner_mask(
+    painter: &egui::Painter,
+    rect: egui::Rect,
+    radius: f32,
+    fill: Color32,
+) {
+    use std::f32::consts::FRAC_PI_2;
+
+    /// Arc segments per corner — a 10px radius needs no more to read as round.
+    const SEGMENTS: u32 = 6;
+
+    // (square corner, arc centre, angle of the arc's first point). Angles run
+    // clockwise in egui's y-down space, each corner sweeping a quarter turn.
+    let corners = [
+        (
+            rect.left_top(),
+            egui::pos2(rect.left() + radius, rect.top() + radius),
+            2.0 * FRAC_PI_2,
+        ),
+        (
+            rect.right_top(),
+            egui::pos2(rect.right() - radius, rect.top() + radius),
+            3.0 * FRAC_PI_2,
+        ),
+        (
+            rect.right_bottom(),
+            egui::pos2(rect.right() - radius, rect.bottom() - radius),
+            0.0,
+        ),
+        (
+            rect.left_bottom(),
+            egui::pos2(rect.left() + radius, rect.bottom() - radius),
+            FRAC_PI_2,
+        ),
+    ];
+    let mut mesh = egui::Mesh::default();
+    for (corner, centre, start) in corners {
+        let base = mesh.vertices.len() as u32;
+        mesh.colored_vertex(corner, fill);
+        for i in 0..=SEGMENTS {
+            let angle = start + FRAC_PI_2 * i as f32 / SEGMENTS as f32;
+            mesh.colored_vertex(centre + radius * egui::vec2(angle.cos(), angle.sin()), fill);
+        }
+        for i in 0..SEGMENTS {
+            mesh.add_triangle(base, base + 1 + i, base + 2 + i);
+        }
+    }
+    painter.add(egui::Shape::mesh(mesh));
+}
+
+/// Paint the sticky header — the `#` gutter plus one cell per column (design
+/// `.tv thead th`: mantle fill, a `surface` right divider and a brighter
+/// `surface1` bottom divider).
+fn paint_header_row(
+    mut header_row: egui_extras::TableRow<'_, '_>,
+    headers: &[String],
+    colors: &ThemeColors,
+) {
+    header_row.col(|ui| {
+        ui.painter()
+            .rect_filled(ui.max_rect(), 0.0, colors.bg_panel);
+        paint_row_number(ui, colors, "#");
+        paint_cell_borders(ui, colors.surface, colors.surface_raised);
+    });
+    for h in headers {
+        let (_, resp) = header_row.col(|ui| {
+            ui.painter()
+                .rect_filled(ui.max_rect(), 0.0, colors.bg_panel);
+            paint_header_label(ui, colors, h);
+            paint_cell_borders(ui, colors.surface, colors.surface_raised);
+        });
+        let _ = crate::theme::hover_text(resp, h.as_str());
+    }
+}
+
+/// Paint one header cell's text: the column name left-aligned inside the 10px
+/// padding box at semibold 11px, then the optional `"name  ·  type"` suffix as a
+/// small muted mono annotation 5px further right.
+fn paint_header_label(ui: &egui::Ui, colors: &ThemeColors, label: &str) {
+    let rect = ui.max_rect();
+    let pad = f32::from(CELL_PAD);
+    let (name, ty) = label.split_once("  ·  ").unwrap_or((label, ""));
+
+    let mut x = rect.left() + pad;
+    // Design `thead th{font-weight:600}` — a real semibold face. (The previous
+    // `RichText::strong()` here was a no-op, because `strong` only recolours and
+    // an explicit colour was already set.)
+    let name_galley = layout_line(
+        ui.painter(),
+        name,
+        crate::theme::semibold_font_id(ui.ctx(), FONT_CAPTION),
+        colors.fg,
+        (rect.right() - pad - x).max(0.0),
+    );
+    let pos = egui::pos2(x, rect.center().y - name_galley.size().y / 2.0);
+    x += name_galley.size().x + TYPE_GAP;
+    ui.painter().galley(pos, name_galley, colors.fg);
+
+    if !ty.is_empty() {
+        let galley = layout_line(
+            ui.painter(),
+            ty,
+            egui::FontId::monospace(TYPE_FONT),
+            colors.fg_muted,
+            (rect.right() - pad - x).max(0.0),
+        );
+        let pos = egui::pos2(x, rect.center().y - galley.size().y / 2.0);
+        ui.painter().galley(pos, galley, colors.fg_muted);
+    }
+}
+
+/// Paint a `#` gutter value: right-aligned muted mono, 10px off the right edge
+/// (design `.tv th.num,.tv td.num`).
+fn paint_row_number(ui: &egui::Ui, colors: &ThemeColors, text: &str) {
+    let rect = ui.max_rect();
+    ui.painter().text(
+        egui::pos2(rect.right() - f32::from(CELL_PAD), rect.center().y),
+        egui::Align2::RIGHT_CENTER,
+        text,
+        egui::FontId::monospace(NUM_FONT),
+        colors.fg_muted,
+    );
+}
+
+/// Run `content` inside a body cell's padding box: 10px horizontal padding, 12px
+/// text, no wrapping, and right-to-left flow for numeric/temporal columns.
+fn cell_frame(ui: &mut egui::Ui, align_right: bool, content: impl FnOnce(&mut egui::Ui)) {
+    egui::Frame::NONE
+        .inner_margin(egui::Margin::symmetric(CELL_PAD, 0))
+        .show(ui, |ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
+            ui.style_mut()
+                .text_styles
+                .insert(egui::TextStyle::Body, egui::FontId::proportional(CELL_FONT));
+            let layout = if align_right {
+                egui::Layout::right_to_left(egui::Align::Center)
+            } else {
+                egui::Layout::left_to_right(egui::Align::Center)
+            };
+            ui.with_layout(layout, content);
+        });
+}
+
+/// Lay out one line of text, ellipsised if it would exceed `max_w` (headers
+/// never wrap — design `white-space:nowrap`).
+fn layout_line(
+    painter: &egui::Painter,
+    text: &str,
+    font_id: egui::FontId,
+    color: Color32,
+    max_w: f32,
+) -> std::sync::Arc<egui::Galley> {
+    let mut job = egui::text::LayoutJob::single_section(
+        text.to_owned(),
+        egui::TextFormat {
+            font_id,
+            color,
+            ..Default::default()
+        },
+    );
+    job.wrap = egui::text::TextWrapping {
+        max_width: max_w,
+        max_rows: 1,
+        break_anywhere: true,
+        overflow_character: Some('…'),
+    };
+    painter.layout_job(job)
 }

--- a/thoth-plugin-sdk/src/components/table_view/ui.rs
+++ b/thoth-plugin-sdk/src/components/table_view/ui.rs
@@ -190,12 +190,18 @@ impl TableView {
     /// the viewport (virtual scrolling), so huge datasets stay cheap. Returns
     /// the row clicked this frame, if any.
     ///
+    /// `framed` matches [`TableView::framed`]: pass `true` for a standalone grid,
+    /// `false` when the grid sits in a container that already owns the fill, edge
+    /// and corners.
+    ///
     /// [`RenderNode`]: crate::render_node::RenderNode
+    #[allow(clippy::too_many_arguments)]
     pub fn show_rows(
         ui: &mut egui::Ui,
         headers: &[String],
         row_count: usize,
         min_col_width: Option<f32>,
+        framed: bool,
         events: &mut Vec<UiEvent>,
         mut build_row: impl FnMut(usize) -> Vec<crate::render_node::RenderNode>,
     ) -> Option<usize> {
@@ -207,7 +213,7 @@ impl TableView {
 
         let mut clicked_row: Option<usize> = None;
 
-        container(ui, true, &colors, |ui| {
+        container(ui, framed, &colors, |ui| {
             ui.set_min_width(ui.available_width());
 
             egui::ScrollArea::horizontal()

--- a/thoth-plugin-sdk/src/components/tabs/mod.rs
+++ b/thoth-plugin-sdk/src/components/tabs/mod.rs
@@ -68,7 +68,9 @@ pub struct Tabs {
     #[serde(default)]
     pub children: Vec<RenderNode>,
     /// Gap (px) between the tab strip and the panel content below it. Defaults
-    /// to 10; set to 0 for a panel that sits flush under the tabs.
+    /// to 0 — the design's strip rounds only its top corners and the panel only
+    /// its bottom ones, so the two read as one shape; set a gap to float the
+    /// panel away from the strip.
     #[serde(default, rename = "content-gap")]
     pub content_gap: Option<f32>,
 }

--- a/thoth-plugin-sdk/src/components/tabs/ui.rs
+++ b/thoth-plugin-sdk/src/components/tabs/ui.rs
@@ -1,12 +1,80 @@
-use egui::{Align, Layout};
+use egui::{Align, Color32, Layout, TextFormat, text::LayoutJob};
 
 use crate::components::IconButton;
 use crate::render_node::UiEvent;
-use crate::theme::ThemeColors;
+use crate::theme::{
+    FONT_CONTROL, ICON_CONTROL, RADIUS_CHIP, ThemeColors, phosphor_font_id, with_alpha,
+};
 
 use super::Tabs;
 
+/// Gap between a tab's leading icon and its label — design `.tabs .tab{gap:7px}`.
+const ICON_GAP: f32 = 7.0;
+/// Horizontal padding inside a tab — design `.tabs .tab{padding:0 12px}`.
+const PADDING_X: f32 = 12.0;
+/// Gap between tabs — design `.rtabs{gap:2px}`.
+const TAB_GAP: f32 = 2.0;
+/// Gap between the right-aligned trailing actions — design `.tabs .tacts{gap:1px}`.
+const ACTION_GAP: f32 = 1.0;
+/// The active tab's underline — design `.rtab.active::after`
+/// (`left:8px;right:8px;bottom:0;height:2px;border-radius:2px`). It *is* the whole
+/// active treatment: there is no pill or filled background behind an active tab.
+const UNDERLINE_H: f32 = 2.0;
+/// …inset from each side of the tab.
+const UNDERLINE_INSET: f32 = 8.0;
+/// …and its own (tiny) corner radius, below the shared ladder.
+const UNDERLINE_RADIUS: f32 = 2.0;
+/// Hairline rule along the strip's bottom edge — design
+/// `.rtabs{box-shadow:inset 0 -1px 0 surface1@26%}`.
+const STRIP_RULE_ALPHA: u8 = 66; // 26% of 255
+/// Translucent hover wash behind an icon-only tab. The design sheet has no
+/// icon-only tab, so this keeps the established soft-surface hover.
+const ICON_HOVER_ALPHA: u8 = 40;
+
 impl Tabs {
+    /// Lay out one tab's icon + label. The *label* colour is left as
+    /// [`Color32::PLACEHOLDER`] so the resolved state colour can be applied at
+    /// paint time, once hover is known; the icon carries its own colour because
+    /// the active tab tints only the glyph (design `.rtab.active i{color:mauve}`
+    /// while `.rtab.active` keeps the label at `--text`).
+    fn tab_job(
+        icon: Option<&str>,
+        label: &str,
+        label_font: egui::FontId,
+        icon_px: f32,
+        icon_color: Color32,
+    ) -> LayoutJob {
+        let mut job = LayoutJob::default();
+        let mut gap = 0.0;
+        if let Some(glyph) = icon {
+            job.append(
+                glyph,
+                0.0,
+                TextFormat {
+                    font_id: phosphor_font_id(icon_px),
+                    color: icon_color,
+                    valign: Align::Center,
+                    ..Default::default()
+                },
+            );
+            gap = ICON_GAP;
+        }
+        job.append(
+            label,
+            gap,
+            TextFormat {
+                // Design `.rtab{font-weight:500}` — a real medium face rather than
+                // a double-drawn regular one. Resolved by the caller, which has the
+                // context needed to fall back when no Medium family is registered.
+                font_id: label_font,
+                color: Color32::PLACEHOLDER,
+                valign: Align::Center,
+                ..Default::default()
+            },
+        );
+        job
+    }
+
     /// Render the tab header (with optional per-tab icons and right-aligned
     /// actions) and the selected panel.
     ///
@@ -14,8 +82,7 @@ impl Tabs {
     /// label) when the active tab changes, and a `"click"` event for each action
     /// (id = the action id). The selected index is kept in egui memory.
     pub fn show(&mut self, ui: &mut egui::Ui, events: &mut Vec<UiEvent>) {
-        use crate::components::{Button, ButtonColor, ButtonType, Size};
-        use crate::theme::phosphor_font_id;
+        use crate::components::Size;
 
         let colors = ThemeColors::from_ctx(ui.ctx());
         // Derived from the `ui` (not a global `Id::new`) so two tab bars sharing
@@ -25,17 +92,22 @@ impl Tabs {
         let prev: usize = ui.ctx().data(|d| d.get_temp(state_id).unwrap_or(0));
         let mut selected = prev.min(self.headers.len().saturating_sub(1));
 
-        // Size metrics: (strip height, text-button size, icon-only glyph px,
-        // icon-only cell). Small matches the compact button/select sizing.
-        let (strip_h, btn_size, icon_px, icon_cell) = match self.size {
-            Size::Small => (30.0, Size::Small, 15.0, egui::vec2(28.0, 24.0)),
-            Size::Medium => (40.0, Size::Medium, 18.0, egui::vec2(34.0, 30.0)),
-            Size::Large => (48.0, Size::Large, 20.0, egui::vec2(40.0, 36.0)),
+        // Size metrics: (strip height, label px, icon glyph px, icon-only cell).
+        // Medium is the design sheet's `.tabs` (40px strip, 12.5px label, 15px
+        // icon); Small is the compact strip the handoff tightens to 30px.
+        let (strip_h, font_size, icon_px, icon_cell) = match self.size {
+            Size::Small => (30.0, 11.5, ICON_CONTROL, egui::vec2(28.0, 24.0)),
+            Size::Medium => (40.0, FONT_CONTROL, ICON_CONTROL, egui::vec2(34.0, 30.0)),
+            Size::Large => (48.0, 14.0, 17.0, egui::vec2(40.0, 36.0)),
         };
 
-        let content_gap = self.content_gap.unwrap_or(10.0).round() as i8;
+        let content_gap = self.content_gap.unwrap_or(0.0).round() as i8;
+        // The strip carries no fill and no rounding of its own — it sits directly
+        // on the enclosing panel, separated from the content by a hairline rule
+        // (design `.rtabs{box-shadow:inset 0 -1px 0 surface1@26%}` in
+        // app-mockup.html, which is the in-app Tabs surface). Filling and rounding
+        // it here would inset the tab content from its container.
         egui::Frame::new()
-            .fill(colors.bg_panel)
             .outer_margin(egui::Margin {
                 left: 0,
                 right: 0,
@@ -52,9 +124,17 @@ impl Tabs {
                 ui.set_width(ui.available_width());
                 ui.set_height(strip_h);
                 let frame_bottom = ui.max_rect().max.y;
+                // Hairline rule along the strip's bottom edge, full-bleed under
+                // the 8px side padding.
+                let full = ui.max_rect().expand2(egui::vec2(8.0, 0.0));
+                ui.painter().hline(
+                    full.x_range(),
+                    frame_bottom - 0.5,
+                    egui::Stroke::new(1.0, with_alpha(colors.surface_raised, STRIP_RULE_ALPHA)),
+                );
 
                 ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
-                    ui.spacing_mut().item_spacing.x = 3.0;
+                    ui.spacing_mut().item_spacing.x = TAB_GAP;
 
                     for (i, header) in self.headers.iter().enumerate() {
                         let is_active = i == selected;
@@ -62,26 +142,27 @@ impl Tabs {
 
                         // Icon-only (label as tooltip) when `icon_only` is set or
                         // the header is empty — a frameless cell with a glyph.
-                        // Otherwise a text button, with the icon as a leading glyph.
+                        // Otherwise a full-height icon + label tab.
                         let resp = if let Some(glyph) =
                             icon.filter(|_| self.icon_only || header.is_empty())
                         {
                             let (rect, resp) =
                                 ui.allocate_exact_size(icon_cell, egui::Sense::click());
                             if resp.hovered() {
-                                let hover_bg = egui::Color32::from_rgba_premultiplied(
-                                    colors.surface_raised.r(),
-                                    colors.surface_raised.g(),
-                                    colors.surface_raised.b(),
-                                    40,
+                                ui.painter().rect_filled(
+                                    rect,
+                                    RADIUS_CHIP,
+                                    with_alpha(colors.surface_raised, ICON_HOVER_ALPHA),
                                 );
-                                ui.painter().rect_filled(rect, 4.0, hover_bg);
                                 ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
                             }
-                            let icon_color = if is_active || resp.hovered() {
+                            // Mauve when active, matching the labelled tab's glyph.
+                            let icon_color = if is_active {
                                 colors.accent
+                            } else if resp.hovered() {
+                                colors.fg
                             } else {
-                                ui.style().visuals.text_color()
+                                colors.fg_muted
                             };
                             if ui.is_rect_visible(rect) {
                                 ui.painter().text(
@@ -103,37 +184,73 @@ impl Tabs {
                             }
                             resp
                         } else {
-                            let resp = ui.add(
-                                Button::builder()
-                                    .label(header.as_str())
-                                    .maybe_icon(icon.cloned())
-                                    .button_type(ButtonType::Text)
-                                    .color(if is_active {
-                                        ButtonColor::Primary
-                                    } else {
-                                        ButtonColor::Default
-                                    })
-                                    .button_size(btn_size)
-                                    .build(),
+                            // Design `.rtab`: bare text (no pill, no fill),
+                            // `fg-muted` at rest, `fg` on hover *and* when active —
+                            // the active tab is distinguished by its mauve icon and
+                            // underline, not by a different label colour. The tab
+                            // fills the strip's full height so the underline lands
+                            // on the strip's bottom edge.
+                            //
+                            // Hover has to be resolved before layout because the
+                            // icon's colour is baked into the job, so this measures
+                            // the same rect the response will occupy.
+                            let label_font = crate::theme::medium_font_id(ui.ctx(), font_size);
+                            let probe = ui.painter().layout_job(Self::tab_job(
+                                icon.map(String::as_str),
+                                header,
+                                label_font.clone(),
+                                icon_px,
+                                Color32::PLACEHOLDER,
+                            ));
+                            let (rect, resp) = ui.allocate_exact_size(
+                                egui::vec2(probe.size().x + PADDING_X * 2.0, strip_h),
+                                egui::Sense::click(),
                             );
+                            let color = if is_active || resp.hovered() {
+                                colors.fg
+                            } else {
+                                colors.fg_muted
+                            };
+                            let galley = ui.painter().layout_job(Self::tab_job(
+                                icon.map(String::as_str),
+                                header,
+                                label_font,
+                                icon_px,
+                                if is_active { colors.accent } else { color },
+                            ));
+                            if resp.hovered() {
+                                ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                            }
+                            if ui.is_rect_visible(rect) {
+                                let pos = rect.center() - galley.rect.center().to_vec2();
+                                // Real weight 500 — the label is laid out in the
+                                // medium family, so no double-draw is needed.
+                                ui.painter().galley(pos, galley, color);
+                            }
                             if resp.clicked() && !is_active {
                                 selected = i;
                             }
                             resp
                         };
 
-                        // Active underline pinned to the frame bottom.
+                        // Active underline, pinned to the strip's bottom edge and
+                        // inset from both sides of the tab.
                         if is_active {
                             let bar = egui::Rect::from_min_max(
-                                egui::pos2(resp.rect.left(), frame_bottom - 2.0),
-                                egui::pos2(resp.rect.right(), frame_bottom),
+                                egui::pos2(
+                                    resp.rect.left() + UNDERLINE_INSET,
+                                    frame_bottom - UNDERLINE_H,
+                                ),
+                                egui::pos2(resp.rect.right() - UNDERLINE_INSET, frame_bottom),
                             );
-                            ui.painter().rect_filled(bar, 0.0, colors.accent);
+                            ui.painter()
+                                .rect_filled(bar, UNDERLINE_RADIUS, colors.accent);
                         }
                     }
 
                     if !self.actions.is_empty() {
                         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                            ui.spacing_mut().item_spacing.x = ACTION_GAP;
                             for action in self.actions.iter().rev() {
                                 let hit = ui
                                     .add(
@@ -167,6 +284,12 @@ impl Tabs {
         }
         ui.ctx().data_mut(|d| d.insert_temp(state_id, selected));
 
+        // The selected child is rendered flush: no frame, no padding, no rounding.
+        // In the app the tab strip sits *inside* an already-floating panel (the
+        // seshat results pane, a dock leaf), and that panel owns the fill, edge and
+        // corners — see `.rtabs` in app-mockup.html, where the content below the
+        // strip runs edge to edge. Wrapping it here would inset every tab body,
+        // which reads as an unwanted margin around content like `DataView`.
         if let Some(child) = self.children.get_mut(selected) {
             child.show(ui, events);
         }

--- a/thoth-plugin-sdk/src/components/toggle_switch/mod.rs
+++ b/thoth-plugin-sdk/src/components/toggle_switch/mod.rs
@@ -27,6 +27,10 @@ pub struct ToggleSwitch {
     #[builder(default)]
     #[serde(default)]
     pub enabled: bool,
+    /// Disable interaction — the switch still shows its state, dimmed.
+    #[builder(default)]
+    #[serde(default)]
+    pub disabled: bool,
     /// Optional tooltip shown on hover.
     #[serde(default)]
     pub hover_text: Option<String>,

--- a/thoth-plugin-sdk/src/components/toggle_switch/ui.rs
+++ b/thoth-plugin-sdk/src/components/toggle_switch/ui.rs
@@ -1,8 +1,18 @@
-use egui::{Color32, CornerRadius, Response, Sense, Vec2, Widget};
+use egui::{Color32, CornerRadius, Rect, Response, Sense, Vec2, Widget};
 
-use crate::theme::ThemeColors;
+use crate::theme::{RADIUS_PILL, ThemeColors, thumb_shadow};
 
 use super::ToggleSwitch;
+
+/// Track size — design `.switch { width:32px; height:19px }`.
+const TRACK_SIZE: Vec2 = Vec2::new(32.0, 19.0);
+/// Thumb diameter — design `.switch::after { width:13px; height:13px }`.
+const THUMB_DIAMETER: f32 = 13.0;
+/// Thumb inset from the track edge, on all four sides — design
+/// `.switch::after { top:3px; left:3px }` / `.switch.on::after { left:16px }`.
+const THUMB_INSET: f32 = 3.0;
+/// Opacity of a disabled switch — design `.switch.dis { opacity:.4 }`.
+const DISABLED_OPACITY: f32 = 0.4;
 
 #[inline]
 fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
@@ -22,23 +32,49 @@ fn lerp_color(a: Color32, b: Color32, t: f32) -> Color32 {
 impl Widget for ToggleSwitch {
     fn ui(self, ui: &mut egui::Ui) -> Response {
         let colors = ThemeColors::from_ctx(ui.ctx());
+        let interactive = !self.disabled && ui.is_enabled();
 
-        let (rect, mut response) = ui.allocate_exact_size(Vec2::new(36.0, 20.0), Sense::click());
+        let (rect, mut response) = ui.allocate_exact_size(
+            TRACK_SIZE,
+            if interactive {
+                Sense::click()
+            } else {
+                Sense::hover()
+            },
+        );
 
         if ui.is_rect_visible(rect) {
             let animation_id = egui::Id::new("toggle_switch_animation").with(response.id);
             let t = ui.ctx().animate_bool(animation_id, self.enabled);
 
-            let bg = lerp_color(colors.surface_active, colors.accent, t);
-            ui.painter().rect_filled(rect, CornerRadius::same(10), bg);
+            // Disabled switches fade through a *cloned* painter so the opacity
+            // never leaks into the widgets painted after this one.
+            let mut painter = ui.painter().clone();
+            if !interactive {
+                painter.multiply_opacity(DISABLED_OPACITY);
+            }
 
-            let knob_x = egui::lerp((rect.left() + 10.0)..=(rect.right() - 10.0), t);
-            let knob = lerp_color(colors.fg, colors.bg, t);
-            ui.painter()
-                .circle_filled(egui::pos2(knob_x, rect.center().y), 8.0, knob);
+            // `RADIUS_PILL` saturates to `u8::MAX`; the tessellator clamps the
+            // corner radius to half the height, which is the full pill we want.
+            let track_radius = CornerRadius::same(RADIUS_PILL as u8);
+            let track = lerp_color(colors.surface_raised, colors.accent, t);
+            painter.rect_filled(rect, track_radius, track);
+
+            // The thumb slides between a 3px inset on the leading and trailing
+            // side, so its travel is the track width minus both insets and itself.
+            let travel = TRACK_SIZE.x - THUMB_DIAMETER - 2.0 * THUMB_INSET;
+            let thumb_rect = Rect::from_min_size(
+                rect.min + Vec2::splat(THUMB_INSET) + Vec2::new(travel * t, 0.0),
+                Vec2::splat(THUMB_DIAMETER),
+            );
+            painter.add(thumb_shadow().as_shape(thumb_rect, CornerRadius::same(RADIUS_PILL as u8)));
+            let thumb = lerp_color(colors.fg, colors.bg_sunken, t);
+            painter.circle_filled(thumb_rect.center(), THUMB_DIAMETER / 2.0, thumb);
         }
 
-        response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
+        if interactive {
+            response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
+        }
         if let Some(hover_text) = self.hover_text {
             response = crate::theme::hover_text(response, hover_text);
         }

--- a/thoth-plugin-sdk/src/render_node/mod.rs
+++ b/thoth-plugin-sdk/src/render_node/mod.rs
@@ -212,11 +212,17 @@ impl RenderNode {
 
     /// Renders a result cell styled by the column's [`ColumnType`] (rather than
     /// by the JSON shape of the value, as [`json_cell`](RenderNode::json_cell)
-    /// does). Every cell is monospace: numbers/temporal/text use
-    /// `mono(text, ty.text_color())`, an enum becomes a soft coloured pill, a
-    /// json object/array becomes a tree (json-as-text is info-tinted), and null
-    /// is muted italic. `Text` and unknown types fall through to the default
-    /// mono styling — they do **not** defer to `json_cell`.
+    /// does):
+    ///
+    /// - `Text` and `Boolean` are prose, in the body face — monospacing ordinary
+    ///   text columns made them read like code.
+    /// - Numeric, temporal and UUID cells, and any unknown type, are monospace in
+    ///   `ty.text_color()`, so digits line up down the column.
+    /// - An enum becomes a soft coloured pill; a json object/array becomes a tree
+    ///   (json-as-text is info-tinted); null is muted italic.
+    ///
+    /// Unknown types fall through to the mono styling — they do **not** defer to
+    /// `json_cell`.
     pub fn typed_cell(value: &serde_json::Value, ty: crate::components::ColumnType) -> Self {
         use crate::components::{Badge, ColumnType, TypographyVariant};
         use serde_json::Value;

--- a/thoth-plugin-sdk/src/render_node/mod.rs
+++ b/thoth-plugin-sdk/src/render_node/mod.rs
@@ -221,12 +221,25 @@ impl RenderNode {
         use crate::components::{Badge, ColumnType, TypographyVariant};
         use serde_json::Value;
 
-        // Every result cell is monospace, matching the design handoff's grid.
+        // Monospace for the cells whose glyphs need to line up column-wise —
+        // numbers, timestamps, UUIDs, raw JSON.
         let mono = |text: String, color: &str| {
             RenderNode::Text(
                 Typography::builder()
                     .text(text)
                     .variant(TypographyVariant::Mono)
+                    .color(color)
+                    .build(),
+            )
+        };
+        // Prose cells stay proportional: the design's table has numeric cells in
+        // mono (`.tv td.r`) but string cells in the body face (`.tv td.str`).
+        // Monospacing everything made ordinary text columns read like code.
+        let prose = |text: String, color: &str| {
+            RenderNode::Text(
+                Typography::builder()
+                    .text(text)
+                    .variant(TypographyVariant::Body)
                     .color(color)
                     .build(),
             )
@@ -262,7 +275,9 @@ impl RenderNode {
                 }
                 _ => mono(text, "info"),
             },
-            // Numbers → number colour, temporal → string colour, else default fg.
+            // Text and booleans are prose; numbers, temporal values and UUIDs are
+            // mono so digits align down the column.
+            ColumnType::Text | ColumnType::Boolean => prose(text, ty.text_color()),
             _ => mono(text, ty.text_color()),
         }
     }

--- a/thoth-plugin-sdk/src/render_node/render.rs
+++ b/thoth-plugin-sdk/src/render_node/render.rs
@@ -52,7 +52,7 @@ impl RenderNode {
                 ui.add(t.clone());
             }
             RenderNode::Separator(s) => {
-                ui.add(*s);
+                ui.add(s.clone());
             }
             RenderNode::Badge(b) => {
                 ui.add(b.clone());

--- a/thoth-plugin-sdk/src/theme/mod.rs
+++ b/thoth-plugin-sdk/src/theme/mod.rs
@@ -13,6 +13,143 @@ pub use crate::tokens::TextToken;
 /// Standard height of a tree/data row, in points.
 pub const ROW_HEIGHT: f32 = 22.0;
 
+// ── Design tokens: the radius ladder ──────────────────────────────────────────
+//
+// These are the **egui radii** pinned by the design system's implementation
+// handoff (§1–2), not the raw CSS numbers. The design intent is a superellipse
+// (`corner-shape: squircle`) at a larger radius; egui only draws circular arc
+// corners, so the handoff specifies this smaller rounded-rect approximation
+// instead. Do not "correct" these upward against the CSS `--radius-sq-*-cs`
+// values — the gap is deliberate and accounts for the superellipse bump.
+
+/// Window chrome. CSS intent `--radius-sq-window` (18/26).
+pub const RADIUS_WINDOW: f32 = 12.0;
+/// Panels, cards, dialogs. CSS intent `--radius-sq-panel` (16/20).
+pub const RADIUS_PANEL: f32 = 10.0;
+/// Popovers and menus. The handoff folds these in with panels, so this is an
+/// alias for [`RADIUS_PANEL`] that documents the intent at the call site.
+pub const RADIUS_POPOVER: f32 = RADIUS_PANEL;
+/// Buttons, inputs, selects, icon buttons, tab pills.
+/// CSS intent `--radius-sq-control` (10/11).
+pub const RADIUS_CONTROL: f32 = 7.0;
+/// Chips, soft badges, menu items, list rows, tree hover.
+/// CSS intent `--radius-sq-chip` (8/10).
+pub const RADIUS_CHIP: f32 = 6.0;
+/// Checkboxes — below the ladder's smallest rung; design `.cb` is 5px.
+pub const RADIUS_CHECK: f32 = 5.0;
+/// Fully-round pills: toggle tracks, slider tracks — design `border-radius:999px`.
+pub const RADIUS_PILL: f32 = 999.0;
+
+/// Gap between floating panels — the crust background shows through here.
+pub const GUTTER_GAP: f32 = 8.0;
+
+// ── Design tokens: control metrics ────────────────────────────────────────────
+
+/// Height of text-bearing input controls — design `.field` / `.trigger` / `.num`.
+pub const FIELD_HEIGHT: f32 = 28.0;
+/// Body font size — design `body{font-size:13px}`.
+pub const FONT_BODY: f32 = 13.0;
+/// Font size inside controls — design `.btn` / `.field input` / `.opt` (12.5px).
+pub const FONT_CONTROL: f32 = 12.5;
+/// Font size for captions and helper text — design `.lbl` / `.err-msg` (11px).
+pub const FONT_CAPTION: f32 = 11.0;
+/// Icon glyph size inside a control — design `.field i` / `.ib i` (15px).
+pub const ICON_CONTROL: f32 = 15.0;
+
+// ── Design tokens: chrome ─────────────────────────────────────────────────────
+
+/// Hairline inset edge on controls and panels — design
+/// `--edge: inset 0 0 0 1px surface1@34%`.
+pub fn edge_stroke(colors: &ThemeColors) -> egui::Stroke {
+    egui::Stroke::new(1.0, with_alpha(colors.surface_raised, 87)) // 34% of 255
+}
+
+/// Keyboard/active focus ring — design `--focus: 0 0 0 2px lavender@90%`.
+pub fn focus_stroke(colors: &ThemeColors) -> egui::Stroke {
+    egui::Stroke::new(2.0, with_alpha(colors.accent_secondary, 230)) // 90%
+}
+
+/// Soft drop shadow for floating panels — design `--shadow-panel`. The CSS token
+/// layers `0 1px 2px black@42%` under `0 6px 18px black@28%`; egui shadows are
+/// single-layer, so the handoff collapses it to the outer layer.
+/// Light themes get a much weaker shadow — heavy shadows smear on pale surfaces.
+pub fn panel_shadow(dark_mode: bool) -> egui::Shadow {
+    egui::Shadow {
+        offset: [0, 2],
+        blur: 18,
+        spread: 0,
+        color: Color32::from_black_alpha(if dark_mode { 71 } else { 23 }), // 28% / 9%
+    }
+}
+
+/// Shadow under a popover, dropdown, or menu — design `--shadow-menu:
+/// 0 4px 12px black@32%`. Deliberately lighter than [`dialog_shadow`]: a select
+/// menu is not a modal and should not read as one.
+pub fn popover_shadow(dark_mode: bool) -> egui::Shadow {
+    egui::Shadow {
+        offset: [0, 4],
+        blur: 12,
+        spread: 0,
+        color: Color32::from_black_alpha(if dark_mode { 82 } else { 28 }), // 32% / 11%
+    }
+}
+
+/// Shadow under a dialog or modal — design `--shadow-dialog` (`0 12px 40px
+/// black@55%`, collapsed to one layer per the handoff).
+pub fn dialog_shadow(dark_mode: bool) -> egui::Shadow {
+    egui::Shadow {
+        offset: [0, 8],
+        blur: 40,
+        spread: 0,
+        color: Color32::from_black_alpha(if dark_mode { 140 } else { 41 }), // 55% / 16%
+    }
+}
+
+/// Coloured glow under a solid accent control — design
+/// `.btn.primary { box-shadow: 0 3px 10px lavender@38% }`.
+pub fn glow_shadow(tint: Color32) -> egui::Shadow {
+    egui::Shadow {
+        offset: [0, 3],
+        blur: 10,
+        spread: 0,
+        color: with_alpha(tint, 97), // 38%
+    }
+}
+
+/// Tight shadow lifting a small element off its track — design toggle thumb and
+/// selected segment (`0 1px 2px black@40%`).
+pub fn thumb_shadow() -> egui::Shadow {
+    egui::Shadow {
+        offset: [0, 1],
+        blur: 2,
+        spread: 0,
+        color: Color32::from_black_alpha(102), // 40%
+    }
+}
+
+/// Shadow under a slider thumb — design `0 2px 6px black@45%`. Slightly deeper
+/// and softer than [`thumb_shadow`]: the slider thumb is larger and floats over
+/// its own track rather than sitting in a recess.
+pub fn slider_thumb_shadow() -> egui::Shadow {
+    egui::Shadow {
+        offset: [0, 2],
+        blur: 6,
+        spread: 0,
+        color: Color32::from_black_alpha(115), // 45%
+    }
+}
+
+/// The same colour at a different alpha. Keeps callers off `Color32` literals.
+pub fn with_alpha(c: Color32, alpha: u8) -> Color32 {
+    Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), alpha)
+}
+
+/// Midpoint of two opaque colours, per channel.
+fn mix(a: Color32, b: Color32) -> Color32 {
+    let m = |x: u8, y: u8| ((x as u16 + y as u16) / 2) as u8;
+    Color32::from_rgb(m(a.r(), b.r()), m(a.g(), b.g()), m(a.b(), b.b()))
+}
+
 /// egui memory key under which the host publishes the active [`ThemeColors`].
 ///
 /// The host writes the parsed palette here once per frame (via its
@@ -93,6 +230,25 @@ pub struct ThemeColors {
 }
 
 impl ThemeColors {
+    /// Secondary foreground, one step brighter than [`Self::fg_muted`] — design
+    /// `--subtext0`. Used for resting icon-button glyphs and numeric readouts.
+    ///
+    /// Derived rather than stored: in Catppuccin `subtext0` is *exactly* the
+    /// midpoint of `overlay1` (`fg_muted`) and `text` (`fg`), so deriving it keeps
+    /// all twelve theme presets in step without widening the palette schema.
+    pub fn fg_subtle(&self) -> Color32 {
+        mix(self.fg_muted, self.fg)
+    }
+
+    /// Tertiary foreground, one step dimmer than [`Self::fg_muted`] — design
+    /// `--overlay0`. Used for captions, unit suffixes, and file annotations.
+    ///
+    /// Derived as the midpoint of `surface_active` and `fg_muted`, which
+    /// reproduces Catppuccin's `overlay0` to within one 8-bit step.
+    pub fn fg_faint(&self) -> Color32 {
+        mix(self.surface_active, self.fg_muted)
+    }
+
     /// Read the host-injected palette from egui memory.
     ///
     /// Falls back to [`ThemeColors::default`] (a transparent/zeroed palette)
@@ -141,12 +297,15 @@ impl ThemeColors {
             bg: hex(self.bg),
             cursor: fg_hex,
             selection: hex(self.surface_raised),
+            // Design `.code` token mapping: comments muted italic (italic isn't
+            // reachable through `ColorTheme`), keywords carry `--syn-key`,
+            // function names are lavender, punctuation is muted.
             comments: hex(self.fg_muted),
-            functions: hex(self.syntax_key),
-            keywords: hex(self.accent),
+            functions: hex(self.accent_secondary),
+            keywords: hex(self.syntax_key),
             literals: string_hex,
             numerics: hex(self.syntax_number),
-            punctuation: fg_hex,
+            punctuation: hex(self.fg_muted),
             strs: string_hex,
             types: hex(self.info),
             special: hex(self.error),
@@ -212,6 +371,11 @@ pub fn resolve_color(token: &str, colors: &ThemeColors) -> Option<Color32> {
     Some(match token {
         "fg" => colors.fg,
         "muted" | "fg-muted" | "gray" => colors.fg_muted,
+        // The two derived foreground steps (design `--subtext0` / `--overlay0`).
+        // Without these a plugin can't reach them at all and has to settle for
+        // `fg` or `fg-muted`, losing a tier of the type hierarchy.
+        "subtle" | "fg-subtle" => colors.fg_subtle(),
+        "faint" | "fg-faint" => colors.fg_faint(),
         "accent" | "blue" => colors.accent,
         "secondary" | "purple" => colors.accent_secondary,
         "success" | "green" => colors.success,
@@ -321,6 +485,47 @@ pub fn color_to_hex(c: Color32) -> String {
 /// icon-font crate directly.
 pub fn phosphor_font_id(size: f32) -> egui::FontId {
     egui::FontId::new(size, egui::FontFamily::Name("phosphor".into()))
+}
+
+/// Named family carrying the UI face at weight 500 — design `font-weight:500`.
+pub const FAMILY_MEDIUM: &str = "ui-medium";
+/// Named family carrying the UI face at weight 600 — design `font-weight:600`.
+pub const FAMILY_SEMIBOLD: &str = "ui-semibold";
+
+/// A [`FontId`](egui::FontId) for the named weight family, falling back to the
+/// normal proportional face when that family isn't registered.
+///
+/// The fallback is not optional: epaint **panics** ("`FontFamily::Name(..) is not
+/// bound to any fonts`") the moment a `FontId` names a family the active
+/// `FontDefinitions` doesn't define. A widget must not depend on the host having
+/// called its font setup first — a bare `egui::Context` (a unit test, a plugin
+/// rendering before the theme is applied) has only egui's built-in families.
+fn weighted_font_id(ctx: &egui::Context, size: f32, family: &'static str) -> egui::FontId {
+    let named = egui::FontFamily::Name(family.into());
+    if ctx.fonts(|f| f.families().contains(&named)) {
+        egui::FontId::new(size, named)
+    } else {
+        egui::FontId::proportional(size)
+    }
+}
+
+/// A [`FontId`](egui::FontId) for medium (500) UI text.
+///
+/// egui has no weight axis — a `FontId` names a family — so the host registers the
+/// real Medium face under [`FAMILY_MEDIUM`] and this addresses it. Prefer this to
+/// painting a galley twice a fraction of a pixel apart: that trick smears glyphs at
+/// small sizes and lands nearer 600 than 500.
+///
+/// Always safe to call: degrades to the regular proportional face when no Medium
+/// family is registered (see [`weighted_font_id`]).
+pub fn medium_font_id(ctx: &egui::Context, size: f32) -> egui::FontId {
+    weighted_font_id(ctx, size, FAMILY_MEDIUM)
+}
+
+/// A [`FontId`](egui::FontId) for semibold (600) UI text — see
+/// [`medium_font_id`] for why this is a family rather than a weight.
+pub fn semibold_font_id(ctx: &egui::Context, size: f32) -> egui::FontId {
+    weighted_font_id(ctx, size, FAMILY_SEMIBOLD)
 }
 
 #[cfg(test)]

--- a/thoth-plugin-sdk/src/theme/mod.rs
+++ b/thoth-plugin-sdk/src/theme/mod.rs
@@ -502,7 +502,25 @@ pub const FAMILY_SEMIBOLD: &str = "ui-semibold";
 /// rendering before the theme is applied) has only egui's built-in families.
 fn weighted_font_id(ctx: &egui::Context, size: f32, family: &'static str) -> egui::FontId {
     let named = egui::FontFamily::Name(family.into());
-    if ctx.fonts(|f| f.families().contains(&named)) {
+    // `Fonts::families` clones the whole family list behind the font lock, and
+    // this runs for every run of weighted text, so the answer is memoised.
+    //
+    // Invalidation is by pass number, and it has to be: `Context::set_fonts`
+    // applies the new definitions on the *next* pass and never clears
+    // `ctx.data`, so a cache that outlived the pass would keep resolving to the
+    // fallback face after the host installs its fonts. Within one pass the
+    // registered families cannot change, which makes a per-pass entry exact.
+    let cache_id = egui::Id::new(("thoth-weighted-family", family));
+    let pass = ctx.cumulative_pass_nr();
+    let registered = match ctx.data(|d| d.get_temp::<(u64, bool)>(cache_id)) {
+        Some((cached_pass, registered)) if cached_pass == pass => registered,
+        _ => {
+            let registered = ctx.fonts(|f| f.families().contains(&named));
+            ctx.data_mut(|d| d.insert_temp(cache_id, (pass, registered)));
+            registered
+        }
+    };
+    if registered {
         egui::FontId::new(size, named)
     } else {
         egui::FontId::proportional(size)


### PR DESCRIPTION
Implements the squircle redesign across every surface the design system specifies: the app shell, all 24 SDK components, the six overlays, both plugin UIs, and the app screens.

Follows the design system's implementation handoff (§1–6) and its eight reference sheets. Where two sheets disagree, `app-mockup.html` wins — it's the in-app context and its CSS is annotated *"matches real app"*.

## Reviewer notes — things that change appearance beyond this diff

- **`ButtonColor::Primary` moves mauve → lavender.** The design rule is "one mauve accent per view; lavender for primary buttons / active / focus", so mauve is now *state* (selection, toggles) and lavender is *action*. `Secondary` is documented as a legacy alias — it can't be removed because it's serialised in the plugin DSL.
- **`List` rows reshape.** Sidebar lists (recent files, bookmarks, search) are now `.card` rows — separate bordered cards with a gap — rather than flush divided rows, and row height is *derived* rather than pinned at 48px. Anything built on `List` will shift.
- **Two deliberately different tab vocabularies.** Document/dock tabs are filled pills (`.etabs .tab`); in-pane tabs are a 2px accent underline (`.rtabs .rtab`). Both are correct.
- **The consent and update dialogs no longer dismiss on Escape or backdrop click** — both ask a question that needs an answer.

## Breaking SDK changes

There's no `CHANGELOG.md` in the repo, so recording these here:

- **`ButtonColor::Primary` is lavender, not mauve** (see above). `Secondary` is now a documented legacy alias of `Primary` — it can't be removed because `ButtonColor` is serialised in the plugin DSL.
- **`Separator` no longer implements `Copy`** — the new `color: Option<String>` field prevents it. Callers needing an owned duplicate must `.clone()`.
- **`TableView::show_rows` gained a `framed` positional parameter.** Rust has no default arguments, so this is unavoidable; the sole in-repo caller passes `true` and renders unchanged.
- **An omitted `framed` in serialised `TableView`/`JsonTree` deserialises to `true`.** A plugin relying on the previous flush rendering must now pass `framed: false`.
- **`Tabs::content_gap` defaults to 0** (was 10), so the strip and content join into one shape.
- **`List` rows reshape** (see above), and row tags now render on a single line — a row with more tags than fit truncates rather than wrapping. It previously overlapped the row below.

## Bugs found and fixed along the way

These were pre-existing, not introduced here:

- `PersistentState::default()` performed **disk I/O**, so merely constructing one restored the developer's real saved session — which is why an integration test asserted against a file in `~/Downloads`. `Default` is now blank, `load_or_default()` is explicit, and `ThothApp::with_persistent_state` injects state for tests.
- The code editor was rendering a **line-number gutter** nobody asked for: `egui_code_editor` defaults `numlines` to true and the SDK never disabled it.
- Table headers were **never actually semibold** — `RichText::strong()` is a no-op once an explicit colour is set.
- `recent_files` / `bookmarks` / `search` each wrapped `List` in their own `ScrollArea` *inside* the sidebar's, defeating `List`'s virtualisation.
- `List`'s virtual-scroll estimated and actual row heights disagreed.
- `marketplace/detail` reserved a hard-coded 160px for its buttons and hand-painted its progress bar.
- A centred horizontal layout on a vertical `Ui` expands to the **full available height**. That single mistake caused the modal footer void, both theme-picker voids and a Chart Studio header quirk. `tests/welcome_layout_tests.rs` now pins against it.

## SDK API work

Four independent passes hit the same handful of components, so rather than leave the workarounds in place the API was extended and the hand-rolled code deleted: `Badge { icon, pill }`, `List { style }` + per-item title colour and meta tiers, `ListItemPostfix::Text`, `Separator { color, thickness }`, `IconButtonSelectedStyle::Wash` + badge props, `DataRow { chip }` + `DataRowIcon { size }`, `Modal { eyebrow, glyph, dismissible, footer }`, `Split { framed, resizable }`, `Column { padding }`, `Select { icon }`, `ButtonColor::Warning`.

All additive — nothing renamed or removed.

**Real font weights**: egui has no weight axis, so Medium/SemiBold are now registered from the OS via `fontdb` as named families. The helpers check `Fonts::families()` first, because epaint *panics* on an unbound family name — a bare `Context` (a unit test, a plugin rendering before the theme applies) has only egui's built-ins.

## Known divergences

All egui limits rather than oversights: `font-weight: 500` on *monospace* readouts still uses a double-draw (the new families are the proportional face); letter-spacing and line-height are unreachable; rounded clipping is impossible (clip rects are axis-aligned), so containers mask corner wedges back to their own fill; the active dock tab's leading glyph can't be tinted separately from its label.

## Verification

`cargo clippy --workspace --all-targets` clean · **535 tests pass** · both plugin wasm targets clean · no `Color32` literals in any touched component.

Visually confirmed in the running app.
