### PR TITLE
feat: add headless plugin CLI support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,10 +223,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -1069,6 +1113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1077,8 +1122,31 @@ version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1139,6 +1207,12 @@ checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -3523,6 +3597,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4451,6 +4531,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -6512,6 +6598,8 @@ version = "0.4.4"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
+ "clap_complete",
  "criterion",
  "dhat",
  "dirs",
@@ -7161,6 +7249,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6614,6 +6614,7 @@ dependencies = [
  "flate2",
  "fontdb",
  "futures-util",
+ "getrandom 0.3.4",
  "image",
  "keyring",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6123,6 +6123,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "fallible-iterator",
+ "percent-encoding",
  "postgres-protocol",
  "rand 0.8.5",
  "rsa",
@@ -6132,6 +6133,7 @@ dependencies = [
  "sha2 0.10.9",
  "sqlformat",
  "thoth-plugin-sdk",
+ "url",
  "wit-bindgen-rt",
 ]
 
@@ -6642,6 +6644,7 @@ dependencies = [
  "toml 0.8.2",
  "tracing",
  "tracing-subscriber",
+ "unicode-width",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ image = { version = "0.25", default-features = false, features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 getrandom = "0.3"
+unicode-width = "0.2"
 toml = "0.8"
 dirs = "5.0"
 fontdb = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ desktop_template = "assets/thoth.desktop"
 
 [dependencies]
 thoth-plugin-sdk = { path = "thoth-plugin-sdk", features = ["egui"] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "string"] }
 clap_complete = "4.5"
 eframe = "0.34"
 egui-phosphor = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ image = { version = "0.25", default-features = false, features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+getrandom = "0.3"
 toml = "0.8"
 dirs = "5.0"
 fontdb = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,8 @@ desktop_template = "assets/thoth.desktop"
 
 [dependencies]
 thoth-plugin-sdk = { path = "thoth-plugin-sdk", features = ["egui"] }
+clap = { version = "4.5", features = ["derive"] }
+clap_complete = "4.5"
 eframe = "0.34"
 egui-phosphor = "0.12"
 image = { version = "0.25", default-features = false, features = [

--- a/docs/COMPONENT_ARCHITECTURE.md
+++ b/docs/COMPONENT_ARCHITECTURE.md
@@ -9,16 +9,18 @@ Thoth uses a **trait-based component system** inspired by React's component mode
 Application state is split above the component layer:
 
 - `ThothCore` owns display-independent settings, persisted state, updater
-  state, deferred plugin/session work, and the core event queue. It provides
-  `init`, `dispatch_event`, and non-blocking `tick` methods and imports no egui
-  types.
+  state, the asynchronously initialized plugin manager, the dataset store,
+  deferred plugin/session work, and the core event queue. It provides `init`,
+  `dispatch_event`, and non-blocking `tick` methods and imports no egui types.
 - `ThothApp` owns `ThothCore` plus window-only state such as components,
   dialogs, native menus, clipboard integration, and screenshot geometry. GUI
   events are translated into core events; actions returned by `tick` are then
   applied to the active window.
 
 This boundary allows a headless runtime to construct and drive the application
-core without creating an eframe window.
+core without creating an eframe window. Legacy WIT and SDK callbacks reach the
+active plugin manager and dataset store through weak bridges; those bridges do
+not own either service or extend the lifetime of `ThothCore`.
 
 > **Two tiers of UI.** Since the SDK migration, Thoth's UI is split in two:
 >

--- a/docs/COMPONENT_ARCHITECTURE.md
+++ b/docs/COMPONENT_ARCHITECTURE.md
@@ -6,6 +6,20 @@ This document explains Thoth's component architecture and the one-way data bindi
 
 Thoth uses a **trait-based component system** inspired by React's component model, adapted to work with Rust's ownership system and egui's immediate mode GUI pattern.
 
+Application state is split above the component layer:
+
+- `ThothCore` owns display-independent settings, persisted state, updater
+  state, deferred plugin/session work, and the core event queue. It provides
+  `init`, `dispatch_event`, and non-blocking `tick` methods and imports no egui
+  types.
+- `ThothApp` owns `ThothCore` plus window-only state such as components,
+  dialogs, native menus, clipboard integration, and screenshot geometry. GUI
+  events are translated into core events; actions returned by `tick` are then
+  applied to the active window.
+
+This boundary allows a headless runtime to construct and drive the application
+core without creating an eframe window.
+
 > **Two tiers of UI.** Since the SDK migration, Thoth's UI is split in two:
 >
 > 1. **Reusable widgets** (Button, Input, Select, List, Card, DataRow, Tabs, …)

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -88,6 +88,19 @@ plugin can implement `PluginCore` and leave the default UI facet as `None`.
 This is a host-side separation; the language-neutral plugin boundary remains
 the WIT capability/world split described below.
 
+### Headless runtime
+
+`HeadlessRuntime` constructs `ThothCore`, starts plugin discovery, installs the
+core-owned dataset/plugin callback bridges, and executes `CliCommand` values
+without creating an egui context or native window. Its result separates a JSON
+stdout value, a stderr diagnostic, and the intended process exit code.
+
+Display-independent plugin adapters override `PluginCore::init` and
+`PluginCore::on_event`. Initialization runs once per live adapter; subsequent
+commands reuse that initialized instance. The CLI parser and plugin-declared
+subcommand surface are layered on top of this runtime by the later CLI/SDK
+work.
+
 ---
 
 ## Technology Choice: WebAssembly

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -8,6 +8,7 @@ This document describes Thoth's plugin architecture — how it works, how plugin
 
 - [Why a Plugin System](#why-a-plugin-system)
 - [Architecture Overview](#architecture-overview)
+- [Host Runtime Facets](#host-runtime-facets)
 - [Technology Choice: WebAssembly](#technology-choice-webassembly)
 - [Plugin Types](#plugin-types)
 - [Plugin Storage and Discovery](#plugin-storage-and-discovery)
@@ -70,6 +71,22 @@ Features like API/network support, database connectivity, and additional file fo
 The `PluginManager` is initialized once at app startup, scans all plugin directories, loads each `.wasm` file into its own sandboxed Wasmtime instance, and registers it against the capabilities it declares in `plugin.toml`.
 
 When a file is opened the host checks whether the matching plugin also implements `file-viewer`. If it does, a `WasmFileViewerLoader` is used and the viewer renders either a native table (when the plugin returns `preferred-display: table`) or a custom `RenderNode` tree (when it returns `custom`).
+
+## Host Runtime Facets
+
+The Rust host represents a live plugin instance through two object-safe traits:
+
+- `PluginCore` contains the headless runtime surface: identity, lifecycle and
+  settings, tab state, async transport queues, and dataset production. It has no
+  egui types or rendering methods.
+- `PluginUi: PluginCore` contains `render_ui`, `handle_event`, and
+  `render_sidebar`.
+
+Runtime owners store `Box<dyn PluginCore>`. A GUI path calls
+`PluginCore::as_ui` before using the rendering callbacks. A future CLI-only
+plugin can implement `PluginCore` and leave the default UI facet as `None`.
+This is a host-side separation; the language-neutral plugin boundary remains
+the WIT capability/world split described below.
 
 ---
 

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -83,8 +83,8 @@ The Rust host represents a live plugin instance through two object-safe traits:
   `render_sidebar`.
 
 Runtime owners store `Box<dyn PluginCore>`. A GUI path calls
-`PluginCore::as_ui` before using the rendering callbacks. A future CLI-only
-plugin can implement `PluginCore` and leave the default UI facet as `None`.
+`PluginCore::as_ui` before using the rendering callbacks. A CLI-only plugin can
+implement `PluginCore` and leave the default UI facet as `None`.
 This is a host-side separation; the language-neutral plugin boundary remains
 the WIT capability/world split described below.
 
@@ -97,9 +97,9 @@ stdout value, a stderr diagnostic, and the intended process exit code.
 
 Display-independent plugin adapters override `PluginCore::init` and
 `PluginCore::on_event`. Initialization runs once per live adapter; subsequent
-commands reuse that initialized instance. The CLI parser and plugin-declared
-subcommand surface are layered on top of this runtime by the later CLI/SDK
-work.
+commands reuse that initialized instance. The clap-based CLI parser and
+plugin-declared subcommands are available through the `PluginCli` SDK contract
+and the `plugin-cli` WIT export.
 
 ---
 
@@ -133,6 +133,7 @@ WASM wins on portability, safety, and distribution simplicity. A plugin author c
 | **Exporter** | `exporter` | Adds new export formats or destinations |
 | **Search Provider** | `search-provider` | Extends the search experience with custom indexing or remote results |
 | **Data Producer** | `data-producer` | Offers a dataset to the data bus (#113); appears as a source in a consumer's picker. Pairs with the `data-producer` export |
+| **CLI** | `cli` | Declares headless subcommands, arguments, help, and structured results routed by `thoth <plugin> <command>` |
 
 A single plugin can declare multiple capabilities. `file-viewer` always pairs with `file-loader` — use the `file-viewer-plugin` world for this combination. `data-source` always pairs with `ui-component` — use the `data-source-plugin` world.
 

--- a/plugins/card-view/src/bindings.rs
+++ b/plugins/card-view/src/bindings.rs
@@ -33,6 +33,8 @@ pub mod thoth {
                 /// data-renderer.render and appears as an extra view format in a
                 /// DataView (alongside table / json / raw).
                 Renderer,
+                /// Exposes commands through the optional plugin-cli interface.
+                Cli,
             }
             impl ::core::fmt::Debug for Capability {
                 fn fmt(
@@ -64,6 +66,7 @@ pub mod thoth {
                         Capability::Renderer => {
                             f.debug_tuple("Capability::Renderer").finish()
                         }
+                        Capability::Cli => f.debug_tuple("Capability::Cli").finish(),
                     }
                 }
             }
@@ -82,6 +85,7 @@ pub mod thoth {
                         5 => Capability::NewUiComponent,
                         6 => Capability::DataProducer,
                         7 => Capability::Renderer,
+                        8 => Capability::Cli,
                         _ => panic!("invalid enum discriminant"),
                     }
                 }
@@ -933,28 +937,28 @@ pub(crate) use __export_data_renderer_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 983] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xcc\x06\x01A\x02\x01\
-A\x0c\x01B\x0a\x01m\x08\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
-\x0fsearch-provider\x10new-ui-component\x0ddata-producer\x08renderer\x04\0\x0aca\
-pability\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescript\
-ions\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplug\
-in-info\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\x01\
-r\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugin/ty\
-pes@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01@\0\0s\x04\0\x04name\x01\x02\x01j\x01s\x01\x01\x01@\x01\x0c\
-records-jsons\0\x03\x04\0\x06render\x01\x04\x04\0\x20thoth:plugin/data-renderer@\
-0.1.0\x05\x02\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x03\x04\0\x0bp\
-lugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/\
-plugin-meta@0.1.0\x05\x04\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\
-\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0\
-#thoth:plugin/plugin-lifecycle@0.1.0\x05\x05\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-ou\
-tput\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\
-\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x06\x04\0'thoth:plugin/data-rende\
-rer-plugin@0.1.0\x04\0\x0b\x1a\x01\0\x14data-renderer-plugin\x03\0\0\0G\x09produ\
-cers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x06\
-0.41.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 987] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xd0\x06\x01A\x02\x01\
+A\x0c\x01B\x0a\x01m\x09\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
+\x0fsearch-provider\x10new-ui-component\x0ddata-producer\x08renderer\x03cli\x04\0\
+\x0acapability\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bde\
+scriptions\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0b\
+plugin-info\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\
+\x01r\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugi\
+n/types@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x07\x02\x03\x02\x01\x01\x04\
+\0\x0cplugin-error\x03\0\0\x01@\0\0s\x04\0\x04name\x01\x02\x01j\x01s\x01\x01\x01\
+@\x01\x0crecords-jsons\0\x03\x04\0\x06render\x01\x04\x04\0\x20thoth:plugin/data-\
+renderer@0.1.0\x05\x02\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x03\x04\
+\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:\
+plugin/plugin-meta@0.1.0\x05\x04\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on\
+-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\
+\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x05\x01B\x07\x02\x03\x02\x01\x01\
+\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fs\
+ettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-setti\
+ngs\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x06\x04\0'thoth:plugin\
+/data-renderer-plugin@0.1.0\x04\0\x0b\x1a\x01\0\x14data-renderer-plugin\x03\0\0\0\
+G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindge\
+n-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/card-view/src/bindings.rs
+++ b/plugins/card-view/src/bindings.rs
@@ -317,6 +317,155 @@ pub mod exports {
                 );
             }
             /// ---------------------------------------------------------------------------
+            /// Worlds — plugin authors implement one of these
+            ///
+            /// A world declares exactly which interfaces a plugin exports. Pick the
+            /// world that matches your plugin's capabilities. If you implement multiple
+            /// capabilities, implement the combined world or compose component binaries.
+            /// ---------------------------------------------------------------------------
+            /// ---------------------------------------------------------------------------
+            /// plugin-settings — implement on every plugin (trivial no-op is fine)
+            ///
+            /// Lets a plugin own its settings UI. The host calls render-settings() once
+            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
+            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
+            /// back via handle-setting-event(). On Save the host calls get-settings() to
+            /// read the current values for persistence, and calls apply-settings() on the
+            /// next load so the plugin can restore its state.
+            /// ---------------------------------------------------------------------------
+            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+            pub mod plugin_settings {
+                #[used]
+                #[doc(hidden)]
+                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
+                use super::super::super::super::_rt;
+                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
+                #[derive(Clone)]
+                pub struct SettingsOutput {
+                    /// JSON-encoded UiNode tree (same DSL as ui-component).
+                    pub node_json: _rt::String,
+                    /// Height hint in logical pixels; 0 = auto.
+                    pub height_hint: u32,
+                }
+                impl ::core::fmt::Debug for SettingsOutput {
+                    fn fmt(
+                        &self,
+                        f: &mut ::core::fmt::Formatter<'_>,
+                    ) -> ::core::fmt::Result {
+                        f.debug_struct("SettingsOutput")
+                            .field("node-json", &self.node_json)
+                            .field("height-hint", &self.height_hint)
+                            .finish()
+                    }
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let result0 = T::render_settings();
+                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result0 {
+                        Ok(e) => {
+                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
+                            let SettingsOutput {
+                                node_json: node_json2,
+                                height_hint: height_hint2,
+                            } = e;
+                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
+                            let ptr3 = vec3.as_ptr().cast::<u8>();
+                            let len3 = vec3.len();
+                            ::core::mem::forget(vec3);
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len3;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr3.cast_mut();
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(height_hint2);
+                        }
+                        Err(e) => {
+                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
+                            let super::super::super::super::thoth::plugin::types::PluginError {
+                                code: code4,
+                                message: message4,
+                            } = e;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(code4);
+                            let vec5 = (message4.into_bytes()).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len5;
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr5.cast_mut();
+                        }
+                    };
+                    ptr1
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {
+                            let l1 = *arg0
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                        _ => {
+                            let l3 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l4 = *arg0
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l3, l4, 1);
+                        }
+                    }
+                }
+                pub trait Guest {
+                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
+                    fn render_settings() -> Result<SettingsOutput, PluginError>;
+                }
+                #[doc(hidden)]
+                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
+                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
+                        const _ : () = { #[unsafe (export_name =
+                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
+                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
+                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
+                        #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
+                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
+                        u8,) { unsafe { $($path_to_types)*::
+                        __post_return_render_settings::<$ty > (arg0) } } };
+                    };
+                }
+                #[doc(hidden)]
+                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
+                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                struct _RetArea(
+                    [::core::mem::MaybeUninit<
+                        u8,
+                    >; 4 * ::core::mem::size_of::<*const u8>()],
+                );
+                static mut _RET_AREA: _RetArea = _RetArea(
+                    [::core::mem::MaybeUninit::uninit(); 4
+                        * ::core::mem::size_of::<*const u8>()],
+                );
+            }
+            /// ---------------------------------------------------------------------------
             /// plugin-meta — required by every plugin
             ///
             /// Maps from src/wit/mod.rs `Plugin` struct (as the return type of get-info).
@@ -655,155 +804,6 @@ pub mod exports {
                 #[doc(hidden)]
                 pub(crate) use __export_thoth_plugin_plugin_lifecycle_0_1_0_cabi;
             }
-            /// ---------------------------------------------------------------------------
-            /// Worlds — plugin authors implement one of these
-            ///
-            /// A world declares exactly which interfaces a plugin exports. Pick the
-            /// world that matches your plugin's capabilities. If you implement multiple
-            /// capabilities, implement the combined world or compose component binaries.
-            /// ---------------------------------------------------------------------------
-            /// ---------------------------------------------------------------------------
-            /// plugin-settings — implement on every plugin (trivial no-op is fine)
-            ///
-            /// Lets a plugin own its settings UI. The host calls render-settings() once
-            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
-            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
-            /// back via handle-setting-event(). On Save the host calls get-settings() to
-            /// read the current values for persistence, and calls apply-settings() on the
-            /// next load so the plugin can restore its state.
-            /// ---------------------------------------------------------------------------
-            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
-            pub mod plugin_settings {
-                #[used]
-                #[doc(hidden)]
-                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
-                use super::super::super::super::_rt;
-                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
-                #[derive(Clone)]
-                pub struct SettingsOutput {
-                    /// JSON-encoded UiNode tree (same DSL as ui-component).
-                    pub node_json: _rt::String,
-                    /// Height hint in logical pixels; 0 = auto.
-                    pub height_hint: u32,
-                }
-                impl ::core::fmt::Debug for SettingsOutput {
-                    fn fmt(
-                        &self,
-                        f: &mut ::core::fmt::Formatter<'_>,
-                    ) -> ::core::fmt::Result {
-                        f.debug_struct("SettingsOutput")
-                            .field("node-json", &self.node_json)
-                            .field("height-hint", &self.height_hint)
-                            .finish()
-                    }
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
-                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
-                    let result0 = T::render_settings();
-                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
-                    match result0 {
-                        Ok(e) => {
-                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
-                            let SettingsOutput {
-                                node_json: node_json2,
-                                height_hint: height_hint2,
-                            } = e;
-                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
-                            let ptr3 = vec3.as_ptr().cast::<u8>();
-                            let len3 = vec3.len();
-                            ::core::mem::forget(vec3);
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len3;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr3.cast_mut();
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(height_hint2);
-                        }
-                        Err(e) => {
-                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::thoth::plugin::types::PluginError {
-                                code: code4,
-                                message: message4,
-                            } = e;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(code4);
-                            let vec5 = (message4.into_bytes()).into_boxed_slice();
-                            let ptr5 = vec5.as_ptr().cast::<u8>();
-                            let len5 = vec5.len();
-                            ::core::mem::forget(vec5);
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len5;
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr5.cast_mut();
-                        }
-                    };
-                    ptr1
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
-                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
-                    match l0 {
-                        0 => {
-                            let l1 = *arg0
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l2 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l1, l2, 1);
-                        }
-                        _ => {
-                            let l3 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l4 = *arg0
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l3, l4, 1);
-                        }
-                    }
-                }
-                pub trait Guest {
-                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
-                    fn render_settings() -> Result<SettingsOutput, PluginError>;
-                }
-                #[doc(hidden)]
-                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
-                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
-                        const _ : () = { #[unsafe (export_name =
-                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
-                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
-                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
-                        #[unsafe (export_name =
-                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
-                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
-                        u8,) { unsafe { $($path_to_types)*::
-                        __post_return_render_settings::<$ty > (arg0) } } };
-                    };
-                }
-                #[doc(hidden)]
-                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
-                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
-                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
-                struct _RetArea(
-                    [::core::mem::MaybeUninit<
-                        u8,
-                    >; 4 * ::core::mem::size_of::<*const u8>()],
-                );
-                static mut _RET_AREA: _RetArea = _RetArea(
-                    [::core::mem::MaybeUninit::uninit(); 4
-                        * ::core::mem::size_of::<*const u8>()],
-                );
-            }
         }
     }
 }
@@ -919,14 +919,15 @@ macro_rules! __export_data_renderer_plugin_impl {
         exports::thoth::plugin::data_renderer::__export_thoth_plugin_data_renderer_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::data_renderer);
         $($path_to_types_root)*::
+        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
+        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        $($path_to_types_root)*::
         exports::thoth::plugin::plugin_meta::__export_thoth_plugin_plugin_meta_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_meta);
         $($path_to_types_root)*::
         exports::thoth::plugin::plugin_lifecycle::__export_thoth_plugin_plugin_lifecycle_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_lifecycle); $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
-        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        exports::thoth::plugin::plugin_lifecycle);
     };
 }
 #[doc(inline)]
@@ -948,17 +949,17 @@ plugin-info\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\
 n/types@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x07\x02\x03\x02\x01\x01\x04\
 \0\x0cplugin-error\x03\0\0\x01@\0\0s\x04\0\x04name\x01\x02\x01j\x01s\x01\x01\x01\
 @\x01\x0crecords-jsons\0\x03\x04\0\x06render\x01\x04\x04\0\x20thoth:plugin/data-\
-renderer@0.1.0\x05\x02\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x03\x04\
-\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:\
-plugin/plugin-meta@0.1.0\x05\x04\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on\
--load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\
-\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x05\x01B\x07\x02\x03\x02\x01\x01\
-\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fs\
-ettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-setti\
-ngs\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x06\x04\0'thoth:plugin\
-/data-renderer-plugin@0.1.0\x04\0\x0b\x1a\x01\0\x14data-renderer-plugin\x03\0\0\0\
-G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindge\
-n-rust\x060.41.0";
+renderer@0.1.0\x05\x02\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\
+\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\
+\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/p\
+lugin-settings@0.1.0\x05\x03\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\
+\x04\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1e\
+thoth:plugin/plugin-meta@0.1.0\x05\x05\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\
+\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-cha\
+nge\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x06\x04\0'thoth:plugin/d\
+ata-renderer-plugin@0.1.0\x04\0\x0b\x1a\x01\0\x14data-renderer-plugin\x03\0\0\0G\
+\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen\
+-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/csv-export/src/bindings.rs
+++ b/plugins/csv-export/src/bindings.rs
@@ -606,6 +606,155 @@ pub mod exports {
                 );
             }
             /// ---------------------------------------------------------------------------
+            /// Worlds — plugin authors implement one of these
+            ///
+            /// A world declares exactly which interfaces a plugin exports. Pick the
+            /// world that matches your plugin's capabilities. If you implement multiple
+            /// capabilities, implement the combined world or compose component binaries.
+            /// ---------------------------------------------------------------------------
+            /// ---------------------------------------------------------------------------
+            /// plugin-settings — implement on every plugin (trivial no-op is fine)
+            ///
+            /// Lets a plugin own its settings UI. The host calls render-settings() once
+            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
+            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
+            /// back via handle-setting-event(). On Save the host calls get-settings() to
+            /// read the current values for persistence, and calls apply-settings() on the
+            /// next load so the plugin can restore its state.
+            /// ---------------------------------------------------------------------------
+            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+            pub mod plugin_settings {
+                #[used]
+                #[doc(hidden)]
+                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
+                use super::super::super::super::_rt;
+                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
+                #[derive(Clone)]
+                pub struct SettingsOutput {
+                    /// JSON-encoded UiNode tree (same DSL as ui-component).
+                    pub node_json: _rt::String,
+                    /// Height hint in logical pixels; 0 = auto.
+                    pub height_hint: u32,
+                }
+                impl ::core::fmt::Debug for SettingsOutput {
+                    fn fmt(
+                        &self,
+                        f: &mut ::core::fmt::Formatter<'_>,
+                    ) -> ::core::fmt::Result {
+                        f.debug_struct("SettingsOutput")
+                            .field("node-json", &self.node_json)
+                            .field("height-hint", &self.height_hint)
+                            .finish()
+                    }
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let result0 = T::render_settings();
+                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result0 {
+                        Ok(e) => {
+                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
+                            let SettingsOutput {
+                                node_json: node_json2,
+                                height_hint: height_hint2,
+                            } = e;
+                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
+                            let ptr3 = vec3.as_ptr().cast::<u8>();
+                            let len3 = vec3.len();
+                            ::core::mem::forget(vec3);
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len3;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr3.cast_mut();
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(height_hint2);
+                        }
+                        Err(e) => {
+                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
+                            let super::super::super::super::thoth::plugin::types::PluginError {
+                                code: code4,
+                                message: message4,
+                            } = e;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(code4);
+                            let vec5 = (message4.into_bytes()).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len5;
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr5.cast_mut();
+                        }
+                    };
+                    ptr1
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {
+                            let l1 = *arg0
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                        _ => {
+                            let l3 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l4 = *arg0
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l3, l4, 1);
+                        }
+                    }
+                }
+                pub trait Guest {
+                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
+                    fn render_settings() -> Result<SettingsOutput, PluginError>;
+                }
+                #[doc(hidden)]
+                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
+                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
+                        const _ : () = { #[unsafe (export_name =
+                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
+                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
+                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
+                        #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
+                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
+                        u8,) { unsafe { $($path_to_types)*::
+                        __post_return_render_settings::<$ty > (arg0) } } };
+                    };
+                }
+                #[doc(hidden)]
+                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
+                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                struct _RetArea(
+                    [::core::mem::MaybeUninit<
+                        u8,
+                    >; 4 * ::core::mem::size_of::<*const u8>()],
+                );
+                static mut _RET_AREA: _RetArea = _RetArea(
+                    [::core::mem::MaybeUninit::uninit(); 4
+                        * ::core::mem::size_of::<*const u8>()],
+                );
+            }
+            /// ---------------------------------------------------------------------------
             /// plugin-meta — required by every plugin
             ///
             /// Maps from src/wit/mod.rs `Plugin` struct (as the return type of get-info).
@@ -944,155 +1093,6 @@ pub mod exports {
                 #[doc(hidden)]
                 pub(crate) use __export_thoth_plugin_plugin_lifecycle_0_1_0_cabi;
             }
-            /// ---------------------------------------------------------------------------
-            /// Worlds — plugin authors implement one of these
-            ///
-            /// A world declares exactly which interfaces a plugin exports. Pick the
-            /// world that matches your plugin's capabilities. If you implement multiple
-            /// capabilities, implement the combined world or compose component binaries.
-            /// ---------------------------------------------------------------------------
-            /// ---------------------------------------------------------------------------
-            /// plugin-settings — implement on every plugin (trivial no-op is fine)
-            ///
-            /// Lets a plugin own its settings UI. The host calls render-settings() once
-            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
-            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
-            /// back via handle-setting-event(). On Save the host calls get-settings() to
-            /// read the current values for persistence, and calls apply-settings() on the
-            /// next load so the plugin can restore its state.
-            /// ---------------------------------------------------------------------------
-            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
-            pub mod plugin_settings {
-                #[used]
-                #[doc(hidden)]
-                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
-                use super::super::super::super::_rt;
-                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
-                #[derive(Clone)]
-                pub struct SettingsOutput {
-                    /// JSON-encoded UiNode tree (same DSL as ui-component).
-                    pub node_json: _rt::String,
-                    /// Height hint in logical pixels; 0 = auto.
-                    pub height_hint: u32,
-                }
-                impl ::core::fmt::Debug for SettingsOutput {
-                    fn fmt(
-                        &self,
-                        f: &mut ::core::fmt::Formatter<'_>,
-                    ) -> ::core::fmt::Result {
-                        f.debug_struct("SettingsOutput")
-                            .field("node-json", &self.node_json)
-                            .field("height-hint", &self.height_hint)
-                            .finish()
-                    }
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
-                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
-                    let result0 = T::render_settings();
-                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
-                    match result0 {
-                        Ok(e) => {
-                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
-                            let SettingsOutput {
-                                node_json: node_json2,
-                                height_hint: height_hint2,
-                            } = e;
-                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
-                            let ptr3 = vec3.as_ptr().cast::<u8>();
-                            let len3 = vec3.len();
-                            ::core::mem::forget(vec3);
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len3;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr3.cast_mut();
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(height_hint2);
-                        }
-                        Err(e) => {
-                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::thoth::plugin::types::PluginError {
-                                code: code4,
-                                message: message4,
-                            } = e;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(code4);
-                            let vec5 = (message4.into_bytes()).into_boxed_slice();
-                            let ptr5 = vec5.as_ptr().cast::<u8>();
-                            let len5 = vec5.len();
-                            ::core::mem::forget(vec5);
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len5;
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr5.cast_mut();
-                        }
-                    };
-                    ptr1
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
-                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
-                    match l0 {
-                        0 => {
-                            let l1 = *arg0
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l2 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l1, l2, 1);
-                        }
-                        _ => {
-                            let l3 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l4 = *arg0
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l3, l4, 1);
-                        }
-                    }
-                }
-                pub trait Guest {
-                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
-                    fn render_settings() -> Result<SettingsOutput, PluginError>;
-                }
-                #[doc(hidden)]
-                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
-                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
-                        const _ : () = { #[unsafe (export_name =
-                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
-                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
-                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
-                        #[unsafe (export_name =
-                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
-                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
-                        u8,) { unsafe { $($path_to_types)*::
-                        __post_return_render_settings::<$ty > (arg0) } } };
-                    };
-                }
-                #[doc(hidden)]
-                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
-                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
-                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
-                struct _RetArea(
-                    [::core::mem::MaybeUninit<
-                        u8,
-                    >; 4 * ::core::mem::size_of::<*const u8>()],
-                );
-                static mut _RET_AREA: _RetArea = _RetArea(
-                    [::core::mem::MaybeUninit::uninit(); 4
-                        * ::core::mem::size_of::<*const u8>()],
-                );
-            }
         }
     }
 }
@@ -1208,14 +1208,15 @@ macro_rules! __export_exporter_plugin_impl {
         exports::thoth::plugin::exporter::__export_thoth_plugin_exporter_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::exporter);
         $($path_to_types_root)*::
+        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
+        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        $($path_to_types_root)*::
         exports::thoth::plugin::plugin_meta::__export_thoth_plugin_plugin_meta_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_meta);
         $($path_to_types_root)*::
         exports::thoth::plugin::plugin_lifecycle::__export_thoth_plugin_plugin_lifecycle_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_lifecycle); $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
-        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        exports::thoth::plugin::plugin_lifecycle);
     };
 }
 #[doc(inline)]
@@ -1240,17 +1241,16 @@ input-types\x07choices\x02\x04\0\x0dexport-option\x03\0\x03\x01@\0\0s\x04\0\x04n
 ame\x01\x05\x04\0\x10output-extension\x01\x05\x01p\x04\x01@\0\0\x06\x04\0\x11ava\
 ilable-options\x01\x07\x01o\x02ss\x01p\x08\x01p}\x01j\x01\x0a\x01\x01\x01@\x02\x0c\
 records-jsons\x07options\x09\0\x0b\x04\0\x03run\x01\x0c\x04\0\x1bthoth:plugin/ex\
-porter@0.1.0\x05\x02\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x03\x04\
-\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:\
-plugin/plugin-meta@0.1.0\x05\x04\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on\
--load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\
-\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x05\x01B\x07\x02\x03\x02\x01\x01\
-\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fs\
-ettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-setti\
-ngs\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x06\x04\0\"thoth:plugi\
-n/exporter-plugin@0.1.0\x04\0\x0b\x15\x01\0\x0fexporter-plugin\x03\0\0\0G\x09pro\
-ducers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x06\
-0.41.0";
+porter@0.1.0\x05\x02\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01\
+r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\
+\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugi\
+n-settings@0.1.0\x05\x03\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x04\
+\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1eth\
+oth:plugin/plugin-meta@0.1.0\x05\x05\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07\
+on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\
+\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x06\x04\0\"thoth:plugin/exporte\
+r-plugin@0.1.0\x04\0\x0b\x15\x01\0\x0fexporter-plugin\x03\0\0\0G\x09producers\x01\
+\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/csv-export/src/bindings.rs
+++ b/plugins/csv-export/src/bindings.rs
@@ -33,6 +33,8 @@ pub mod thoth {
                 /// data-renderer.render and appears as an extra view format in a
                 /// DataView (alongside table / json / raw).
                 Renderer,
+                /// Exposes commands through the optional plugin-cli interface.
+                Cli,
             }
             impl ::core::fmt::Debug for Capability {
                 fn fmt(
@@ -64,6 +66,7 @@ pub mod thoth {
                         Capability::Renderer => {
                             f.debug_tuple("Capability::Renderer").finish()
                         }
+                        Capability::Cli => f.debug_tuple("Capability::Cli").finish(),
                     }
                 }
             }
@@ -82,6 +85,7 @@ pub mod thoth {
                         5 => Capability::NewUiComponent,
                         6 => Capability::DataProducer,
                         7 => Capability::Renderer,
+                        8 => Capability::Cli,
                         _ => panic!("invalid enum discriminant"),
                     }
                 }
@@ -1222,30 +1226,31 @@ pub(crate) use __export_exporter_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1109] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xcf\x07\x01A\x02\x01\
-A\x0c\x01B\x0a\x01m\x08\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
-\x0fsearch-provider\x10new-ui-component\x0ddata-producer\x08renderer\x04\0\x0aca\
-pability\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescript\
-ions\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplug\
-in-info\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\x01\
-r\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugin/ty\
-pes@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01ps\x01r\x05\x03keys\x05labels\x0ddefault-values\x0ainput\
--types\x07choices\x02\x04\0\x0dexport-option\x03\0\x03\x01@\0\0s\x04\0\x04name\x01\
-\x05\x04\0\x10output-extension\x01\x05\x01p\x04\x01@\0\0\x06\x04\0\x11available-\
-options\x01\x07\x01o\x02ss\x01p\x08\x01p}\x01j\x01\x0a\x01\x01\x01@\x02\x0crecor\
-ds-jsons\x07options\x09\0\x0b\x04\0\x03run\x01\x0c\x04\0\x1bthoth:plugin/exporte\
-r@0.1.0\x05\x02\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x03\x04\0\x0b\
-plugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin\
-/plugin-meta@0.1.0\x05\x04\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\
-\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0\
-#thoth:plugin/plugin-lifecycle@0.1.0\x05\x05\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-ou\
-tput\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\
-\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x06\x04\0\"thoth:plugin/exporter-\
-plugin@0.1.0\x04\0\x0b\x15\x01\0\x0fexporter-plugin\x03\0\0\0G\x09producers\x01\x0c\
-processed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1113] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xd3\x07\x01A\x02\x01\
+A\x0c\x01B\x0a\x01m\x09\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
+\x0fsearch-provider\x10new-ui-component\x0ddata-producer\x08renderer\x03cli\x04\0\
+\x0acapability\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bde\
+scriptions\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0b\
+plugin-info\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\
+\x01r\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugi\
+n/types@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x11\x02\x03\x02\x01\x01\x04\
+\0\x0cplugin-error\x03\0\0\x01ps\x01r\x05\x03keys\x05labels\x0ddefault-values\x0a\
+input-types\x07choices\x02\x04\0\x0dexport-option\x03\0\x03\x01@\0\0s\x04\0\x04n\
+ame\x01\x05\x04\0\x10output-extension\x01\x05\x01p\x04\x01@\0\0\x06\x04\0\x11ava\
+ilable-options\x01\x07\x01o\x02ss\x01p\x08\x01p}\x01j\x01\x0a\x01\x01\x01@\x02\x0c\
+records-jsons\x07options\x09\0\x0b\x04\0\x03run\x01\x0c\x04\0\x1bthoth:plugin/ex\
+porter@0.1.0\x05\x02\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x03\x04\
+\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:\
+plugin/plugin-meta@0.1.0\x05\x04\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on\
+-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\
+\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x05\x01B\x07\x02\x03\x02\x01\x01\
+\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fs\
+ettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-setti\
+ngs\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x06\x04\0\"thoth:plugi\
+n/exporter-plugin@0.1.0\x04\0\x0b\x15\x01\0\x0fexporter-plugin\x03\0\0\0G\x09pro\
+ducers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x06\
+0.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/csv-loader/src/bindings.rs
+++ b/plugins/csv-loader/src/bindings.rs
@@ -952,6 +952,155 @@ pub mod exports {
                 );
             }
             /// ---------------------------------------------------------------------------
+            /// Worlds — plugin authors implement one of these
+            ///
+            /// A world declares exactly which interfaces a plugin exports. Pick the
+            /// world that matches your plugin's capabilities. If you implement multiple
+            /// capabilities, implement the combined world or compose component binaries.
+            /// ---------------------------------------------------------------------------
+            /// ---------------------------------------------------------------------------
+            /// plugin-settings — implement on every plugin (trivial no-op is fine)
+            ///
+            /// Lets a plugin own its settings UI. The host calls render-settings() once
+            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
+            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
+            /// back via handle-setting-event(). On Save the host calls get-settings() to
+            /// read the current values for persistence, and calls apply-settings() on the
+            /// next load so the plugin can restore its state.
+            /// ---------------------------------------------------------------------------
+            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+            pub mod plugin_settings {
+                #[used]
+                #[doc(hidden)]
+                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
+                use super::super::super::super::_rt;
+                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
+                #[derive(Clone)]
+                pub struct SettingsOutput {
+                    /// JSON-encoded UiNode tree (same DSL as ui-component).
+                    pub node_json: _rt::String,
+                    /// Height hint in logical pixels; 0 = auto.
+                    pub height_hint: u32,
+                }
+                impl ::core::fmt::Debug for SettingsOutput {
+                    fn fmt(
+                        &self,
+                        f: &mut ::core::fmt::Formatter<'_>,
+                    ) -> ::core::fmt::Result {
+                        f.debug_struct("SettingsOutput")
+                            .field("node-json", &self.node_json)
+                            .field("height-hint", &self.height_hint)
+                            .finish()
+                    }
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let result0 = T::render_settings();
+                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result0 {
+                        Ok(e) => {
+                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
+                            let SettingsOutput {
+                                node_json: node_json2,
+                                height_hint: height_hint2,
+                            } = e;
+                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
+                            let ptr3 = vec3.as_ptr().cast::<u8>();
+                            let len3 = vec3.len();
+                            ::core::mem::forget(vec3);
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len3;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr3.cast_mut();
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(height_hint2);
+                        }
+                        Err(e) => {
+                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
+                            let super::super::super::super::thoth::plugin::types::PluginError {
+                                code: code4,
+                                message: message4,
+                            } = e;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(code4);
+                            let vec5 = (message4.into_bytes()).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len5;
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr5.cast_mut();
+                        }
+                    };
+                    ptr1
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {
+                            let l1 = *arg0
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                        _ => {
+                            let l3 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l4 = *arg0
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l3, l4, 1);
+                        }
+                    }
+                }
+                pub trait Guest {
+                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
+                    fn render_settings() -> Result<SettingsOutput, PluginError>;
+                }
+                #[doc(hidden)]
+                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
+                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
+                        const _ : () = { #[unsafe (export_name =
+                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
+                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
+                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
+                        #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
+                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
+                        u8,) { unsafe { $($path_to_types)*::
+                        __post_return_render_settings::<$ty > (arg0) } } };
+                    };
+                }
+                #[doc(hidden)]
+                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
+                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                struct _RetArea(
+                    [::core::mem::MaybeUninit<
+                        u8,
+                    >; 4 * ::core::mem::size_of::<*const u8>()],
+                );
+                static mut _RET_AREA: _RetArea = _RetArea(
+                    [::core::mem::MaybeUninit::uninit(); 4
+                        * ::core::mem::size_of::<*const u8>()],
+                );
+            }
+            /// ---------------------------------------------------------------------------
             /// plugin-meta — required by every plugin
             ///
             /// Maps from src/wit/mod.rs `Plugin` struct (as the return type of get-info).
@@ -1290,155 +1439,6 @@ pub mod exports {
                 #[doc(hidden)]
                 pub(crate) use __export_thoth_plugin_plugin_lifecycle_0_1_0_cabi;
             }
-            /// ---------------------------------------------------------------------------
-            /// Worlds — plugin authors implement one of these
-            ///
-            /// A world declares exactly which interfaces a plugin exports. Pick the
-            /// world that matches your plugin's capabilities. If you implement multiple
-            /// capabilities, implement the combined world or compose component binaries.
-            /// ---------------------------------------------------------------------------
-            /// ---------------------------------------------------------------------------
-            /// plugin-settings — implement on every plugin (trivial no-op is fine)
-            ///
-            /// Lets a plugin own its settings UI. The host calls render-settings() once
-            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
-            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
-            /// back via handle-setting-event(). On Save the host calls get-settings() to
-            /// read the current values for persistence, and calls apply-settings() on the
-            /// next load so the plugin can restore its state.
-            /// ---------------------------------------------------------------------------
-            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
-            pub mod plugin_settings {
-                #[used]
-                #[doc(hidden)]
-                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
-                use super::super::super::super::_rt;
-                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
-                #[derive(Clone)]
-                pub struct SettingsOutput {
-                    /// JSON-encoded UiNode tree (same DSL as ui-component).
-                    pub node_json: _rt::String,
-                    /// Height hint in logical pixels; 0 = auto.
-                    pub height_hint: u32,
-                }
-                impl ::core::fmt::Debug for SettingsOutput {
-                    fn fmt(
-                        &self,
-                        f: &mut ::core::fmt::Formatter<'_>,
-                    ) -> ::core::fmt::Result {
-                        f.debug_struct("SettingsOutput")
-                            .field("node-json", &self.node_json)
-                            .field("height-hint", &self.height_hint)
-                            .finish()
-                    }
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
-                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
-                    let result0 = T::render_settings();
-                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
-                    match result0 {
-                        Ok(e) => {
-                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
-                            let SettingsOutput {
-                                node_json: node_json2,
-                                height_hint: height_hint2,
-                            } = e;
-                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
-                            let ptr3 = vec3.as_ptr().cast::<u8>();
-                            let len3 = vec3.len();
-                            ::core::mem::forget(vec3);
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len3;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr3.cast_mut();
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(height_hint2);
-                        }
-                        Err(e) => {
-                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::thoth::plugin::types::PluginError {
-                                code: code4,
-                                message: message4,
-                            } = e;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(code4);
-                            let vec5 = (message4.into_bytes()).into_boxed_slice();
-                            let ptr5 = vec5.as_ptr().cast::<u8>();
-                            let len5 = vec5.len();
-                            ::core::mem::forget(vec5);
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len5;
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr5.cast_mut();
-                        }
-                    };
-                    ptr1
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
-                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
-                    match l0 {
-                        0 => {
-                            let l1 = *arg0
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l2 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l1, l2, 1);
-                        }
-                        _ => {
-                            let l3 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l4 = *arg0
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l3, l4, 1);
-                        }
-                    }
-                }
-                pub trait Guest {
-                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
-                    fn render_settings() -> Result<SettingsOutput, PluginError>;
-                }
-                #[doc(hidden)]
-                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
-                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
-                        const _ : () = { #[unsafe (export_name =
-                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
-                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
-                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
-                        #[unsafe (export_name =
-                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
-                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
-                        u8,) { unsafe { $($path_to_types)*::
-                        __post_return_render_settings::<$ty > (arg0) } } };
-                    };
-                }
-                #[doc(hidden)]
-                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
-                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
-                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
-                struct _RetArea(
-                    [::core::mem::MaybeUninit<
-                        u8,
-                    >; 4 * ::core::mem::size_of::<*const u8>()],
-                );
-                static mut _RET_AREA: _RetArea = _RetArea(
-                    [::core::mem::MaybeUninit::uninit(); 4
-                        * ::core::mem::size_of::<*const u8>()],
-                );
-            }
         }
     }
 }
@@ -1580,14 +1580,15 @@ macro_rules! __export_file_viewer_plugin_impl {
         exports::thoth::plugin::file_viewer::__export_thoth_plugin_file_viewer_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::file_viewer);
         $($path_to_types_root)*::
+        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
+        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        $($path_to_types_root)*::
         exports::thoth::plugin::plugin_meta::__export_thoth_plugin_plugin_meta_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_meta);
         $($path_to_types_root)*::
         exports::thoth::plugin::plugin_lifecycle::__export_thoth_plugin_plugin_lifecycle_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_lifecycle); $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
-        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        exports::thoth::plugin::plugin_lifecycle);
     };
 }
 #[doc(inline)]
@@ -1617,14 +1618,14 @@ table\x06custom\x04\0\x0cdisplay-mode\x03\0\x02\x01r\x02\x09node-jsons\x0bheight
 -hinty\x04\0\x0drender-output\x03\0\x04\x01@\0\0\x03\x04\0\x11preferred-display\x01\
 \x06\x01j\x01\x05\x01\x01\x01@\x01\x0brecord-jsons\0\x07\x04\0\x0drender-record\x01\
 \x08\x01ps\x01k\x09\x01@\0\0\x0a\x04\0\x0ecolumn-headers\x01\x0b\x04\0\x1ethoth:\
-plugin/file-viewer@0.1.0\x05\x03\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\
-\x01\x04\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\
-\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x05\x01B\x05\x01@\x01\x07settings\x01\0\
-\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setti\
-ng-change\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x06\x01B\x07\x02\x03\
-\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hint\
-y\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0f\
-render-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x07\x04\0%\
+plugin/file-viewer@0.1.0\x05\x03\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-er\
+ror\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\
+\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"t\
+hoth:plugin/plugin-settings@0.1.0\x05\x04\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\
+\x03\x02\x01\x05\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\
+\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x06\x01B\x05\x01@\x01\x07settin\
+gs\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11\
+on-setting-change\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x07\x04\0%\
 thoth:plugin/file-viewer-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12file-viewer-plugin\x03\
 \0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-\
 bindgen-rust\x060.41.0";

--- a/plugins/csv-loader/src/bindings.rs
+++ b/plugins/csv-loader/src/bindings.rs
@@ -33,6 +33,8 @@ pub mod thoth {
                 /// data-renderer.render and appears as an extra view format in a
                 /// DataView (alongside table / json / raw).
                 Renderer,
+                /// Exposes commands through the optional plugin-cli interface.
+                Cli,
             }
             impl ::core::fmt::Debug for Capability {
                 fn fmt(
@@ -64,6 +66,7 @@ pub mod thoth {
                         Capability::Renderer => {
                             f.debug_tuple("Capability::Renderer").finish()
                         }
+                        Capability::Cli => f.debug_tuple("Capability::Cli").finish(),
                     }
                 }
             }
@@ -82,6 +85,7 @@ pub mod thoth {
                         5 => Capability::NewUiComponent,
                         6 => Capability::DataProducer,
                         7 => Capability::Renderer,
+                        8 => Capability::Cli,
                         _ => panic!("invalid enum discriminant"),
                     }
                 }
@@ -1594,36 +1598,36 @@ pub(crate) use __export_file_viewer_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1322] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xa1\x09\x01A\x02\x01\
-A\x0e\x01B\x0a\x01m\x08\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
-\x0fsearch-provider\x10new-ui-component\x0ddata-producer\x08renderer\x04\0\x0aca\
-pability\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescript\
-ions\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplug\
-in-info\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\x01\
-r\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugin/ty\
-pes@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x12\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01ps\x01@\0\0\x02\x04\0\x14supported-extensions\x01\x03\x01\
-j\x01w\x01\x01\x01@\x01\x04paths\0\x04\x04\0\x04open\x01\x05\x01j\x01s\x01\x01\x01\
-@\x01\x03idxw\0\x06\x04\0\x03get\x01\x07\x01j\x01\x02\x01\x01\x01@\x02\x05startw\
-\x05countw\0\x08\x04\0\x09get-range\x01\x09\x01p}\x01j\x01\x0a\x01\x01\x01@\x01\x03\
-idxw\0\x0b\x04\0\x09raw-bytes\x01\x0c\x04\0\x1ethoth:plugin/file-loader@0.1.0\x05\
-\x02\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01m\x02\x05tabl\
-e\x06custom\x04\0\x0cdisplay-mode\x03\0\x02\x01r\x02\x09node-jsons\x0bheight-hin\
-ty\x04\0\x0drender-output\x03\0\x04\x01@\0\0\x03\x04\0\x11preferred-display\x01\x06\
-\x01j\x01\x05\x01\x01\x01@\x01\x0brecord-jsons\0\x07\x04\0\x0drender-record\x01\x08\
-\x01ps\x01k\x09\x01@\0\0\x0a\x04\0\x0ecolumn-headers\x01\x0b\x04\0\x1ethoth:plug\
-in/file-viewer@0.1.0\x05\x03\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\
-\x04\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1e\
-thoth:plugin/plugin-meta@0.1.0\x05\x05\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\
-\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-cha\
-nge\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x06\x01B\x07\x02\x03\x02\
-\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\
-\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frende\
-r-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x07\x04\0%thoth\
-:plugin/file-viewer-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12file-viewer-plugin\x03\0\
-\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bi\
-ndgen-rust\x060.41.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1326] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xa5\x09\x01A\x02\x01\
+A\x0e\x01B\x0a\x01m\x09\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\
+\x0fsearch-provider\x10new-ui-component\x0ddata-producer\x08renderer\x03cli\x04\0\
+\x0acapability\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bde\
+scriptions\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0b\
+plugin-info\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\
+\x01r\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugi\
+n/types@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x12\x02\x03\x02\x01\x01\x04\
+\0\x0cplugin-error\x03\0\0\x01ps\x01@\0\0\x02\x04\0\x14supported-extensions\x01\x03\
+\x01j\x01w\x01\x01\x01@\x01\x04paths\0\x04\x04\0\x04open\x01\x05\x01j\x01s\x01\x01\
+\x01@\x01\x03idxw\0\x06\x04\0\x03get\x01\x07\x01j\x01\x02\x01\x01\x01@\x02\x05st\
+artw\x05countw\0\x08\x04\0\x09get-range\x01\x09\x01p}\x01j\x01\x0a\x01\x01\x01@\x01\
+\x03idxw\0\x0b\x04\0\x09raw-bytes\x01\x0c\x04\0\x1ethoth:plugin/file-loader@0.1.\
+0\x05\x02\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01m\x02\x05\
+table\x06custom\x04\0\x0cdisplay-mode\x03\0\x02\x01r\x02\x09node-jsons\x0bheight\
+-hinty\x04\0\x0drender-output\x03\0\x04\x01@\0\0\x03\x04\0\x11preferred-display\x01\
+\x06\x01j\x01\x05\x01\x01\x01@\x01\x0brecord-jsons\0\x07\x04\0\x0drender-record\x01\
+\x08\x01ps\x01k\x09\x01@\0\0\x0a\x04\0\x0ecolumn-headers\x01\x0b\x04\0\x1ethoth:\
+plugin/file-viewer@0.1.0\x05\x03\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\
+\x01\x04\x04\0\x0bplugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\
+\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x05\x01B\x05\x01@\x01\x07settings\x01\0\
+\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setti\
+ng-change\x01\0\x04\0#thoth:plugin/plugin-lifecycle@0.1.0\x05\x06\x01B\x07\x02\x03\
+\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hint\
+y\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0f\
+render-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x07\x04\0%\
+thoth:plugin/file-viewer-plugin@0.1.0\x04\0\x0b\x18\x01\0\x12file-viewer-plugin\x03\
+\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-\
+bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/seshat/Cargo.toml
+++ b/plugins/seshat/Cargo.toml
@@ -34,4 +34,4 @@ package = "thoth:seshat"
 
 [package.metadata.component.target]
 path = "../../wit"
-world = "data-source-plugin"
+world = "data-source-cli-plugin"

--- a/plugins/seshat/Cargo.toml
+++ b/plugins/seshat/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["cdylib"] # required for WASM component output
 wit-bindgen-rt = "0.41"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+url = "2"
+percent-encoding = "2"
 # Postgres wire-protocol codec (transport-agnostic; driven over the host
 # tcp-client shim). The high-level `postgres`/`tokio-postgres` crates open their
 # own sockets and won't compile to wasm32-wasip1 — this is just the codec.

--- a/plugins/seshat/plugin.toml
+++ b/plugins/seshat/plugin.toml
@@ -3,7 +3,7 @@ name         = "Seshat"
 version      = "0.1.0"
 description  = "Database client — connect, browse schemas, run SQL (Postgres, MySQL) or Query DSL (Elasticsearch)"
 author       = "Thoth contributors"
-capabilities = ["data-source", "new-ui-component", "data-producer"]
+capabilities = ["data-source", "new-ui-component", "data-producer", "cli"]
 icon         = ""    # egui_phosphor::regular::DATABASE
 
 [data-source]

--- a/plugins/seshat/src/bindings.rs
+++ b/plugins/seshat/src/bindings.rs
@@ -5080,6 +5080,155 @@ pub mod exports {
                 );
             }
             /// ---------------------------------------------------------------------------
+            /// Worlds — plugin authors implement one of these
+            ///
+            /// A world declares exactly which interfaces a plugin exports. Pick the
+            /// world that matches your plugin's capabilities. If you implement multiple
+            /// capabilities, implement the combined world or compose component binaries.
+            /// ---------------------------------------------------------------------------
+            /// ---------------------------------------------------------------------------
+            /// plugin-settings — implement on every plugin (trivial no-op is fine)
+            ///
+            /// Lets a plugin own its settings UI. The host calls render-settings() once
+            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
+            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
+            /// back via handle-setting-event(). On Save the host calls get-settings() to
+            /// read the current values for persistence, and calls apply-settings() on the
+            /// next load so the plugin can restore its state.
+            /// ---------------------------------------------------------------------------
+            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+            pub mod plugin_settings {
+                #[used]
+                #[doc(hidden)]
+                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
+                use super::super::super::super::_rt;
+                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
+                #[derive(Clone)]
+                pub struct SettingsOutput {
+                    /// JSON-encoded UiNode tree (same DSL as ui-component).
+                    pub node_json: _rt::String,
+                    /// Height hint in logical pixels; 0 = auto.
+                    pub height_hint: u32,
+                }
+                impl ::core::fmt::Debug for SettingsOutput {
+                    fn fmt(
+                        &self,
+                        f: &mut ::core::fmt::Formatter<'_>,
+                    ) -> ::core::fmt::Result {
+                        f.debug_struct("SettingsOutput")
+                            .field("node-json", &self.node_json)
+                            .field("height-hint", &self.height_hint)
+                            .finish()
+                    }
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let result0 = T::render_settings();
+                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result0 {
+                        Ok(e) => {
+                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
+                            let SettingsOutput {
+                                node_json: node_json2,
+                                height_hint: height_hint2,
+                            } = e;
+                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
+                            let ptr3 = vec3.as_ptr().cast::<u8>();
+                            let len3 = vec3.len();
+                            ::core::mem::forget(vec3);
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len3;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr3.cast_mut();
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(height_hint2);
+                        }
+                        Err(e) => {
+                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
+                            let super::super::super::super::thoth::plugin::types::PluginError {
+                                code: code4,
+                                message: message4,
+                            } = e;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(code4);
+                            let vec5 = (message4.into_bytes()).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len5;
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr5.cast_mut();
+                        }
+                    };
+                    ptr1
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {
+                            let l1 = *arg0
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                        _ => {
+                            let l3 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l4 = *arg0
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l3, l4, 1);
+                        }
+                    }
+                }
+                pub trait Guest {
+                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
+                    fn render_settings() -> Result<SettingsOutput, PluginError>;
+                }
+                #[doc(hidden)]
+                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
+                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
+                        const _ : () = { #[unsafe (export_name =
+                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
+                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
+                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
+                        #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
+                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
+                        u8,) { unsafe { $($path_to_types)*::
+                        __post_return_render_settings::<$ty > (arg0) } } };
+                    };
+                }
+                #[doc(hidden)]
+                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
+                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                struct _RetArea(
+                    [::core::mem::MaybeUninit<
+                        u8,
+                    >; 4 * ::core::mem::size_of::<*const u8>()],
+                );
+                static mut _RET_AREA: _RetArea = _RetArea(
+                    [::core::mem::MaybeUninit::uninit(); 4
+                        * ::core::mem::size_of::<*const u8>()],
+                );
+            }
+            /// ---------------------------------------------------------------------------
             /// plugin-meta — required by every plugin
             ///
             /// Maps from src/wit/mod.rs `Plugin` struct (as the return type of get-info).
@@ -5418,155 +5567,6 @@ pub mod exports {
                 #[doc(hidden)]
                 pub(crate) use __export_thoth_plugin_plugin_lifecycle_0_1_0_cabi;
             }
-            /// ---------------------------------------------------------------------------
-            /// Worlds — plugin authors implement one of these
-            ///
-            /// A world declares exactly which interfaces a plugin exports. Pick the
-            /// world that matches your plugin's capabilities. If you implement multiple
-            /// capabilities, implement the combined world or compose component binaries.
-            /// ---------------------------------------------------------------------------
-            /// ---------------------------------------------------------------------------
-            /// plugin-settings — implement on every plugin (trivial no-op is fine)
-            ///
-            /// Lets a plugin own its settings UI. The host calls render-settings() once
-            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
-            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
-            /// back via handle-setting-event(). On Save the host calls get-settings() to
-            /// read the current values for persistence, and calls apply-settings() on the
-            /// next load so the plugin can restore its state.
-            /// ---------------------------------------------------------------------------
-            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
-            pub mod plugin_settings {
-                #[used]
-                #[doc(hidden)]
-                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
-                use super::super::super::super::_rt;
-                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
-                #[derive(Clone)]
-                pub struct SettingsOutput {
-                    /// JSON-encoded UiNode tree (same DSL as ui-component).
-                    pub node_json: _rt::String,
-                    /// Height hint in logical pixels; 0 = auto.
-                    pub height_hint: u32,
-                }
-                impl ::core::fmt::Debug for SettingsOutput {
-                    fn fmt(
-                        &self,
-                        f: &mut ::core::fmt::Formatter<'_>,
-                    ) -> ::core::fmt::Result {
-                        f.debug_struct("SettingsOutput")
-                            .field("node-json", &self.node_json)
-                            .field("height-hint", &self.height_hint)
-                            .finish()
-                    }
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
-                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
-                    let result0 = T::render_settings();
-                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
-                    match result0 {
-                        Ok(e) => {
-                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
-                            let SettingsOutput {
-                                node_json: node_json2,
-                                height_hint: height_hint2,
-                            } = e;
-                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
-                            let ptr3 = vec3.as_ptr().cast::<u8>();
-                            let len3 = vec3.len();
-                            ::core::mem::forget(vec3);
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len3;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr3.cast_mut();
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(height_hint2);
-                        }
-                        Err(e) => {
-                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::thoth::plugin::types::PluginError {
-                                code: code4,
-                                message: message4,
-                            } = e;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(code4);
-                            let vec5 = (message4.into_bytes()).into_boxed_slice();
-                            let ptr5 = vec5.as_ptr().cast::<u8>();
-                            let len5 = vec5.len();
-                            ::core::mem::forget(vec5);
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len5;
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr5.cast_mut();
-                        }
-                    };
-                    ptr1
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
-                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
-                    match l0 {
-                        0 => {
-                            let l1 = *arg0
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l2 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l1, l2, 1);
-                        }
-                        _ => {
-                            let l3 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l4 = *arg0
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l3, l4, 1);
-                        }
-                    }
-                }
-                pub trait Guest {
-                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
-                    fn render_settings() -> Result<SettingsOutput, PluginError>;
-                }
-                #[doc(hidden)]
-                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
-                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
-                        const _ : () = { #[unsafe (export_name =
-                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
-                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
-                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
-                        #[unsafe (export_name =
-                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
-                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
-                        u8,) { unsafe { $($path_to_types)*::
-                        __post_return_render_settings::<$ty > (arg0) } } };
-                    };
-                }
-                #[doc(hidden)]
-                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
-                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
-                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
-                struct _RetArea(
-                    [::core::mem::MaybeUninit<
-                        u8,
-                    >; 4 * ::core::mem::size_of::<*const u8>()],
-                );
-                static mut _RET_AREA: _RetArea = _RetArea(
-                    [::core::mem::MaybeUninit::uninit(); 4
-                        * ::core::mem::size_of::<*const u8>()],
-                );
-            }
         }
     }
 }
@@ -5735,14 +5735,15 @@ macro_rules! __export_data_source_cli_plugin_impl {
         exports::thoth::plugin::data_producer::__export_thoth_plugin_data_producer_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::data_producer);
         $($path_to_types_root)*::
+        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
+        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        $($path_to_types_root)*::
         exports::thoth::plugin::plugin_meta::__export_thoth_plugin_plugin_meta_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_meta);
         $($path_to_types_root)*::
         exports::thoth::plugin::plugin_lifecycle::__export_thoth_plugin_plugin_lifecycle_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_lifecycle); $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
-        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        exports::thoth::plugin::plugin_lifecycle);
     };
 }
 #[doc(inline)]
@@ -5830,15 +5831,15 @@ d\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.0\x05\x11\x01B\x0c\x02\x03\x02\x01\
 \x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04names\x09type-hints\x04\0\x0edataset-\
 column\x03\0\x02\x01p\x03\x01ps\x01p\x05\x01r\x04\x04names\x04kinds\x07columns\x04\
 \x04rows\x06\x04\0\x07dataset\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\x09\x04\0\x0f\
-provide-dataset\x01\x0a\x04\0\x20thoth:plugin/data-producer@0.1.0\x05\x12\x02\x03\
-\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x13\x04\0\x0bplugin-info\x03\0\0\x01\
-@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x14\
-\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08\
-on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:plugin/plugin-life\
-cycle@0.1.0\x05\x15\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01\
-r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\
-\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugi\
-n-settings@0.1.0\x05\x16\x04\0)thoth:plugin/data-source-cli-plugin@0.1.0\x04\0\x0b\
+provide-dataset\x01\x0a\x04\0\x20thoth:plugin/data-producer@0.1.0\x05\x12\x01B\x07\
+\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node-jsons\x0bhei\
+ght-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\
+\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0.1.0\x05\x13\x02\
+\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x14\x04\0\x0bplugin-info\x03\0\0\
+\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\
+\x15\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\
+\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:plugin/plugi\
+n-lifecycle@0.1.0\x05\x16\x04\0)thoth:plugin/data-source-cli-plugin@0.1.0\x04\0\x0b\
 \x1c\x01\0\x16data-source-cli-plugin\x03\0\0\0G\x09producers\x01\x0cprocessed-by\
 \x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]

--- a/plugins/seshat/src/bindings.rs
+++ b/plugins/seshat/src/bindings.rs
@@ -2994,6 +2994,206 @@ pub mod exports {
     pub mod thoth {
         pub mod plugin {
             /// ---------------------------------------------------------------------------
+            /// plugin-cli — optional display-free command interface
+            ///
+            /// The schema and invocation payloads use the versioned JSON structures from
+            /// thoth-plugin-sdk::cli. JSON keeps this boundary extensible and equally usable
+            /// from non-Rust component languages. Worlds that do not export this interface
+            /// remain fully compatible.
+            /// ---------------------------------------------------------------------------
+            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+            pub mod plugin_cli {
+                #[used]
+                #[doc(hidden)]
+                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
+                use super::super::super::super::_rt;
+                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_schema_cabi<T: Guest>() -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let result0 = T::schema();
+                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result0 {
+                        Ok(e) => {
+                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
+                            let vec2 = (e.into_bytes()).into_boxed_slice();
+                            let ptr2 = vec2.as_ptr().cast::<u8>();
+                            let len2 = vec2.len();
+                            ::core::mem::forget(vec2);
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len2;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr2.cast_mut();
+                        }
+                        Err(e) => {
+                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
+                            let super::super::super::super::thoth::plugin::types::PluginError {
+                                code: code3,
+                                message: message3,
+                            } = e;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(code3);
+                            let vec4 = (message3.into_bytes()).into_boxed_slice();
+                            let ptr4 = vec4.as_ptr().cast::<u8>();
+                            let len4 = vec4.len();
+                            ::core::mem::forget(vec4);
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len4;
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr4.cast_mut();
+                        }
+                    };
+                    ptr1
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_schema<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {
+                            let l1 = *arg0
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                        _ => {
+                            let l3 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l4 = *arg0
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l3, l4, 1);
+                        }
+                    }
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_run_cabi<T: Guest>(
+                    arg0: *mut u8,
+                    arg1: usize,
+                ) -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let len0 = arg1;
+                    let bytes0 = _rt::Vec::from_raw_parts(arg0.cast(), len0, len0);
+                    let result1 = T::run(_rt::string_lift(bytes0));
+                    let ptr2 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result1 {
+                        Ok(e) => {
+                            *ptr2.add(0).cast::<u8>() = (0i32) as u8;
+                            let vec3 = (e.into_bytes()).into_boxed_slice();
+                            let ptr3 = vec3.as_ptr().cast::<u8>();
+                            let len3 = vec3.len();
+                            ::core::mem::forget(vec3);
+                            *ptr2
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len3;
+                            *ptr2
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr3.cast_mut();
+                        }
+                        Err(e) => {
+                            *ptr2.add(0).cast::<u8>() = (1i32) as u8;
+                            let super::super::super::super::thoth::plugin::types::PluginError {
+                                code: code4,
+                                message: message4,
+                            } = e;
+                            *ptr2
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(code4);
+                            let vec5 = (message4.into_bytes()).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr2
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len5;
+                            *ptr2
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr5.cast_mut();
+                        }
+                    };
+                    ptr2
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_run<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {
+                            let l1 = *arg0
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                        _ => {
+                            let l3 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l4 = *arg0
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l3, l4, 1);
+                        }
+                    }
+                }
+                pub trait Guest {
+                    /// Return a JSON-encoded `CliSchema`. The host uses it to build clap help,
+                    /// validation, and completion definitions before invoking the plugin.
+                    fn schema() -> Result<_rt::String, PluginError>;
+                    /// Run a JSON-encoded `CliInvocation`. On success, return a JSON-encoded
+                    /// `CliOutput`; the host renders its structured records for the active
+                    /// output surface (for example, a table in the terminal).
+                    fn run(
+                        invocation_json: _rt::String,
+                    ) -> Result<_rt::String, PluginError>;
+                }
+                #[doc(hidden)]
+                macro_rules! __export_thoth_plugin_plugin_cli_0_1_0_cabi {
+                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
+                        const _ : () = { #[unsafe (export_name =
+                        "thoth:plugin/plugin-cli@0.1.0#schema")] unsafe extern "C" fn
+                        export_schema() -> * mut u8 { unsafe { $($path_to_types)*::
+                        _export_schema_cabi::<$ty > () } } #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/plugin-cli@0.1.0#schema")] unsafe extern
+                        "C" fn _post_return_schema(arg0 : * mut u8,) { unsafe {
+                        $($path_to_types)*:: __post_return_schema::<$ty > (arg0) } }
+                        #[unsafe (export_name = "thoth:plugin/plugin-cli@0.1.0#run")]
+                        unsafe extern "C" fn export_run(arg0 : * mut u8, arg1 : usize,)
+                        -> * mut u8 { unsafe { $($path_to_types)*::
+                        _export_run_cabi::<$ty > (arg0, arg1) } } #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/plugin-cli@0.1.0#run")] unsafe extern "C"
+                        fn _post_return_run(arg0 : * mut u8,) { unsafe {
+                        $($path_to_types)*:: __post_return_run::<$ty > (arg0) } } };
+                    };
+                }
+                #[doc(hidden)]
+                pub(crate) use __export_thoth_plugin_plugin_cli_0_1_0_cabi;
+                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                struct _RetArea(
+                    [::core::mem::MaybeUninit<
+                        u8,
+                    >; 4 * ::core::mem::size_of::<*const u8>()],
+                );
+                static mut _RET_AREA: _RetArea = _RetArea(
+                    [::core::mem::MaybeUninit::uninit(); 4
+                        * ::core::mem::size_of::<*const u8>()],
+                );
+            }
+            /// ---------------------------------------------------------------------------
             /// data-source — implement when capability = data-source
             ///
             /// Connects Thoth to an external system: REST API, database, message queue,
@@ -5514,11 +5714,14 @@ mod _rt {
 /// ```
 #[allow(unused_macros)]
 #[doc(hidden)]
-macro_rules! __export_data_source_plugin_impl {
+macro_rules! __export_data_source_cli_plugin_impl {
     ($ty:ident) => {
         self::export!($ty with_types_in self);
     };
     ($ty:ident with_types_in $($path_to_types_root:tt)*) => {
+        $($path_to_types_root)*::
+        exports::thoth::plugin::plugin_cli::__export_thoth_plugin_plugin_cli_0_1_0_cabi!($ty
+        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_cli);
         $($path_to_types_root)*::
         exports::thoth::plugin::data_source::__export_thoth_plugin_data_source_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::data_source);
@@ -5543,16 +5746,16 @@ macro_rules! __export_data_source_plugin_impl {
     };
 }
 #[doc(inline)]
-pub(crate) use __export_data_source_plugin_impl as export;
+pub(crate) use __export_data_source_cli_plugin_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[unsafe(
-    link_section = "component-type:wit-bindgen:0.41.0:thoth:plugin@0.1.0:data-source-plugin:encoded world"
+    link_section = "component-type:wit-bindgen:0.41.0:thoth:plugin@0.1.0:data-source-cli-plugin:encoded world"
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3684] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xdb\x1b\x01A\x02\x01\
-A)\x01B\x0a\x01m\x09\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3804] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xcf\x1c\x01A\x02\x01\
+A+\x01B\x0a\x01m\x09\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
 search-provider\x10new-ui-component\x0ddata-producer\x08renderer\x03cli\x04\0\x0a\
 capability\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescri\
 ptions\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0bpl\
@@ -5600,41 +5803,44 @@ r\x02\x04paths\x08contentss\x04\0\x0bopened-file\x03\0\x02\x01ps\x01k\x03\x01j\x
 \x05\x01\x01\x01@\x02\x05titles\x0aextensions\x04\0\x06\x04\0\x09open-file\x01\x07\
 \x01ks\x01j\x01\x08\x01\x01\x01@\x04\x05titles\x0cdefault-names\x0aextensions\x04\
 \x08contentss\0\x09\x04\0\x09save-file\x01\x0a\x03\0\x1ethoth:plugin/file-dialog\
-@0.1.0\x05\x0d\x01B\x1c\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\
-\x04names\x0bdescriptions\x08required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\
-\x01r\x03\x04names\x09type-hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\
-\x01p\x05\x01r\x02\x04names\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\
-\x09node-jsons\x0bheight-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\
-\x04\0\x0frequired-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\
-\x04\0\x07connect\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\
-\x04\0\x06schema\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01\
-@\x01\x06handles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06h\
-andles\0\x14\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.\
-0\x05\x0e\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09\
-widget-ids\x04kinds\x05values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\
-\x0bheight-hinty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\
-\0\x09render-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\
-\x01k\x05\x01j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\
-\x1fthoth:plugin/ui-component@0.1.0\x05\x0f\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\
-\0\x08tab-icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\
-\x01j\0\x01\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\
-\x01\0\x04\0\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0d\
-on-tab-closed\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.0\x05\x10\x01B\x0c\x02\x03\
-\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04names\x09type-hints\x04\0\
-\x0edataset-column\x03\0\x02\x01p\x03\x01ps\x01p\x05\x01r\x04\x04names\x04kinds\x07\
-columns\x04\x04rows\x06\x04\0\x07dataset\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\
-\x09\x04\0\x0fprovide-dataset\x01\x0a\x04\0\x20thoth:plugin/data-producer@0.1.0\x05\
-\x11\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x12\x04\0\x0bplugin-inf\
-o\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-me\
-ta@0.1.0\x05\x13\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\
-\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:\
-plugin/plugin-lifecycle@0.1.0\x05\x14\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplug\
-in-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\
-\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\
-\0\"thoth:plugin/plugin-settings@0.1.0\x05\x15\x04\0%thoth:plugin/data-source-pl\
-ugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\x01\
-\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
+@0.1.0\x05\x0d\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01j\x01\
+s\x01\x01\x01@\0\0\x02\x04\0\x06schema\x01\x03\x01@\x01\x0finvocation-jsons\0\x02\
+\x04\0\x03run\x01\x04\x04\0\x1dthoth:plugin/plugin-cli@0.1.0\x05\x0e\x01B\x1c\x02\
+\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x04\x04names\x0bdescriptions\
+\x08required\x7f\x05values\x04\0\x0cconfig-entry\x03\0\x02\x01r\x03\x04names\x09\
+type-hints\x08nullable\x7f\x04\0\x0cfield-schema\x03\0\x04\x01p\x05\x01r\x02\x04\
+names\x06fields\x06\x04\0\x0dsource-schema\x03\0\x07\x01r\x02\x09node-jsons\x0bh\
+eight-hinty\x04\0\x0bpane-output\x03\0\x09\x01p\x03\x01@\0\0\x0b\x04\0\x0frequir\
+ed-config\x01\x0c\x01j\x01s\x01\x01\x01@\x01\x06config\x0b\0\x0d\x04\0\x07connec\
+t\x01\x0e\x01p\x08\x01j\x01\x0f\x01\x01\x01@\x01\x06handles\0\x10\x04\0\x06schem\
+a\x01\x11\x01@\x02\x06handles\x01qs\0\x0d\x04\0\x05query\x01\x12\x01@\x01\x06han\
+dles\x01\0\x04\0\x05close\x01\x13\x01j\x01\x0a\x01\x01\x01@\x01\x06handles\0\x14\
+\x04\0\x0brender-pane\x01\x15\x04\0\x1ethoth:plugin/data-source@0.1.0\x05\x0f\x01\
+B\x0f\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x03\x09widget-ids\x04\
+kinds\x05values\x04\0\x08ui-event\x03\0\x02\x01r\x02\x09node-jsons\x0bheight-hin\
+ty\x04\0\x09ui-output\x03\0\x04\x01j\x01\x05\x01\x01\x01@\0\0\x06\x04\0\x09rende\
+r-ui\x01\x07\x01@\x01\x05event\x03\0\x06\x04\0\x0chandle-event\x01\x08\x01k\x05\x01\
+j\x01\x09\x01\x01\x01@\0\0\x0a\x04\0\x0erender-sidebar\x01\x0b\x04\0\x1fthoth:pl\
+ugin/ui-component@0.1.0\x05\x10\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-err\
+or\x03\0\0\x01@\0\0s\x04\0\x09tab-title\x01\x02\x01ks\x01@\0\0\x03\x04\0\x08tab-\
+icon\x01\x04\x01j\x01s\x01\x01\x01@\0\0\x05\x04\0\x09get-state\x01\x06\x01j\0\x01\
+\x01\x01@\x01\x05states\0\x07\x04\0\x0finit-with-state\x01\x08\x01@\0\x01\0\x04\0\
+\x0eon-tab-focused\x01\x09\x04\0\x0eon-tab-blurred\x01\x09\x04\0\x0don-tab-close\
+d\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.0\x05\x11\x01B\x0c\x02\x03\x02\x01\x01\
+\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x04names\x09type-hints\x04\0\x0edataset-\
+column\x03\0\x02\x01p\x03\x01ps\x01p\x05\x01r\x04\x04names\x04kinds\x07columns\x04\
+\x04rows\x06\x04\0\x07dataset\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\x09\x04\0\x0f\
+provide-dataset\x01\x0a\x04\0\x20thoth:plugin/data-producer@0.1.0\x05\x12\x02\x03\
+\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x13\x04\0\x0bplugin-info\x03\0\0\x01\
+@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-meta@0.1.0\x05\x14\
+\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\0\x01\0\x04\0\x08\
+on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:plugin/plugin-life\
+cycle@0.1.0\x05\x15\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01\
+r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\
+\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugi\
+n-settings@0.1.0\x05\x16\x04\0)thoth:plugin/data-source-cli-plugin@0.1.0\x04\0\x0b\
+\x1c\x01\0\x16data-source-cli-plugin\x03\0\0\0G\x09producers\x01\x0cprocessed-by\
+\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/seshat/src/bindings.rs
+++ b/plugins/seshat/src/bindings.rs
@@ -33,6 +33,8 @@ pub mod thoth {
                 /// data-renderer.render and appears as an extra view format in a
                 /// DataView (alongside table / json / raw).
                 Renderer,
+                /// Exposes commands through the optional plugin-cli interface.
+                Cli,
             }
             impl ::core::fmt::Debug for Capability {
                 fn fmt(
@@ -64,6 +66,7 @@ pub mod thoth {
                         Capability::Renderer => {
                             f.debug_tuple("Capability::Renderer").finish()
                         }
+                        Capability::Cli => f.debug_tuple("Capability::Cli").finish(),
                     }
                 }
             }
@@ -82,6 +85,7 @@ pub mod thoth {
                         5 => Capability::NewUiComponent,
                         6 => Capability::DataProducer,
                         7 => Capability::Renderer,
+                        8 => Capability::Cli,
                         _ => panic!("invalid enum discriminant"),
                     }
                 }
@@ -5546,27 +5550,27 @@ pub(crate) use __export_data_source_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3680] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xd7\x1b\x01A\x02\x01\
-A)\x01B\x0a\x01m\x08\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
-search-provider\x10new-ui-component\x0ddata-producer\x08renderer\x04\0\x0acapabi\
-lity\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescriptions\
-\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplugin-i\
-nfo\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\x01r\
-\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugin/typ\
-es@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01o\x02ss\x01p\x02\x01p}\x01k\x04\x01r\x04\x03urls\x06meth\
-ods\x07headers\x03\x04body\x05\x04\0\x0chttp-request\x03\0\x06\x01r\x03\x06statu\
-s{\x07headers\x03\x04body\x04\x04\0\x0dhttp-response\x03\0\x08\x01j\x01\x09\x01\x01\
-\x01@\x01\x03req\x07\0\x0a\x04\0\x05fetch\x01\x0b\x01@\x01\x03req\x07\0s\x04\0\x06\
-submit\x01\x0c\x03\0\x1ethoth:plugin/http-client@0.1.0\x05\x02\x01B\x05\x01@\0\0\
-s\x04\0\x04read\x01\0\x01j\0\x01s\x01@\x01\x04datas\0\x01\x04\0\x05write\x01\x02\
-\x03\0!thoth:plugin/plugin-storage@0.1.0\x05\x03\x01B\x03\x01ks\x01@\x03\x05titl\
-es\x04icon\0\x0dinitial-state\0\0s\x04\0\x08open-tab\x01\x01\x03\0\x1athoth:plug\
-in/ui-tabs@0.1.0\x05\x04\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\
-\0\x01j\x01w\x01\x01\x01@\x03\x04hosts\x04port{\x03tls\x7f\0\x02\x04\0\x07connec\
-t\x01\x03\x01p}\x01j\x01\x04\x01\x01\x01@\x02\x02idw\x03maxy\0\x05\x04\0\x04read\
-\x01\x06\x01j\x01y\x01\x01\x01@\x02\x02idw\x05bytes\x04\0\x07\x04\0\x05write\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3684] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xdb\x1b\x01A\x02\x01\
+A)\x01B\x0a\x01m\x09\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
+search-provider\x10new-ui-component\x0ddata-producer\x08renderer\x03cli\x04\0\x0a\
+capability\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescri\
+ptions\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0bpl\
+ugin-info\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\
+\x01r\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugi\
+n/types@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x0f\x02\x03\x02\x01\x01\x04\
+\0\x0cplugin-error\x03\0\0\x01o\x02ss\x01p\x02\x01p}\x01k\x04\x01r\x04\x03urls\x06\
+methods\x07headers\x03\x04body\x05\x04\0\x0chttp-request\x03\0\x06\x01r\x03\x06s\
+tatus{\x07headers\x03\x04body\x04\x04\0\x0dhttp-response\x03\0\x08\x01j\x01\x09\x01\
+\x01\x01@\x01\x03req\x07\0\x0a\x04\0\x05fetch\x01\x0b\x01@\x01\x03req\x07\0s\x04\
+\0\x06submit\x01\x0c\x03\0\x1ethoth:plugin/http-client@0.1.0\x05\x02\x01B\x05\x01\
+@\0\0s\x04\0\x04read\x01\0\x01j\0\x01s\x01@\x01\x04datas\0\x01\x04\0\x05write\x01\
+\x02\x03\0!thoth:plugin/plugin-storage@0.1.0\x05\x03\x01B\x03\x01ks\x01@\x03\x05\
+titles\x04icon\0\x0dinitial-state\0\0s\x04\0\x08open-tab\x01\x01\x03\0\x1athoth:\
+plugin/ui-tabs@0.1.0\x05\x04\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\
+\0\0\x01j\x01w\x01\x01\x01@\x03\x04hosts\x04port{\x03tls\x7f\0\x02\x04\0\x07conn\
+ect\x01\x03\x01p}\x01j\x01\x04\x01\x01\x01@\x02\x02idw\x03maxy\0\x05\x04\0\x04re\
+ad\x01\x06\x01j\x01y\x01\x01\x01@\x02\x02idw\x05bytes\x04\0\x07\x04\0\x05write\x01\
 \x08\x01j\0\x01\x01\x01@\x02\x02idw\x04hosts\0\x09\x04\0\x09start-tls\x01\x0a\x01\
 @\x01\x02idw\x01\0\x04\0\x05close\x01\x0b\x03\0\x1dthoth:plugin/tcp-client@0.1.0\
 \x05\x05\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01j\0\x01\x01\

--- a/plugins/seshat/src/cli.rs
+++ b/plugins/seshat/src/cli.rs
@@ -4,9 +4,12 @@ use serde_json::{json, Map, Value};
 use thoth_plugin_sdk::cli::{
     CliArg, CliArgKind, CliInvocation, CliOutput, CliSchema, CliSubcommand,
 };
+use url::Url;
 
 use crate::{
     db::{self, AuthMode, Engine, Profile},
+    query::{self, Bound},
+    service,
     state::STATE,
 };
 
@@ -19,7 +22,7 @@ pub(crate) fn schema() -> CliSchema {
             "thoth seshat ping production".into(),
             "thoth seshat indices production".into(),
             "thoth seshat query production -q 'select * from logs'".into(),
-            "thoth seshat ping --connection-string 'postgres://user:password@localhost:5432/postgres'".into(),
+            "THOTH_SESHAT_PASSWORD=secret thoth seshat ping --connection-string 'postgres://user@localhost:5432/postgres'".into(),
         ],
         subcommands: vec![
             CliSubcommand {
@@ -34,7 +37,7 @@ pub(crate) fn schema() -> CliSchema {
                 args: connection_args(),
                 examples: vec![
                     "thoth seshat ping production".into(),
-                    "thoth seshat ping --connection-string 'postgres://user:password@localhost:5432/postgres'".into(),
+                    "THOTH_SESHAT_PASSWORD=secret thoth seshat ping --connection-string 'postgres://user@localhost:5432/postgres'".into(),
                 ],
             },
             CliSubcommand {
@@ -48,7 +51,7 @@ pub(crate) fn schema() -> CliSchema {
             },
             CliSubcommand {
                 name: "query".into(),
-                about: "Run a query and emit one JSON object per row".into(),
+                about: "Run a query and render the returned rows as a table".into(),
                 args: {
                     let mut args = connection_args();
                     args.extend([
@@ -82,7 +85,7 @@ pub(crate) fn schema() -> CliSchema {
                 examples: vec![
                     "thoth seshat query production -q 'select * from logs' --limit 100".into(),
                     "thoth seshat query elastic-local --index logs -q '{\"query\":{\"match_all\":{}}}'".into(),
-                    "thoth seshat query --connection-string 'mysql://root:password@localhost:3306/app' -q 'show tables'".into(),
+                    "THOTH_SESHAT_PASSWORD=secret thoth seshat query --connection-string 'mysql://root@localhost:3306/app' -q 'select * from users'".into(),
                 ],
             },
         ],
@@ -93,7 +96,7 @@ fn connection_args() -> Vec<CliArg> {
     vec![
         CliArg {
             id: "connection".into(),
-            help: "Saved connection id or display name".into(),
+            help: "Saved connection id (preferred) or unique display name".into(),
             required: false,
             kind: CliArgKind::Positional {
                 value_name: "CONNECTION".into(),
@@ -112,7 +115,7 @@ fn connection_args() -> Vec<CliArg> {
             "connection-string",
             None,
             "URL",
-            "Connection URL; otherwise use a saved Seshat connection",
+            "Connection URL; saved connections are preferred. Inline passwords are exposed in process arguments and shell history; omit the password and set THOTH_SESHAT_PASSWORD instead",
             false,
         ),
     ]
@@ -156,10 +159,9 @@ pub(crate) fn run(invocation: CliInvocation) -> Result<CliOutput, String> {
         return Ok(CliOutput { records });
     }
     let (engine, profile) = connection(&invocation.values)?;
-    let adapter = db::adapter(engine);
     match invocation.subcommand.as_str() {
         "ping" => {
-            let detail = adapter.test_connection(&profile)?;
+            let detail = service::test_connection(engine, &profile)?;
             Ok(CliOutput::one(json!({
                 "status": "ok",
                 "engine": engine_name(engine),
@@ -168,14 +170,12 @@ pub(crate) fn run(invocation: CliInvocation) -> Result<CliOutput, String> {
         }
         "indices" => {
             let records = if engine == Engine::Elasticsearch {
-                adapter
-                    .list_tables(&profile, "_all")?
+                service::list_indices(engine, &profile)?
                     .into_iter()
                     .map(|table| json!({ "index": table.name }))
                     .collect()
             } else {
-                adapter
-                    .list_databases(&profile)?
+                service::list_databases(engine, &profile)?
                     .into_iter()
                     .map(|database| json!({ "database": database }))
                     .collect()
@@ -193,8 +193,18 @@ pub(crate) fn run(invocation: CliInvocation) -> Result<CliOutput, String> {
             if limit == 0 {
                 return Err("--limit must be greater than zero".into());
             }
-            let query = cap_query(engine, string(&invocation.values, "index"), query, limit);
-            let result = adapter.run_query(&profile, &query)?;
+            let query = if engine == Engine::Elasticsearch {
+                string(&invocation.values, "index")
+                    .map(|index| format!("{index}\n{query}"))
+                    .unwrap_or_else(|| query.to_string())
+            } else {
+                query.to_string()
+            };
+            let prepared = query::prepare(engine, &query, limit);
+            if prepared.bound == Bound::Unavailable {
+                return Err("query cannot be safely bounded; use a read query with an explicit result limit".into());
+            }
+            let result = service::run_query(engine, &profile, &prepared.sql)?;
             let names: Vec<String> = result
                 .columns
                 .into_iter()
@@ -249,9 +259,8 @@ fn connection(values: &Map<String, Value>) -> Result<(Engine, Profile), String> 
 }
 
 fn parse_connection_url(url: &str, requested: Option<&str>) -> Result<(Engine, Profile), String> {
-    let (scheme, rest) = url
-        .split_once("://")
-        .ok_or_else(|| "connection string must be a URL".to_string())?;
+    let parsed = Url::parse(url).map_err(|error| format!("invalid connection URL: {error}"))?;
+    let scheme = parsed.scheme();
     let inferred = match scheme {
         "postgres" | "postgresql" => Engine::Postgres,
         "mysql" => Engine::Mysql,
@@ -259,22 +268,30 @@ fn parse_connection_url(url: &str, requested: Option<&str>) -> Result<(Engine, P
         _ => return Err(format!("unsupported connection scheme '{scheme}'")),
     };
     let engine = requested.map(parse_engine).transpose()?.unwrap_or(inferred);
-    let (credentials, address) = rest.rsplit_once('@').unwrap_or(("", rest));
-    let (user, password) = credentials.split_once(':').unwrap_or((credentials, ""));
-    let (authority, database) = address.split_once('/').unwrap_or((address, ""));
     let defaults = db::adapter(engine).connection_defaults();
-    let (host, port) = authority
-        .rsplit_once(':')
-        .map(|(host, port)| {
-            port.parse::<u16>()
-                .map(|port| (host, port))
-                .map_err(|_| "connection URL has an invalid port".to_string())
-        })
-        .transpose()?
-        .unwrap_or((authority, defaults.port));
-    if host.is_empty() {
-        return Err("connection URL has no host".into());
-    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "connection URL has no host".to_string())?
+        .trim_start_matches('[')
+        .trim_end_matches(']');
+    let port = parsed.port().unwrap_or(defaults.port);
+    let decode = |value: &str| {
+        percent_encoding::percent_decode_str(value)
+            .decode_utf8()
+            .map(|value| value.into_owned())
+            .map_err(|error| format!("connection URL contains invalid UTF-8: {error}"))
+    };
+    let user = decode(parsed.username())?;
+    let inline_password = parsed.password().map(decode).transpose()?;
+    let password = inline_password
+        .or_else(|| std::env::var("THOTH_SESHAT_PASSWORD").ok())
+        .unwrap_or_default();
+    let database = decode(parsed.path().trim_start_matches('/'))?;
+    let auth = if engine == Engine::Elasticsearch && user.is_empty() && password.is_empty() {
+        AuthMode::None
+    } else {
+        AuthMode::Password
+    };
     Ok((
         engine,
         Profile {
@@ -283,35 +300,18 @@ fn parse_connection_url(url: &str, requested: Option<&str>) -> Result<(Engine, P
             database: if database.is_empty() {
                 defaults.database.into()
             } else {
-                database.into()
+                database
             },
             user: if user.is_empty() {
                 defaults.user.into()
             } else {
-                user.into()
+                user
             },
-            password: password.into(),
+            password: password.clone(),
             tls: scheme == "https",
-            auth: if engine == Engine::Elasticsearch && user.is_empty() && password.is_empty() {
-                AuthMode::None
-            } else {
-                AuthMode::Password
-            },
+            auth,
         },
     ))
-}
-
-fn cap_query(engine: Engine, index: Option<&str>, query: &str, limit: usize) -> String {
-    if engine == Engine::Elasticsearch {
-        let query = if let Some(index) = index {
-            format!("{index}\n{query}")
-        } else {
-            query.to_string()
-        };
-        crate::es::cap(&query, limit).unwrap_or(query)
-    } else {
-        crate::sql::add_limit(query, limit).unwrap_or_else(|| query.to_string())
-    }
 }
 
 fn string<'a>(values: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
@@ -337,7 +337,7 @@ fn engine_name(engine: Engine) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{cap_query, parse_connection_url, schema};
+    use super::{parse_connection_url, schema};
     use crate::db::Engine;
 
     #[test]
@@ -361,10 +361,14 @@ mod tests {
     }
 
     #[test]
-    fn caps_sql_queries() {
-        assert_eq!(
-            cap_query(Engine::Postgres, None, "select * from logs", 25),
-            "select * from logs LIMIT 25"
-        );
+    fn parses_percent_encoded_credentials_and_ipv6() {
+        let (_, profile) =
+            parse_connection_url("postgres://alice%40example:p%40ss@[::1]:5440/my%20db", None)
+                .unwrap();
+        assert_eq!(profile.user, "alice@example");
+        assert_eq!(profile.password, "p@ss");
+        assert_eq!(profile.host, "::1");
+        assert_eq!(profile.port, 5440);
+        assert_eq!(profile.database, "my db");
     }
 }

--- a/plugins/seshat/src/cli.rs
+++ b/plugins/seshat/src/cli.rs
@@ -1,0 +1,370 @@
+//! Seshat's display-free commands, exported through `plugin-cli` WIT.
+
+use serde_json::{json, Map, Value};
+use thoth_plugin_sdk::cli::{
+    CliArg, CliArgKind, CliInvocation, CliOutput, CliSchema, CliSubcommand,
+};
+
+use crate::{
+    db::{self, AuthMode, Engine, Profile},
+    state::STATE,
+};
+
+pub(crate) fn schema() -> CliSchema {
+    CliSchema {
+        id: "seshat".into(),
+        about: "Query PostgreSQL, MySQL, or Elasticsearch".into(),
+        examples: vec![
+            "thoth seshat connections".into(),
+            "thoth seshat ping production".into(),
+            "thoth seshat indices production".into(),
+            "thoth seshat query production -q 'select * from logs'".into(),
+            "thoth seshat ping --connection-string 'postgres://user:password@localhost:5432/postgres'".into(),
+        ],
+        subcommands: vec![
+            CliSubcommand {
+                name: "connections".into(),
+                about: "List saved Seshat connections".into(),
+                args: vec![],
+                examples: vec!["thoth seshat connections".into()],
+            },
+            CliSubcommand {
+                name: "ping".into(),
+                about: "Test a database connection".into(),
+                args: connection_args(),
+                examples: vec![
+                    "thoth seshat ping production".into(),
+                    "thoth seshat ping --connection-string 'postgres://user:password@localhost:5432/postgres'".into(),
+                ],
+            },
+            CliSubcommand {
+                name: "indices".into(),
+                about: "List databases or Elasticsearch indices".into(),
+                args: connection_args(),
+                examples: vec![
+                    "thoth seshat indices production".into(),
+                    "thoth seshat indices --connection-string 'http://localhost:9200'".into(),
+                ],
+            },
+            CliSubcommand {
+                name: "query".into(),
+                about: "Run a query and emit one JSON object per row".into(),
+                args: {
+                    let mut args = connection_args();
+                    args.extend([
+                        option(
+                            "index",
+                            "index",
+                            None,
+                            "INDEX",
+                            "Elasticsearch index",
+                            false,
+                        ),
+                        option(
+                            "query",
+                            "query",
+                            Some('q'),
+                            "QUERY",
+                            "SQL, ES|QL, or Query DSL",
+                            true,
+                        ),
+                        option(
+                            "limit",
+                            "limit",
+                            None,
+                            "ROWS",
+                            "Maximum returned rows",
+                            false,
+                        ),
+                    ]);
+                    args
+                },
+                examples: vec![
+                    "thoth seshat query production -q 'select * from logs' --limit 100".into(),
+                    "thoth seshat query elastic-local --index logs -q '{\"query\":{\"match_all\":{}}}'".into(),
+                    "thoth seshat query --connection-string 'mysql://root:password@localhost:3306/app' -q 'show tables'".into(),
+                ],
+            },
+        ],
+    }
+}
+
+fn connection_args() -> Vec<CliArg> {
+    vec![
+        CliArg {
+            id: "connection".into(),
+            help: "Saved connection id or display name".into(),
+            required: false,
+            kind: CliArgKind::Positional {
+                value_name: "CONNECTION".into(),
+            },
+        },
+        option(
+            "engine",
+            "engine",
+            None,
+            "ENGINE",
+            "postgres, mysql, or elasticsearch",
+            false,
+        ),
+        option(
+            "connection_string",
+            "connection-string",
+            None,
+            "URL",
+            "Connection URL; otherwise use a saved Seshat connection",
+            false,
+        ),
+    ]
+}
+
+fn option(
+    id: &str,
+    long: &str,
+    short: Option<char>,
+    value_name: &str,
+    help: &str,
+    required: bool,
+) -> CliArg {
+    CliArg {
+        id: id.into(),
+        help: help.into(),
+        required,
+        kind: CliArgKind::Option {
+            long: long.into(),
+            short,
+            value_name: value_name.into(),
+        },
+    }
+}
+
+pub(crate) fn run(invocation: CliInvocation) -> Result<CliOutput, String> {
+    if invocation.subcommand == "connections" {
+        let records = crate::state::saved_connections()
+            .into_iter()
+            .map(|connection| {
+                json!({
+                    "id": connection.id,
+                    "name": connection.name,
+                    "engine": engine_name(connection.engine),
+                    "host": connection.host,
+                    "port": connection.port,
+                    "database": connection.database,
+                })
+            })
+            .collect();
+        return Ok(CliOutput { records });
+    }
+    let (engine, profile) = connection(&invocation.values)?;
+    let adapter = db::adapter(engine);
+    match invocation.subcommand.as_str() {
+        "ping" => {
+            let detail = adapter.test_connection(&profile)?;
+            Ok(CliOutput::one(json!({
+                "status": "ok",
+                "engine": engine_name(engine),
+                "detail": detail,
+            })))
+        }
+        "indices" => {
+            let records = if engine == Engine::Elasticsearch {
+                adapter
+                    .list_tables(&profile, "_all")?
+                    .into_iter()
+                    .map(|table| json!({ "index": table.name }))
+                    .collect()
+            } else {
+                adapter
+                    .list_databases(&profile)?
+                    .into_iter()
+                    .map(|database| json!({ "database": database }))
+                    .collect()
+            };
+            Ok(CliOutput { records })
+        }
+        "query" => {
+            let query = string(&invocation.values, "query")
+                .ok_or_else(|| "query requires --query/-q".to_string())?;
+            let limit = string(&invocation.values, "limit")
+                .map(|value| value.parse::<usize>())
+                .transpose()
+                .map_err(|_| "--limit must be a positive integer".to_string())?
+                .unwrap_or(100);
+            if limit == 0 {
+                return Err("--limit must be greater than zero".into());
+            }
+            let query = cap_query(engine, string(&invocation.values, "index"), query, limit);
+            let result = adapter.run_query(&profile, &query)?;
+            let names: Vec<String> = result
+                .columns
+                .into_iter()
+                .map(|column| column.name)
+                .collect();
+            let records = result
+                .rows
+                .into_iter()
+                .take(limit)
+                .map(|row| {
+                    let mut record = Map::new();
+                    for (index, name) in names.iter().enumerate() {
+                        record.insert(name.clone(), row.get(index).cloned().unwrap_or(Value::Null));
+                    }
+                    Value::Object(record)
+                })
+                .collect();
+            Ok(CliOutput { records })
+        }
+        command => Err(format!("unsupported Seshat command '{command}'")),
+    }
+}
+
+fn connection(values: &Map<String, Value>) -> Result<(Engine, Profile), String> {
+    if let Some(url) = string(values, "connection_string") {
+        return parse_connection_url(url, string(values, "engine"));
+    }
+    if let Some(name) = string(values, "connection") {
+        let (engine, profile) = crate::state::saved_profile(name)?;
+        if let Some(requested) = string(values, "engine") {
+            let requested = parse_engine(requested)?;
+            if requested != engine {
+                return Err(format!(
+                    "saved connection '{name}' uses {}, not {}",
+                    engine_name(engine),
+                    engine_name(requested)
+                ));
+            }
+        }
+        return Ok((engine, profile));
+    }
+    let requested = string(values, "engine").map(parse_engine).transpose()?;
+    STATE.with(|state| {
+        let engine = requested.unwrap_or_else(|| state.engine());
+        let profile = state.query_profile();
+        if profile.host.trim().is_empty() {
+            Err("no saved Seshat connection; pass --connection-string".into())
+        } else {
+            Ok((engine, profile))
+        }
+    })
+}
+
+fn parse_connection_url(url: &str, requested: Option<&str>) -> Result<(Engine, Profile), String> {
+    let (scheme, rest) = url
+        .split_once("://")
+        .ok_or_else(|| "connection string must be a URL".to_string())?;
+    let inferred = match scheme {
+        "postgres" | "postgresql" => Engine::Postgres,
+        "mysql" => Engine::Mysql,
+        "http" | "https" | "elasticsearch" => Engine::Elasticsearch,
+        _ => return Err(format!("unsupported connection scheme '{scheme}'")),
+    };
+    let engine = requested.map(parse_engine).transpose()?.unwrap_or(inferred);
+    let (credentials, address) = rest.rsplit_once('@').unwrap_or(("", rest));
+    let (user, password) = credentials.split_once(':').unwrap_or((credentials, ""));
+    let (authority, database) = address.split_once('/').unwrap_or((address, ""));
+    let defaults = db::adapter(engine).connection_defaults();
+    let (host, port) = authority
+        .rsplit_once(':')
+        .map(|(host, port)| {
+            port.parse::<u16>()
+                .map(|port| (host, port))
+                .map_err(|_| "connection URL has an invalid port".to_string())
+        })
+        .transpose()?
+        .unwrap_or((authority, defaults.port));
+    if host.is_empty() {
+        return Err("connection URL has no host".into());
+    }
+    Ok((
+        engine,
+        Profile {
+            host: host.into(),
+            port,
+            database: if database.is_empty() {
+                defaults.database.into()
+            } else {
+                database.into()
+            },
+            user: if user.is_empty() {
+                defaults.user.into()
+            } else {
+                user.into()
+            },
+            password: password.into(),
+            tls: scheme == "https",
+            auth: if engine == Engine::Elasticsearch && user.is_empty() && password.is_empty() {
+                AuthMode::None
+            } else {
+                AuthMode::Password
+            },
+        },
+    ))
+}
+
+fn cap_query(engine: Engine, index: Option<&str>, query: &str, limit: usize) -> String {
+    if engine == Engine::Elasticsearch {
+        let query = if let Some(index) = index {
+            format!("{index}\n{query}")
+        } else {
+            query.to_string()
+        };
+        crate::es::cap(&query, limit).unwrap_or(query)
+    } else {
+        crate::sql::add_limit(query, limit).unwrap_or_else(|| query.to_string())
+    }
+}
+
+fn string<'a>(values: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
+    values.get(key).and_then(Value::as_str)
+}
+
+fn parse_engine(value: &str) -> Result<Engine, String> {
+    match value {
+        "postgres" | "postgresql" => Ok(Engine::Postgres),
+        "mysql" => Ok(Engine::Mysql),
+        "elasticsearch" | "elastic" | "es" => Ok(Engine::Elasticsearch),
+        _ => Err(format!("unsupported engine '{value}'")),
+    }
+}
+
+fn engine_name(engine: Engine) -> &'static str {
+    match engine {
+        Engine::Postgres => "postgres",
+        Engine::Mysql => "mysql",
+        Engine::Elasticsearch => "elasticsearch",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cap_query, parse_connection_url, schema};
+    use crate::db::Engine;
+
+    #[test]
+    fn schema_is_valid_and_exposes_expected_commands() {
+        let schema = schema();
+        schema.validate().unwrap();
+        assert_eq!(schema.id, "seshat");
+        assert_eq!(schema.subcommands.len(), 4);
+    }
+
+    #[test]
+    fn parses_postgres_connection_url() {
+        let (engine, profile) =
+            parse_connection_url("postgres://alice:secret@db.local:5433/app", None).unwrap();
+        assert_eq!(engine, Engine::Postgres);
+        assert_eq!(profile.host, "db.local");
+        assert_eq!(profile.port, 5433);
+        assert_eq!(profile.database, "app");
+        assert_eq!(profile.user, "alice");
+        assert_eq!(profile.password, "secret");
+    }
+
+    #[test]
+    fn caps_sql_queries() {
+        assert_eq!(
+            cap_query(Engine::Postgres, None, "select * from logs", 25),
+            "select * from logs LIMIT 25"
+        );
+    }
+}

--- a/plugins/seshat/src/es.rs
+++ b/plugins/seshat/src/es.rs
@@ -839,6 +839,18 @@ pub(crate) fn cap(text: &str, n: usize) -> Option<String> {
     }
 }
 
+/// Whether a query already carries an explicit result cap for its dialect.
+pub(crate) fn has_explicit_cap(text: &str) -> bool {
+    match dialect(text) {
+        Dialect::Sql => crate::sql::has_explicit_limit(text),
+        Dialect::Esql => has_esql_limit_stage(text.trim()),
+        Dialect::QueryDsl => split_query(text)
+            .1
+            .as_object()
+            .is_some_and(|body| body.contains_key("size")),
+    }
+}
+
 /// Cap a Query-DSL search to `n` hits by injecting `"size": n` into its body.
 ///
 /// `n` is clamped to [`MAX_RESULT_WINDOW`] — the server rejects a larger `size`,

--- a/plugins/seshat/src/events.rs
+++ b/plugins/seshat/src/events.rs
@@ -8,6 +8,7 @@ use crate::bindings::thoth::plugin::dataset_bus::{self, DatasetColumn};
 use crate::bindings::thoth::plugin::signals::{self, Status as SignalStatus};
 use crate::bindings::thoth::plugin::{file_dialog, secure_storage, ui_tabs};
 use crate::db::{self, ColumnInfo, TableInfo};
+use crate::query::{self, Bound};
 use crate::sql;
 use crate::state::{
     engine_from_value, make_id, pw_key, record_history, save_connections, submit, Connection,
@@ -455,19 +456,11 @@ fn execute_current(st: &mut State) {
     // Push a "running" signal to the host status bar; the result handler
     // overwrites it with the row count + latency (Ready) or an Error.
     signals::emit_signal("rows", "", SignalStatus::Loading, 0);
-    // Elasticsearch caps rows per query dialect (Query-DSL `size`, SQL/ES|QL
-    // LIMIT); both use the same +1 sentinel-row convention as the SQL engines.
-    let capped = if st.engine() == crate::db::Engine::Elasticsearch {
-        crate::es::cap(&base, st.row_limit + 1)
-    } else {
-        sql::add_limit(&base, st.row_limit + 1)
-    };
-    let (sql, limited) = match capped {
-        Some(c) => (c, true),
-        None => (base, false),
-    };
-    st.run_limited = limited;
-    submit(&Request::Query { sql }, Kind::Query, st);
+    // Query preparation is shared with the CLI. The UI requests one sentinel
+    // row so it can reveal "Load more" when Seshat applied the bound itself.
+    let prepared = query::prepare(st.engine(), &base, st.row_limit + 1);
+    st.run_limited = prepared.bound == Bound::Applied;
+    submit(&Request::Query { sql: prepared.sql }, Kind::Query, st);
 }
 
 /// Lazily run `EXPLAIN ANALYZE` for the **last-run** query — triggered when the

--- a/plugins/seshat/src/lib.rs
+++ b/plugins/seshat/src/lib.rs
@@ -1,5 +1,6 @@
 #[rustfmt::skip]
 mod bindings;
+mod cli;
 mod constants;
 mod db;
 mod es;
@@ -21,6 +22,7 @@ use bindings::exports::thoth::plugin::{
         PluginError as ProducerError,
     },
     data_source::{ConfigEntry, Guest as DataSourceGuest, PaneOutput, PluginError, SourceSchema},
+    plugin_cli::Guest as CliGuest,
     plugin_lifecycle::Guest as LifecycleGuest,
     plugin_settings::{Guest as SettingsGuest, SettingsOutput},
     tab_host::Guest as TabHostGuest,
@@ -67,11 +69,42 @@ pub(crate) const ICON_CHART_BAR: &str = "\u{E150}"; // Stats result tab
     name = "Seshat",
     version = "0.1.0",
     description = "Database client for Thoth",
-    capabilities = [DataSource, NewUiComponent],
+    capabilities = [DataSource, NewUiComponent, Cli],
     author = "Thoth contributors",
     icon = ICON_DATABASE,
 )]
 struct Seshat;
+
+impl CliGuest for Seshat {
+    fn schema() -> Result<String, bindings::exports::thoth::plugin::plugin_cli::PluginError> {
+        serde_json::to_string(&cli::schema()).map_err(|error| {
+            bindings::exports::thoth::plugin::plugin_cli::PluginError {
+                code: 1,
+                message: error.to_string(),
+            }
+        })
+    }
+
+    fn run(
+        invocation_json: String,
+    ) -> Result<String, bindings::exports::thoth::plugin::plugin_cli::PluginError> {
+        let invocation = serde_json::from_str(&invocation_json).map_err(|error| {
+            bindings::exports::thoth::plugin::plugin_cli::PluginError {
+                code: 2,
+                message: format!("invalid CLI invocation: {error}"),
+            }
+        })?;
+        let output = cli::run(invocation).map_err(|message| {
+            bindings::exports::thoth::plugin::plugin_cli::PluginError { code: 3, message }
+        })?;
+        serde_json::to_string(&output).map_err(|error| {
+            bindings::exports::thoth::plugin::plugin_cli::PluginError {
+                code: 4,
+                message: error.to_string(),
+            }
+        })
+    }
+}
 
 // ── shared helpers ────────────────────────────────────────────────────────────
 

--- a/plugins/seshat/src/lib.rs
+++ b/plugins/seshat/src/lib.rs
@@ -8,6 +8,8 @@ mod events;
 mod icons;
 mod mysql;
 mod pg;
+mod query;
+mod service;
 mod shim;
 mod sql;
 mod state;
@@ -69,7 +71,7 @@ pub(crate) const ICON_CHART_BAR: &str = "\u{E150}"; // Stats result tab
     name = "Seshat",
     version = "0.1.0",
     description = "Database client for Thoth",
-    capabilities = [DataSource, NewUiComponent, Cli],
+    capabilities = [DataSource, NewUiComponent, DataProducer, Cli],
     author = "Thoth contributors",
     icon = ICON_DATABASE,
 )]
@@ -241,7 +243,6 @@ impl DataSourceGuest for Seshat {
     /// Dispatch one [`Request`] against the active profile and return its JSON.
     fn query(_handle: String, q: String) -> Result<String, PluginError> {
         let (profile, engine) = STATE.with(|st| (st.query_profile(), st.engine()));
-        let adapter = db::adapter(engine);
         let req: Request =
             serde_json::from_str(&q).map_err(|e| err(2, format!("bad request: {e}")))?;
         // Queries and database listing use the connection's configured database;
@@ -249,14 +250,16 @@ impl DataSourceGuest for Seshat {
         // reconnect there by overriding `database` (Postgres can't introspect a
         // database other than the one it's connected to).
         match req {
-            Request::Query { sql } => to_json(adapter.run_query(&profile, &sql)),
-            Request::TestConnection => to_json(adapter.test_connection(&profile)),
-            Request::ListDatabases => to_json(adapter.list_databases(&profile)),
-            Request::ListSchemas { database } => to_json(adapter.list_schemas(&db::Profile {
-                database,
-                ..profile
-            })),
-            Request::ListTables { database, schema } => to_json(adapter.list_tables(
+            Request::Query { sql } => to_json(service::run_query(engine, &profile, &sql)),
+            Request::TestConnection => to_json(service::test_connection(engine, &profile)),
+            Request::ListDatabases => to_json(service::list_databases(engine, &profile)),
+            Request::ListSchemas { database } => {
+                to_json(db::adapter(engine).list_schemas(&db::Profile {
+                    database,
+                    ..profile
+                }))
+            }
+            Request::ListTables { database, schema } => to_json(db::adapter(engine).list_tables(
                 &db::Profile {
                     database,
                     ..profile
@@ -265,12 +268,14 @@ impl DataSourceGuest for Seshat {
             )),
             // Search scope is the adapter's concern (MySQL is server-wide;
             // Postgres iterates its databases), so query against the base profile.
-            Request::FindTables { query } => to_json(adapter.find_tables(&profile, &query)),
+            Request::FindTables { query } => {
+                to_json(db::adapter(engine).find_tables(&profile, &query))
+            }
             Request::DescribeTable {
                 database,
                 schema,
                 table,
-            } => to_json(adapter.describe_table(
+            } => to_json(db::adapter(engine).describe_table(
                 &db::Profile {
                     database,
                     ..profile
@@ -282,7 +287,7 @@ impl DataSourceGuest for Seshat {
                 database,
                 schema,
                 table,
-            } => to_json(adapter.list_columns(
+            } => to_json(db::adapter(engine).list_columns(
                 &db::Profile {
                     database,
                     ..profile

--- a/plugins/seshat/src/query.rs
+++ b/plugins/seshat/src/query.rs
@@ -1,0 +1,78 @@
+//! Shared query preparation used by every Seshat interface.
+
+use crate::db::Engine;
+
+/// How the server-side result bound was obtained.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Bound {
+    /// Seshat added a bound to the submitted query.
+    Applied,
+    /// The query already contained an explicit bound.
+    Existing,
+    /// The query cannot be safely bounded by Seshat.
+    Unavailable,
+}
+
+/// A query after engine-specific preparation.
+pub(crate) struct Prepared {
+    pub sql: String,
+    pub bound: Bound,
+}
+
+/// Apply the engine-specific server-side row bound, or classify why the query
+/// is left unchanged. UI and CLI callers consume this same result instead of
+/// interpreting the lower-level SQL/Elasticsearch rewriters independently.
+pub(crate) fn prepare(engine: Engine, query: &str, limit: usize) -> Prepared {
+    let applied = if engine == Engine::Elasticsearch {
+        crate::es::cap(query, limit)
+    } else {
+        crate::sql::add_limit(query, limit)
+    };
+    if let Some(sql) = applied {
+        return Prepared {
+            sql,
+            bound: Bound::Applied,
+        };
+    }
+
+    let existing = if engine == Engine::Elasticsearch {
+        crate::es::has_explicit_cap(query)
+    } else {
+        crate::sql::has_explicit_limit(query)
+    };
+    Prepared {
+        sql: query.to_string(),
+        bound: if existing {
+            Bound::Existing
+        } else {
+            Bound::Unavailable
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{prepare, Bound};
+    use crate::db::Engine;
+
+    #[test]
+    fn applies_a_bound_to_plain_selects() {
+        let query = prepare(Engine::Postgres, "select * from logs", 25);
+        assert_eq!(query.sql, "select * from logs LIMIT 25");
+        assert_eq!(query.bound, Bound::Applied);
+    }
+
+    #[test]
+    fn preserves_existing_bounds() {
+        let query = prepare(Engine::Postgres, "SELECT id FROM cr_users LIMIT 10", 200);
+        assert_eq!(query.sql, "SELECT id FROM cr_users LIMIT 10");
+        assert_eq!(query.bound, Bound::Existing);
+    }
+
+    #[test]
+    fn identifies_queries_that_cannot_be_bounded() {
+        let query = prepare(Engine::Mysql, "show tables", 25);
+        assert_eq!(query.sql, "show tables");
+        assert_eq!(query.bound, Bound::Unavailable);
+    }
+}

--- a/plugins/seshat/src/service.rs
+++ b/plugins/seshat/src/service.rs
@@ -1,0 +1,27 @@
+//! Interface-neutral Seshat operations.
+//!
+//! UI events and CLI commands are adapters around this module. Database
+//! selection, connection testing, metadata access, and query execution belong
+//! here so every entry point follows the same path.
+
+use crate::db::{self, Engine, Profile, QueryResult, TableInfo};
+
+pub(crate) fn test_connection(engine: Engine, profile: &Profile) -> Result<String, String> {
+    db::adapter(engine).test_connection(profile)
+}
+
+pub(crate) fn list_databases(engine: Engine, profile: &Profile) -> Result<Vec<String>, String> {
+    db::adapter(engine).list_databases(profile)
+}
+
+pub(crate) fn list_indices(engine: Engine, profile: &Profile) -> Result<Vec<TableInfo>, String> {
+    db::adapter(engine).list_tables(profile, "_all")
+}
+
+pub(crate) fn run_query(
+    engine: Engine,
+    profile: &Profile,
+    sql: &str,
+) -> Result<QueryResult, String> {
+    db::adapter(engine).run_query(profile, sql)
+}

--- a/plugins/seshat/src/sql.rs
+++ b/plugins/seshat/src/sql.rs
@@ -126,29 +126,112 @@ pub(crate) fn add_limit(sql: &str, n: usize) -> Option<String> {
     if !(lower.starts_with("select") || lower.starts_with("with")) {
         return None;
     }
-    // Conservative: any existing `limit` token (even in a subquery) means we
-    // leave the query alone rather than risk a double `LIMIT`.
-    if lower
-        .split(|c: char| !c.is_alphanumeric() && c != '_')
-        .any(|w| w == "limit")
-    {
+    if has_top_level_token(trimmed, "limit") {
         return None;
     }
     Some(format!("{trimmed} LIMIT {n}"))
 }
 
-/// Whether a single read query already contains an explicit `LIMIT` token.
-/// This intentionally mirrors [`add_limit`]'s conservative detection so callers
-/// can distinguish "already capped" from "cannot be capped".
+/// Whether a single read query already contains an outer result `LIMIT`.
 pub(crate) fn has_explicit_limit(sql: &str) -> bool {
     if statements(sql).len() != 1 {
         return false;
     }
     let lower = sql.trim().trim_end_matches(';').trim().to_lowercase();
-    (lower.starts_with("select") || lower.starts_with("with"))
-        && lower
-            .split(|c: char| !c.is_alphanumeric() && c != '_')
-            .any(|word| word == "limit")
+    (lower.starts_with("select") || lower.starts_with("with")) && has_top_level_token(sql, "limit")
+}
+
+/// Find a keyword outside literals, comments, and nested expressions. At depth
+/// zero, `LIMIT` belongs to the outer query result rather than a CTE/subquery.
+fn has_top_level_token(sql: &str, token: &str) -> bool {
+    let chars: Vec<char> = sql.chars().collect();
+    let mut state = State::Normal;
+    let mut tag = String::new();
+    let mut depth = 0usize;
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        let c = chars[i];
+        match state {
+            State::Normal => match c {
+                '\'' => state = State::Single,
+                '"' => state = State::Double,
+                '-' if chars.get(i + 1) == Some(&'-') => {
+                    state = State::Line;
+                    i += 1;
+                }
+                '/' if chars.get(i + 1) == Some(&'*') => {
+                    state = State::Block;
+                    i += 1;
+                }
+                '$' => {
+                    if let Some((t, len)) = dollar_open(&chars, i) {
+                        tag = t;
+                        state = State::Dollar;
+                        i += len - 1;
+                    }
+                }
+                '(' => depth += 1,
+                ')' => depth = depth.saturating_sub(1),
+                _ if depth == 0 && (c.is_alphanumeric() || c == '_') => {
+                    let start = i;
+                    while chars
+                        .get(i + 1)
+                        .is_some_and(|next| next.is_alphanumeric() || *next == '_')
+                    {
+                        i += 1;
+                    }
+                    if chars[start..=i]
+                        .iter()
+                        .collect::<String>()
+                        .eq_ignore_ascii_case(token)
+                    {
+                        return true;
+                    }
+                }
+                _ => {}
+            },
+            State::Single => {
+                if c == '\'' {
+                    if chars.get(i + 1) == Some(&'\'') {
+                        i += 1;
+                    } else {
+                        state = State::Normal;
+                    }
+                }
+            }
+            State::Double => {
+                if c == '"' {
+                    if chars.get(i + 1) == Some(&'"') {
+                        i += 1;
+                    } else {
+                        state = State::Normal;
+                    }
+                }
+            }
+            State::Line => {
+                if c == '\n' {
+                    state = State::Normal;
+                }
+            }
+            State::Block => {
+                if c == '*' && chars.get(i + 1) == Some(&'/') {
+                    state = State::Normal;
+                    i += 1;
+                }
+            }
+            State::Dollar => {
+                if c == '$' {
+                    if let Some(len) = dollar_close(&chars, i, &tag) {
+                        state = State::Normal;
+                        i += len - 1;
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    false
 }
 
 /// The trimmed text of a character range `[start, end)` of `sql`.
@@ -277,5 +360,29 @@ mod tests {
         assert!(!has_explicit_limit("UPDATE t SET a = 1 LIMIT 5"));
         assert_eq!(add_limit("UPDATE t SET a = 1", 101), None);
         assert_eq!(add_limit("SELECT 1; SELECT 2;", 101), None);
+    }
+
+    #[test]
+    fn result_limit_ignores_literals_comments_and_nested_queries() {
+        let literal = "SELECT * FROM logs WHERE message = 'limit'";
+        assert_eq!(
+            add_limit(literal, 101).as_deref(),
+            Some("SELECT * FROM logs WHERE message = 'limit' LIMIT 101")
+        );
+        assert!(!has_explicit_limit(literal));
+
+        let nested = "WITH x AS (SELECT * FROM logs LIMIT 5) SELECT * FROM x";
+        assert_eq!(
+            add_limit(nested, 101).as_deref(),
+            Some("WITH x AS (SELECT * FROM logs LIMIT 5) SELECT * FROM x LIMIT 101")
+        );
+        assert!(!has_explicit_limit(nested));
+
+        let comment = "SELECT * FROM logs /* LIMIT 5 */";
+        assert_eq!(
+            add_limit(comment, 101).as_deref(),
+            Some("SELECT * FROM logs /* LIMIT 5 */ LIMIT 101")
+        );
+        assert!(!has_explicit_limit(comment));
     }
 }

--- a/plugins/seshat/src/sql.rs
+++ b/plugins/seshat/src/sql.rs
@@ -137,6 +137,20 @@ pub(crate) fn add_limit(sql: &str, n: usize) -> Option<String> {
     Some(format!("{trimmed} LIMIT {n}"))
 }
 
+/// Whether a single read query already contains an explicit `LIMIT` token.
+/// This intentionally mirrors [`add_limit`]'s conservative detection so callers
+/// can distinguish "already capped" from "cannot be capped".
+pub(crate) fn has_explicit_limit(sql: &str) -> bool {
+    if statements(sql).len() != 1 {
+        return false;
+    }
+    let lower = sql.trim().trim_end_matches(';').trim().to_lowercase();
+    (lower.starts_with("select") || lower.starts_with("with"))
+        && lower
+            .split(|c: char| !c.is_alphanumeric() && c != '_')
+            .any(|word| word == "limit")
+}
+
 /// The trimmed text of a character range `[start, end)` of `sql`.
 pub(crate) fn slice(sql: &str, start: usize, end: usize) -> String {
     sql.chars()
@@ -259,6 +273,8 @@ mod tests {
         );
         // Already limited, non-select, or multi-statement → untouched.
         assert_eq!(add_limit("SELECT * FROM t LIMIT 5", 101), None);
+        assert!(has_explicit_limit("SELECT * FROM t LIMIT 5"));
+        assert!(!has_explicit_limit("UPDATE t SET a = 1 LIMIT 5"));
         assert_eq!(add_limit("UPDATE t SET a = 1", 101), None);
         assert_eq!(add_limit("SELECT 1; SELECT 2;", 101), None);
     }

--- a/plugins/seshat/src/state.rs
+++ b/plugins/seshat/src/state.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thoth_plugin_sdk::state::PluginState;
 
-use crate::bindings::thoth::plugin::{db_runtime, plugin_storage};
+use crate::bindings::thoth::plugin::{db_runtime, plugin_storage, secure_storage};
 use crate::db::{self, AuthMode, ColumnInfo, Engine, TableDetail, TableInfo};
 
 // ── connection + form models ──────────────────────────────────────────────────
@@ -411,6 +411,35 @@ fn read_persisted() -> Persisted {
         return Persisted::default();
     }
     serde_json::from_str(&raw).unwrap_or_default()
+}
+
+/// Saved connection metadata for display-free commands.
+pub(crate) fn saved_connections() -> Vec<Connection> {
+    read_persisted().connections
+}
+
+/// Resolve an exact saved connection id or display name and load its secret.
+pub(crate) fn saved_profile(name: &str) -> Result<(Engine, db::Profile), String> {
+    let connections = saved_connections();
+    let connection = connections
+        .iter()
+        .find(|connection| connection.id == name || connection.name == name)
+        .ok_or_else(|| format!("saved connection '{name}' was not found"))?;
+    let password = secure_storage::read(&pw_key(&connection.id))
+        .map_err(|error| error.message)?
+        .unwrap_or_default();
+    Ok((
+        connection.engine,
+        db::Profile {
+            host: connection.host.clone(),
+            port: connection.port,
+            database: connection.database.clone(),
+            user: connection.user.clone(),
+            password,
+            tls: connection.tls,
+            auth: connection.auth,
+        },
+    ))
 }
 
 fn write_persisted(p: &Persisted) {

--- a/plugins/seshat/src/state.rs
+++ b/plugins/seshat/src/state.rs
@@ -421,13 +421,37 @@ pub(crate) fn saved_connections() -> Vec<Connection> {
 /// Resolve an exact saved connection id or display name and load its secret.
 pub(crate) fn saved_profile(name: &str) -> Result<(Engine, db::Profile), String> {
     let connections = saved_connections();
-    let connection = connections
-        .iter()
-        .find(|connection| connection.id == name || connection.name == name)
-        .ok_or_else(|| format!("saved connection '{name}' was not found"))?;
-    let password = secure_storage::read(&pw_key(&connection.id))
-        .map_err(|error| error.message)?
-        .unwrap_or_default();
+    let connection = if let Some(connection) = connections.iter().find(|item| item.id == name) {
+        connection
+    } else {
+        let mut matches = connections.iter().filter(|item| item.name == name);
+        let connection = matches
+            .next()
+            .ok_or_else(|| format!("saved connection '{name}' was not found"))?;
+        if matches.next().is_some() {
+            return Err(format!(
+                "saved connection name '{name}' is ambiguous; use its connection id"
+            ));
+        }
+        connection
+    };
+    let password = secure_storage::read(&pw_key(&connection.id)).map_err(|error| error.message)?;
+    let password = match (connection.auth, password) {
+        (AuthMode::None, secret) => secret.unwrap_or_default(),
+        (AuthMode::Password, Some(secret)) | (AuthMode::ApiKey, Some(secret)) => secret,
+        (AuthMode::Password, None) => {
+            return Err(format!(
+                "saved connection '{}' has no stored password",
+                connection.id
+            ));
+        }
+        (AuthMode::ApiKey, None) => {
+            return Err(format!(
+                "saved connection '{}' has no stored API key",
+                connection.id
+            ));
+        }
+    };
     Ok((
         connection.engine,
         db::Profile {

--- a/plugins/url-source/src/bindings.rs
+++ b/plugins/url-source/src/bindings.rs
@@ -4880,6 +4880,155 @@ pub mod exports {
                 );
             }
             /// ---------------------------------------------------------------------------
+            /// Worlds — plugin authors implement one of these
+            ///
+            /// A world declares exactly which interfaces a plugin exports. Pick the
+            /// world that matches your plugin's capabilities. If you implement multiple
+            /// capabilities, implement the combined world or compose component binaries.
+            /// ---------------------------------------------------------------------------
+            /// ---------------------------------------------------------------------------
+            /// plugin-settings — implement on every plugin (trivial no-op is fine)
+            ///
+            /// Lets a plugin own its settings UI. The host calls render-settings() once
+            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
+            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
+            /// back via handle-setting-event(). On Save the host calls get-settings() to
+            /// read the current values for persistence, and calls apply-settings() on the
+            /// next load so the plugin can restore its state.
+            /// ---------------------------------------------------------------------------
+            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
+            pub mod plugin_settings {
+                #[used]
+                #[doc(hidden)]
+                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
+                use super::super::super::super::_rt;
+                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
+                #[derive(Clone)]
+                pub struct SettingsOutput {
+                    /// JSON-encoded UiNode tree (same DSL as ui-component).
+                    pub node_json: _rt::String,
+                    /// Height hint in logical pixels; 0 = auto.
+                    pub height_hint: u32,
+                }
+                impl ::core::fmt::Debug for SettingsOutput {
+                    fn fmt(
+                        &self,
+                        f: &mut ::core::fmt::Formatter<'_>,
+                    ) -> ::core::fmt::Result {
+                        f.debug_struct("SettingsOutput")
+                            .field("node-json", &self.node_json)
+                            .field("height-hint", &self.height_hint)
+                            .finish()
+                    }
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
+                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
+                    let result0 = T::render_settings();
+                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
+                    match result0 {
+                        Ok(e) => {
+                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
+                            let SettingsOutput {
+                                node_json: node_json2,
+                                height_hint: height_hint2,
+                            } = e;
+                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
+                            let ptr3 = vec3.as_ptr().cast::<u8>();
+                            let len3 = vec3.len();
+                            ::core::mem::forget(vec3);
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len3;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr3.cast_mut();
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(height_hint2);
+                        }
+                        Err(e) => {
+                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
+                            let super::super::super::super::thoth::plugin::types::PluginError {
+                                code: code4,
+                                message: message4,
+                            } = e;
+                            *ptr1
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<i32>() = _rt::as_i32(code4);
+                            let vec5 = (message4.into_bytes()).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr1
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>() = len5;
+                            *ptr1
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>() = ptr5.cast_mut();
+                        }
+                    };
+                    ptr1
+                }
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
+                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
+                    match l0 {
+                        0 => {
+                            let l1 = *arg0
+                                .add(::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l2 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l1, l2, 1);
+                        }
+                        _ => {
+                            let l3 = *arg0
+                                .add(2 * ::core::mem::size_of::<*const u8>())
+                                .cast::<*mut u8>();
+                            let l4 = *arg0
+                                .add(3 * ::core::mem::size_of::<*const u8>())
+                                .cast::<usize>();
+                            _rt::cabi_dealloc(l3, l4, 1);
+                        }
+                    }
+                }
+                pub trait Guest {
+                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
+                    fn render_settings() -> Result<SettingsOutput, PluginError>;
+                }
+                #[doc(hidden)]
+                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
+                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
+                        const _ : () = { #[unsafe (export_name =
+                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
+                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
+                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
+                        #[unsafe (export_name =
+                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
+                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
+                        u8,) { unsafe { $($path_to_types)*::
+                        __post_return_render_settings::<$ty > (arg0) } } };
+                    };
+                }
+                #[doc(hidden)]
+                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
+                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
+                struct _RetArea(
+                    [::core::mem::MaybeUninit<
+                        u8,
+                    >; 4 * ::core::mem::size_of::<*const u8>()],
+                );
+                static mut _RET_AREA: _RetArea = _RetArea(
+                    [::core::mem::MaybeUninit::uninit(); 4
+                        * ::core::mem::size_of::<*const u8>()],
+                );
+            }
+            /// ---------------------------------------------------------------------------
             /// plugin-meta — required by every plugin
             ///
             /// Maps from src/wit/mod.rs `Plugin` struct (as the return type of get-info).
@@ -5218,155 +5367,6 @@ pub mod exports {
                 #[doc(hidden)]
                 pub(crate) use __export_thoth_plugin_plugin_lifecycle_0_1_0_cabi;
             }
-            /// ---------------------------------------------------------------------------
-            /// Worlds — plugin authors implement one of these
-            ///
-            /// A world declares exactly which interfaces a plugin exports. Pick the
-            /// world that matches your plugin's capabilities. If you implement multiple
-            /// capabilities, implement the combined world or compose component binaries.
-            /// ---------------------------------------------------------------------------
-            /// ---------------------------------------------------------------------------
-            /// plugin-settings — implement on every plugin (trivial no-op is fine)
-            ///
-            /// Lets a plugin own its settings UI. The host calls render-settings() once
-            /// with the persisted key/value pairs; the plugin returns a UiNode tree.
-            /// Events from the UI (text-input changes, button clicks, etc.) are forwarded
-            /// back via handle-setting-event(). On Save the host calls get-settings() to
-            /// read the current values for persistence, and calls apply-settings() on the
-            /// next load so the plugin can restore its state.
-            /// ---------------------------------------------------------------------------
-            #[allow(dead_code, async_fn_in_trait, unused_imports, clippy::all)]
-            pub mod plugin_settings {
-                #[used]
-                #[doc(hidden)]
-                static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
-                use super::super::super::super::_rt;
-                pub type PluginError = super::super::super::super::thoth::plugin::types::PluginError;
-                #[derive(Clone)]
-                pub struct SettingsOutput {
-                    /// JSON-encoded UiNode tree (same DSL as ui-component).
-                    pub node_json: _rt::String,
-                    /// Height hint in logical pixels; 0 = auto.
-                    pub height_hint: u32,
-                }
-                impl ::core::fmt::Debug for SettingsOutput {
-                    fn fmt(
-                        &self,
-                        f: &mut ::core::fmt::Formatter<'_>,
-                    ) -> ::core::fmt::Result {
-                        f.debug_struct("SettingsOutput")
-                            .field("node-json", &self.node_json)
-                            .field("height-hint", &self.height_hint)
-                            .finish()
-                    }
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn _export_render_settings_cabi<T: Guest>() -> *mut u8 {
-                    #[cfg(target_arch = "wasm32")] _rt::run_ctors_once();
-                    let result0 = T::render_settings();
-                    let ptr1 = (&raw mut _RET_AREA.0).cast::<u8>();
-                    match result0 {
-                        Ok(e) => {
-                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
-                            let SettingsOutput {
-                                node_json: node_json2,
-                                height_hint: height_hint2,
-                            } = e;
-                            let vec3 = (node_json2.into_bytes()).into_boxed_slice();
-                            let ptr3 = vec3.as_ptr().cast::<u8>();
-                            let len3 = vec3.len();
-                            ::core::mem::forget(vec3);
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len3;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr3.cast_mut();
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(height_hint2);
-                        }
-                        Err(e) => {
-                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::thoth::plugin::types::PluginError {
-                                code: code4,
-                                message: message4,
-                            } = e;
-                            *ptr1
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<i32>() = _rt::as_i32(code4);
-                            let vec5 = (message4.into_bytes()).into_boxed_slice();
-                            let ptr5 = vec5.as_ptr().cast::<u8>();
-                            let len5 = vec5.len();
-                            ::core::mem::forget(vec5);
-                            *ptr1
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>() = len5;
-                            *ptr1
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>() = ptr5.cast_mut();
-                        }
-                    };
-                    ptr1
-                }
-                #[doc(hidden)]
-                #[allow(non_snake_case)]
-                pub unsafe fn __post_return_render_settings<T: Guest>(arg0: *mut u8) {
-                    let l0 = i32::from(*arg0.add(0).cast::<u8>());
-                    match l0 {
-                        0 => {
-                            let l1 = *arg0
-                                .add(::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l2 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l1, l2, 1);
-                        }
-                        _ => {
-                            let l3 = *arg0
-                                .add(2 * ::core::mem::size_of::<*const u8>())
-                                .cast::<*mut u8>();
-                            let l4 = *arg0
-                                .add(3 * ::core::mem::size_of::<*const u8>())
-                                .cast::<usize>();
-                            _rt::cabi_dealloc(l3, l4, 1);
-                        }
-                    }
-                }
-                pub trait Guest {
-                    /// Render the settings UI. Called once when the user opens the settings for this plugin.
-                    fn render_settings() -> Result<SettingsOutput, PluginError>;
-                }
-                #[doc(hidden)]
-                macro_rules! __export_thoth_plugin_plugin_settings_0_1_0_cabi {
-                    ($ty:ident with_types_in $($path_to_types:tt)*) => {
-                        const _ : () = { #[unsafe (export_name =
-                        "thoth:plugin/plugin-settings@0.1.0#render-settings")] unsafe
-                        extern "C" fn export_render_settings() -> * mut u8 { unsafe {
-                        $($path_to_types)*:: _export_render_settings_cabi::<$ty > () } }
-                        #[unsafe (export_name =
-                        "cabi_post_thoth:plugin/plugin-settings@0.1.0#render-settings")]
-                        unsafe extern "C" fn _post_return_render_settings(arg0 : * mut
-                        u8,) { unsafe { $($path_to_types)*::
-                        __post_return_render_settings::<$ty > (arg0) } } };
-                    };
-                }
-                #[doc(hidden)]
-                pub(crate) use __export_thoth_plugin_plugin_settings_0_1_0_cabi;
-                #[cfg_attr(target_pointer_width = "64", repr(align(8)))]
-                #[cfg_attr(target_pointer_width = "32", repr(align(4)))]
-                struct _RetArea(
-                    [::core::mem::MaybeUninit<
-                        u8,
-                    >; 4 * ::core::mem::size_of::<*const u8>()],
-                );
-                static mut _RET_AREA: _RetArea = _RetArea(
-                    [::core::mem::MaybeUninit::uninit(); 4
-                        * ::core::mem::size_of::<*const u8>()],
-                );
-            }
         }
     }
 }
@@ -5532,14 +5532,15 @@ macro_rules! __export_data_source_plugin_impl {
         exports::thoth::plugin::data_producer::__export_thoth_plugin_data_producer_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::data_producer);
         $($path_to_types_root)*::
+        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
+        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        $($path_to_types_root)*::
         exports::thoth::plugin::plugin_meta::__export_thoth_plugin_plugin_meta_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_meta);
         $($path_to_types_root)*::
         exports::thoth::plugin::plugin_lifecycle::__export_thoth_plugin_plugin_lifecycle_0_1_0_cabi!($ty
         with_types_in $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_lifecycle); $($path_to_types_root)*::
-        exports::thoth::plugin::plugin_settings::__export_thoth_plugin_plugin_settings_0_1_0_cabi!($ty
-        with_types_in $($path_to_types_root)*:: exports::thoth::plugin::plugin_settings);
+        exports::thoth::plugin::plugin_lifecycle);
     };
 }
 #[doc(inline)]
@@ -5625,16 +5626,16 @@ on-tab-closed\x01\x09\x04\0\x1bthoth:plugin/tab-host@0.1.0\x05\x10\x01B\x0c\x02\
 \x0edataset-column\x03\0\x02\x01p\x03\x01ps\x01p\x05\x01r\x04\x04names\x04kinds\x07\
 columns\x04\x04rows\x06\x04\0\x07dataset\x03\0\x07\x01j\x01\x08\x01\x01\x01@\0\0\
 \x09\x04\0\x0fprovide-dataset\x01\x0a\x04\0\x20thoth:plugin/data-producer@0.1.0\x05\
-\x11\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x12\x04\0\x0bplugin-inf\
-o\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/plugin-me\
-ta@0.1.0\x05\x13\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\0\x01@\
-\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0#thoth:\
-plugin/plugin-lifecycle@0.1.0\x05\x14\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplug\
-in-error\x03\0\0\x01r\x02\x09node-jsons\x0bheight-hinty\x04\0\x0fsettings-output\
-\x03\0\x02\x01j\x01\x03\x01\x01\x01@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\
-\0\"thoth:plugin/plugin-settings@0.1.0\x05\x15\x04\0%thoth:plugin/data-source-pl\
-ugin@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\x01\
-\x0cprocessed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
+\x11\x01B\x07\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01r\x02\x09node\
+-jsons\x0bheight-hinty\x04\0\x0fsettings-output\x03\0\x02\x01j\x01\x03\x01\x01\x01\
+@\0\0\x04\x04\0\x0frender-settings\x01\x05\x04\0\"thoth:plugin/plugin-settings@0\
+.1.0\x05\x12\x02\x03\0\0\x0bplugin-info\x01B\x04\x02\x03\x02\x01\x13\x04\0\x0bpl\
+ugin-info\x03\0\0\x01@\0\0\x01\x04\0\x08get-info\x01\x02\x04\0\x1ethoth:plugin/p\
+lugin-meta@0.1.0\x05\x14\x01B\x05\x01@\x01\x07settings\x01\0\x04\0\x07on-load\x01\
+\0\x01@\0\x01\0\x04\0\x08on-close\x01\x01\x04\0\x11on-setting-change\x01\0\x04\0\
+#thoth:plugin/plugin-lifecycle@0.1.0\x05\x15\x04\0%thoth:plugin/data-source-plug\
+in@0.1.0\x04\0\x0b\x18\x01\0\x12data-source-plugin\x03\0\0\0G\x09producers\x01\x0c\
+processed-by\x02\x0dwit-component\x070.227.1\x10wit-bindgen-rust\x060.41.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/plugins/url-source/src/bindings.rs
+++ b/plugins/url-source/src/bindings.rs
@@ -33,6 +33,8 @@ pub mod thoth {
                 /// data-renderer.render and appears as an extra view format in a
                 /// DataView (alongside table / json / raw).
                 Renderer,
+                /// Exposes commands through the optional plugin-cli interface.
+                Cli,
             }
             impl ::core::fmt::Debug for Capability {
                 fn fmt(
@@ -64,6 +66,7 @@ pub mod thoth {
                         Capability::Renderer => {
                             f.debug_tuple("Capability::Renderer").finish()
                         }
+                        Capability::Cli => f.debug_tuple("Capability::Cli").finish(),
                     }
                 }
             }
@@ -82,6 +85,7 @@ pub mod thoth {
                         5 => Capability::NewUiComponent,
                         6 => Capability::DataProducer,
                         7 => Capability::Renderer,
+                        8 => Capability::Cli,
                         _ => panic!("invalid enum discriminant"),
                     }
                 }
@@ -5546,27 +5550,27 @@ pub(crate) use __export_data_source_plugin_impl as export;
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3680] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xd7\x1b\x01A\x02\x01\
-A)\x01B\x0a\x01m\x08\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
-search-provider\x10new-ui-component\x0ddata-producer\x08renderer\x04\0\x0acapabi\
-lity\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescriptions\
-\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0bplugin-i\
-nfo\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\x01r\
-\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugin/typ\
-es@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x0f\x02\x03\x02\x01\x01\x04\0\x0c\
-plugin-error\x03\0\0\x01o\x02ss\x01p\x02\x01p}\x01k\x04\x01r\x04\x03urls\x06meth\
-ods\x07headers\x03\x04body\x05\x04\0\x0chttp-request\x03\0\x06\x01r\x03\x06statu\
-s{\x07headers\x03\x04body\x04\x04\0\x0dhttp-response\x03\0\x08\x01j\x01\x09\x01\x01\
-\x01@\x01\x03req\x07\0\x0a\x04\0\x05fetch\x01\x0b\x01@\x01\x03req\x07\0s\x04\0\x06\
-submit\x01\x0c\x03\0\x1ethoth:plugin/http-client@0.1.0\x05\x02\x01B\x05\x01@\0\0\
-s\x04\0\x04read\x01\0\x01j\0\x01s\x01@\x01\x04datas\0\x01\x04\0\x05write\x01\x02\
-\x03\0!thoth:plugin/plugin-storage@0.1.0\x05\x03\x01B\x03\x01ks\x01@\x03\x05titl\
-es\x04icon\0\x0dinitial-state\0\0s\x04\0\x08open-tab\x01\x01\x03\0\x1athoth:plug\
-in/ui-tabs@0.1.0\x05\x04\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\
-\0\x01j\x01w\x01\x01\x01@\x03\x04hosts\x04port{\x03tls\x7f\0\x02\x04\0\x07connec\
-t\x01\x03\x01p}\x01j\x01\x04\x01\x01\x01@\x02\x02idw\x03maxy\0\x05\x04\0\x04read\
-\x01\x06\x01j\x01y\x01\x01\x01@\x02\x02idw\x05bytes\x04\0\x07\x04\0\x05write\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 3684] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xdb\x1b\x01A\x02\x01\
+A)\x01B\x0a\x01m\x09\x0bfile-loader\x0bfile-viewer\x0bdata-source\x08exporter\x0f\
+search-provider\x10new-ui-component\x0ddata-producer\x08renderer\x03cli\x04\0\x0a\
+capability\x03\0\0\x01p\x01\x01ks\x01r\x08\x02ids\x04names\x07versions\x0bdescri\
+ptions\x0ccapabilities\x02\x06author\x03\x08homepage\x03\x04icon\x03\x04\0\x0bpl\
+ugin-info\x03\0\x04\x01r\x02\x04codey\x07messages\x04\0\x0cplugin-error\x03\0\x06\
+\x01r\x02\x03keys\x05values\x04\0\x0csetting-data\x03\0\x08\x03\0\x18thoth:plugi\
+n/types@0.1.0\x05\0\x02\x03\0\0\x0cplugin-error\x01B\x0f\x02\x03\x02\x01\x01\x04\
+\0\x0cplugin-error\x03\0\0\x01o\x02ss\x01p\x02\x01p}\x01k\x04\x01r\x04\x03urls\x06\
+methods\x07headers\x03\x04body\x05\x04\0\x0chttp-request\x03\0\x06\x01r\x03\x06s\
+tatus{\x07headers\x03\x04body\x04\x04\0\x0dhttp-response\x03\0\x08\x01j\x01\x09\x01\
+\x01\x01@\x01\x03req\x07\0\x0a\x04\0\x05fetch\x01\x0b\x01@\x01\x03req\x07\0s\x04\
+\0\x06submit\x01\x0c\x03\0\x1ethoth:plugin/http-client@0.1.0\x05\x02\x01B\x05\x01\
+@\0\0s\x04\0\x04read\x01\0\x01j\0\x01s\x01@\x01\x04datas\0\x01\x04\0\x05write\x01\
+\x02\x03\0!thoth:plugin/plugin-storage@0.1.0\x05\x03\x01B\x03\x01ks\x01@\x03\x05\
+titles\x04icon\0\x0dinitial-state\0\0s\x04\0\x08open-tab\x01\x01\x03\0\x1athoth:\
+plugin/ui-tabs@0.1.0\x05\x04\x01B\x11\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\
+\0\0\x01j\x01w\x01\x01\x01@\x03\x04hosts\x04port{\x03tls\x7f\0\x02\x04\0\x07conn\
+ect\x01\x03\x01p}\x01j\x01\x04\x01\x01\x01@\x02\x02idw\x03maxy\0\x05\x04\0\x04re\
+ad\x01\x06\x01j\x01y\x01\x01\x01@\x02\x02idw\x05bytes\x04\0\x07\x04\0\x05write\x01\
 \x08\x01j\0\x01\x01\x01@\x02\x02idw\x04hosts\0\x09\x04\0\x09start-tls\x01\x0a\x01\
 @\x01\x02idw\x01\0\x04\0\x05close\x01\x0b\x03\0\x1dthoth:plugin/tcp-client@0.1.0\
 \x05\x05\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x0cplugin-error\x03\0\0\x01j\0\x01\x01\

--- a/src/app/file_picker.rs
+++ b/src/app/file_picker.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use rfd::FileDialog;
 
-use crate::{PLUGIN_MANAGER, plugin::Capability};
+use crate::plugin::{Capability, runtime::active_manager};
 
 fn supported_files(plugins_enabled: bool) -> Vec<(String, Vec<String>)> {
     let mut all_supported_file_types = vec![(
@@ -10,7 +10,7 @@ fn supported_files(plugins_enabled: bool) -> Vec<(String, Vec<String>)> {
         vec!["json".to_string(), "ndjson".to_string()],
     )];
 
-    if plugins_enabled && let Some(Some(plugin_manager)) = PLUGIN_MANAGER.get() {
+    if plugins_enabled && let Some(plugin_manager) = active_manager() {
         plugin_manager
             .get_all_plugin_by_capability(Capability::FileLoader)
             .iter()

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -5,7 +5,7 @@ use crate::{
     NOTIFICATION_MANAGER, PLUGIN_MANAGER,
     app::{file_picker, pick_file, tab_manager::TabEvent},
     components::{self, traits::ContextComponent},
-    plugin::plugin_ui_host::PluginUiHost,
+    plugin::plugin_ui_host::PluginCore,
     settings, state,
     theme::ThemeColorsExt,
 };
@@ -150,7 +150,7 @@ fn build_ws_event(
 /// spawned from it explicitly via the `ui-tabs` `open-tab` import.
 struct SidebarPluginRuntime {
     plugin_id: String,
-    loader: Box<dyn PluginUiHost>,
+    loader: Box<dyn PluginCore>,
     output: Option<crate::plugin::render_node::UiOutput>,
 }
 
@@ -807,7 +807,7 @@ impl ThothApp {
     /// dock label can be rendered cheaply without locking the WASM store each frame.
     fn make_plugin_pane(
         plugin_id: String,
-        loader: Box<dyn PluginUiHost>,
+        loader: Box<dyn PluginCore>,
         ui_output: crate::plugin::render_node::UiOutput,
     ) -> crate::state::ActivePluginPane {
         let cached_tab_title = loader.tab_title();
@@ -845,13 +845,19 @@ impl ThothApp {
         if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id)
             && let Some(pane) = tab.active_plugin_pane.as_mut()
         {
-            match pane.loader.handle_event(event) {
+            let Some(ui) = pane.loader.as_ui() else {
+                tab.error = Some(crate::error::ThothError::Unknown {
+                    message: format!("Plugin '{}' has no UI facet", pane.plugin_id),
+                });
+                return;
+            };
+            match ui.handle_event(event) {
                 Ok(new_output) => {
                     pane.ui_output = new_output;
                     // Title/icon may change in response to the event.
                     pane.cached_tab_title = pane.loader.tab_title();
                     pane.cached_tab_icon = pane.loader.tab_icon();
-                    if let Ok(sidebar) = pane.loader.render_sidebar() {
+                    if let Ok(sidebar) = ui.render_sidebar() {
                         tab.plugin_sidebar_output = sidebar;
                     }
                     handled = true;
@@ -880,7 +886,7 @@ impl ThothApp {
         manager: &crate::plugin::manager::PluginManager,
         plugin_id: &str,
         settings: &settings::Settings,
-    ) -> Option<Box<dyn PluginUiHost>> {
+    ) -> Option<Box<dyn PluginCore>> {
         use crate::plugin::Capability;
         let plugin = manager.registry.get_by_id(plugin_id)?;
         if plugin.capabilities.contains(&Capability::DataSource) {
@@ -898,12 +904,12 @@ impl ThothApp {
             manager
                 .open_data_source(plugin_id, policy)
                 .ok()
-                .map(|l| Box::new(l) as Box<dyn PluginUiHost>)
+                .map(|l| Box::new(l) as Box<dyn PluginCore>)
         } else if plugin.capabilities.contains(&Capability::NewUIComponent) {
             manager
                 .open_ui_component(plugin_id)
                 .ok()
-                .map(|l| Box::new(l) as Box<dyn PluginUiHost>)
+                .map(|l| Box::new(l) as Box<dyn PluginCore>)
         } else {
             None
         }
@@ -924,10 +930,13 @@ impl ThothApp {
         if let Some(state) = initial_state {
             let _ = loader.init_with_state(state);
         }
-        let Ok(ui_output) = loader.render_ui() else {
+        let Some(ui) = loader.as_ui() else {
             return;
         };
-        let sidebar_output = loader.render_sidebar().ok().flatten();
+        let Ok(ui_output) = ui.render_ui() else {
+            return;
+        };
+        let sidebar_output = ui.render_sidebar().ok().flatten();
         let nav_capacity = self.settings.performance.navigation_history_size;
         let tab_id = if self
             .window_state
@@ -966,10 +975,13 @@ impl ThothApp {
         if let Some(state) = req.initial_state.as_deref() {
             let _ = loader.init_with_state(state);
         }
-        let Ok(ui_output) = loader.render_ui() else {
+        let Some(ui) = loader.as_ui() else {
             return;
         };
-        let sidebar_output = loader.render_sidebar().ok().flatten();
+        let Ok(ui_output) = ui.render_ui() else {
+            return;
+        };
+        let sidebar_output = ui.render_sidebar().ok().flatten();
         let nav_capacity = self.settings.performance.navigation_history_size;
         let tab_id = self.window_state.tab_manager.open_new_tab(nav_capacity);
         if let Some(t) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
@@ -1004,7 +1016,9 @@ impl ThothApp {
         let Some(loader) = Self::build_plugin_loader(manager, plugin_id, &self.settings) else {
             return;
         };
-        let output = loader.render_sidebar().ok().flatten();
+        let output = loader
+            .as_ui()
+            .and_then(|ui| ui.render_sidebar().ok().flatten());
         self.sidebar_plugin = Some(SidebarPluginRuntime {
             plugin_id: plugin_id.to_string(),
             loader,
@@ -1017,9 +1031,12 @@ impl ThothApp {
     /// in `poll_plugin_panes`.)
     fn dispatch_sidebar_event(&mut self, event: crate::plugin::render_node::UiEvent) {
         if let Some(rt) = self.sidebar_plugin.as_mut() {
-            match rt.loader.handle_event(event) {
+            let Some(ui) = rt.loader.as_ui() else {
+                return;
+            };
+            match ui.handle_event(event) {
                 Ok(_) => {
-                    rt.output = rt.loader.render_sidebar().ok().flatten();
+                    rt.output = ui.render_sidebar().ok().flatten();
                 }
                 Err(e) => {
                     eprintln!("Plugin sidebar event error: {e}");
@@ -1438,10 +1455,13 @@ impl ThothApp {
         if let Some(s) = state {
             let _ = loader.init_with_state(s);
         }
-        let Ok(ui_output) = loader.render_ui() else {
+        let Some(ui) = loader.as_ui() else {
             return;
         };
-        let sidebar_output = loader.render_sidebar().ok().flatten();
+        let Ok(ui_output) = ui.render_ui() else {
+            return;
+        };
+        let sidebar_output = ui.render_sidebar().ok().flatten();
         let tab_id = if tab_manager.active_tab_mut().is_some_and(|t| t.is_empty()) {
             tab_manager.active_tab_id().unwrap()
         } else {

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -5,6 +5,7 @@ use crate::{
     NOTIFICATION_MANAGER, PLUGIN_MANAGER,
     app::{file_picker, pick_file, tab_manager::TabEvent},
     components::{self, traits::ContextComponent},
+    core::{CoreAction, CoreEvent, ThothCore},
     plugin::plugin_ui_host::PluginCore,
     settings, state,
     theme::ThemeColorsExt,
@@ -16,39 +17,16 @@ use super::{
 };
 
 pub struct ThothApp {
-    pub settings: settings::Settings,
-    pub persistent_state: PersistentState,
+    /// Display-independent state shared with headless runtimes.
+    pub core: ThothCore,
     pub window_state: state::WindowState,
-    pub update_state: state::ApplicationUpdateState,
     settings_dialog: components::settings_dialog::SettingsDialog,
     clipboard_text: Option<String>,
-    settings_changed: bool,
-    session_dirty: bool,
     show_update_consent: bool,
     /// Holds the live native menu bar (muda) so it isn't dropped.
     _native_menu: Option<crate::platform::native_menu::NativeMenu>,
-    /// Plugin IDs from the persisted session that couldn't be restored yet because
-    /// PLUGIN_MANAGER was still initializing on the background thread. Drained each
-    /// frame once the manager becomes available.
-    pending_plugin_restores: Vec<(String, Option<String>)>,
-    /// Active-tab index to switch to once all deferred session tabs are open.
-    /// `None` once the switch has been applied (or when no session is being restored).
-    session_restore_active_index: Option<usize>,
-    /// The plugin tab that was active last frame. Used to fire on-tab-focused /
-    /// on-tab-blurred lifecycle callbacks when the active tab changes.
-    last_active_plugin_tab: Option<crate::app::tab_manager::TabId>,
     /// The plugin whose sidebar is currently mounted (independent of any tab).
     sidebar_plugin: Option<SidebarPluginRuntime>,
-    /// Per-session counter for chart-tab titles ("Bar 1", "Line 2", …).
-    chart_counter: usize,
-    /// Cached resolution of the Chart Studio's selected source
-    /// `(tab id, column names, string rows)`, reused between column-preview and
-    /// Generate to avoid re-fetching.
-    chart_source: Option<(
-        crate::app::tab_manager::TabId,
-        Vec<String>,
-        Vec<Vec<String>>,
-    )>,
     /// Pending chart PNG export: `(chart rect in points, screenshot requested?)`
     /// — drives the two-frame screenshot → crop → save flow.
     chart_export: Option<(egui::Rect, bool)>,
@@ -171,13 +149,15 @@ impl ThothApp {
         file_to_open: Option<PathBuf>,
         persistent_state: PersistentState,
     ) -> Self {
+        let canvas_color = settings.theme.colors().bg_sunken;
+        let mut core = ThothCore::with_persistent_state(settings, persistent_state);
         let mut window_state = state::WindowState::default();
-        if settings.ui.remember_sidebar_state {
-            window_state.sidebar_expanded = persistent_state.get_sidebar_expanded();
+        if core.settings.ui.remember_sidebar_state {
+            window_state.sidebar_expanded = core.persistent_state.get_sidebar_expanded();
         }
 
         // Replace the default TabManager with one that uses the configured nav history size.
-        let nav_capacity = settings.performance.navigation_history_size;
+        let nav_capacity = core.settings.performance.navigation_history_size;
         window_state.tab_manager = crate::app::TabManager::new(nav_capacity);
 
         let (pending_plugin_restores, session_restore_active_index) =
@@ -193,8 +173,8 @@ impl ThothApp {
                 // here and retried via poll_pending_plugin_restores() each frame.
                 let (deferred, active_index) = Self::restore_tab_session(
                     &mut window_state.tab_manager,
-                    &persistent_state,
-                    &settings,
+                    &core.persistent_state,
+                    &core.settings,
                 );
                 // Switch to the previously-active tab immediately if there are no deferred
                 // plugins; otherwise defer until poll_pending_plugin_restores() finishes.
@@ -209,35 +189,27 @@ impl ThothApp {
                 (deferred, restore_index)
             };
 
+        core.pending_plugin_restores = pending_plugin_restores;
+        core.session_restore_active_index = session_restore_active_index;
+
         Self {
-            canvas_color: settings.theme.colors().bg_sunken,
-            settings,
-            persistent_state,
+            canvas_color,
+            core,
             window_state,
-            update_state: state::ApplicationUpdateState::default(),
             settings_dialog: components::settings_dialog::SettingsDialog::default(),
             clipboard_text: None,
-            settings_changed: false,
-            session_dirty: false,
             show_update_consent: false,
             _native_menu: None,
-            pending_plugin_restores,
-            session_restore_active_index,
-            last_active_plugin_tab: None,
             sidebar_plugin: None,
-            chart_counter: 0,
-            chart_source: None,
             chart_export: None,
         }
     }
 
     pub fn setup_native_menu(&mut self, cc: &eframe::CreationContext<'_>) {
         use raw_window_handle::HasWindowHandle as _;
-        self._native_menu = cc
-            .window_handle()
-            .ok()
-            .map(|h| h.as_raw())
-            .and_then(|raw| crate::platform::native_menu::setup(raw, &self.settings.shortcuts));
+        self._native_menu = cc.window_handle().ok().map(|h| h.as_raw()).and_then(|raw| {
+            crate::platform::native_menu::setup(raw, &self.core.settings.shortcuts)
+        });
     }
 
     pub fn create_new_window(&mut self) {
@@ -251,25 +223,26 @@ impl ThothApp {
     }
 
     fn apply_new_settings(&mut self, new_settings: settings::Settings) {
-        let prev_remember_sidebar = self.settings.ui.remember_sidebar_state;
-        let prev_plugins_enabled = self.settings.plugins.enabled;
-        let prev_disabled_plugin_ids = self.settings.plugins.disabled_plugin_ids.clone();
+        let prev_remember_sidebar = self.core.settings.ui.remember_sidebar_state;
+        let prev_plugins_enabled = self.core.settings.plugins.enabled;
+        let prev_disabled_plugin_ids = self.core.settings.plugins.disabled_plugin_ids.clone();
 
-        self.settings = new_settings;
-        self.settings_changed = true;
+        self.core.settings = new_settings;
+        self.core.settings_changed = true;
 
-        if !prev_remember_sidebar && self.settings.ui.remember_sidebar_state {
-            self.window_state.sidebar_expanded = self.persistent_state.get_sidebar_expanded();
+        if !prev_remember_sidebar && self.core.settings.ui.remember_sidebar_state {
+            self.window_state.sidebar_expanded = self.core.persistent_state.get_sidebar_expanded();
         }
 
         if let Some(Some(pm)) = PLUGIN_MANAGER.get() {
-            pm.update_plugin_settings(self.settings.plugins.plugin_settings.clone());
+            pm.update_plugin_settings(self.core.settings.plugins.plugin_settings.clone());
         }
 
         if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
             && let Some(pane) = tab.active_plugin_pane.as_mut()
         {
             let updated = self
+                .core
                 .settings
                 .plugins
                 .plugin_settings
@@ -284,8 +257,8 @@ impl ThothApp {
             }
         }
 
-        let plugins_changed = self.settings.plugins.enabled != prev_plugins_enabled
-            || self.settings.plugins.disabled_plugin_ids != prev_disabled_plugin_ids;
+        let plugins_changed = self.core.settings.plugins.enabled != prev_plugins_enabled
+            || self.core.settings.plugins.disabled_plugin_ids != prev_disabled_plugin_ids;
         if plugins_changed {
             crate::notification::NotificationManager::notify(
                 crate::notification::Notification::new(
@@ -309,7 +282,7 @@ impl ThothApp {
     }
 
     fn open_settings_window(&mut self, ctx: &egui::Context) {
-        self.settings_dialog.open(&self.settings);
+        self.settings_dialog.open(&self.core.settings);
         ctx.request_repaint();
     }
 }
@@ -342,22 +315,22 @@ impl App for ThothApp {
             self.canvas_color = applied.bg_sunken;
         }
 
-        if UpdateHandler::should_check_updates(&self.update_state, &self.settings) {
-            UpdateHandler::check_for_updates(&mut self.update_state);
+        if UpdateHandler::should_check_updates(&self.core.update_state, &self.core.settings) {
+            UpdateHandler::check_for_updates(&mut self.core.update_state);
         }
 
         let should_show_updates =
-            UpdateHandler::handle_update_messages(&mut self.update_state, ctx);
+            UpdateHandler::handle_update_messages(&mut self.core.update_state, ctx);
 
         if should_show_updates {
             self.show_update_consent = true;
-            UpdateHandler::post_update_notification(&self.update_state);
+            UpdateHandler::post_update_notification(&self.core.update_state);
         }
 
         if crate::OPEN_UPDATES_REQUESTED.swap(false, std::sync::atomic::Ordering::Relaxed)
             && !self.settings_dialog.open
         {
-            self.settings_dialog.open_updates(&self.settings);
+            self.settings_dialog.open_updates(&self.core.settings);
         }
 
         if let Some(nm) = NOTIFICATION_MANAGER.get()
@@ -383,16 +356,16 @@ impl App for ThothApp {
 
         let ctx = ui.ctx().clone();
 
-        settings::Settings::store(&ctx, &self.settings);
+        settings::Settings::store(&ctx, &self.core.settings);
 
         self.poll_plugin_panes(&ctx);
         self.drain_pending_exports();
 
-        if self.settings.ui.show_toolbar {
+        if self.core.settings.ui.show_toolbar {
             self.render_toolbar(ui);
         }
 
-        if self.settings.ui.show_status_bar {
+        if self.core.settings.ui.show_status_bar {
             self.render_status_bar(ui);
         }
 
@@ -428,7 +401,7 @@ impl App for ThothApp {
         }
 
         let shortcut_actions =
-            ShortcutHandler::handle_shortcuts(ui.ctx(), &self.settings.shortcuts);
+            ShortcutHandler::handle_shortcuts(ui.ctx(), &self.core.settings.shortcuts);
         self.handle_shortcut_actions(ui.ctx(), shortcut_actions);
 
         use crate::components::settings_dialog::{SettingsDialogEvent, SettingsDialogProps};
@@ -437,14 +410,14 @@ impl App for ThothApp {
         let settings_output = self.settings_dialog.render(
             ui,
             SettingsDialogProps {
-                update_state: Some(&self.update_state.update_status.state),
-                last_check: self.update_state.update_status.last_check,
+                update_state: Some(&self.core.update_state.update_status.state),
+                last_check: self.core.update_state.update_status.last_check,
                 current_version: crate::update::UpdateManager::get_current_version(),
             },
         );
 
         if !self.settings_dialog.open {
-            crate::theme::apply_theme(&ctx, &self.settings);
+            crate::theme::apply_theme(&ctx, &self.core.settings);
         }
 
         if let Some(new_settings) = settings_output.new_settings {
@@ -454,12 +427,12 @@ impl App for ThothApp {
         for event in settings_output.events {
             match event {
                 SettingsDialogEvent::CheckForUpdates => {
-                    UpdateHandler::check_for_updates(&mut self.update_state);
+                    UpdateHandler::check_for_updates(&mut self.core.update_state);
                 }
                 SettingsDialogEvent::DownloadUpdate => {
                     let latest_release =
                         if let crate::update::UpdateState::UpdateAvailable { releases, .. } =
-                            &self.update_state.update_status.state
+                            &self.core.update_state.update_status.state
                         {
                             releases.first().cloned()
                         } else {
@@ -467,21 +440,24 @@ impl App for ThothApp {
                         };
 
                     if let Some(latest) = latest_release {
-                        self.update_state.pending_download_release = Some(latest.clone());
-                        self.update_state.update_status.state =
+                        self.core.update_state.pending_download_release = Some(latest.clone());
+                        self.core.update_state.update_status.state =
                             crate::update::UpdateState::Downloading {
                                 progress: 0.0,
                                 version: latest.tag_name.clone(),
                             };
-                        self.update_state.update_manager.download_update(&latest);
+                        self.core
+                            .update_state
+                            .update_manager
+                            .download_update(&latest);
                         ctx.request_repaint();
                     }
                 }
                 SettingsDialogEvent::InstallUpdate => {
-                    if let Some(path) = self.update_state.pending_install_path.take() {
-                        self.update_state.update_status.state =
+                    if let Some(path) = self.core.update_state.pending_install_path.take() {
+                        self.core.update_state.update_status.state =
                             crate::update::UpdateState::Installing;
-                        self.update_state.update_manager.install_update(path);
+                        self.core.update_state.update_manager.install_update(path);
                     }
                 }
                 SettingsDialogEvent::RegisterInPath => {
@@ -563,7 +539,7 @@ impl App for ThothApp {
         self.save_session_if_dirty();
 
         #[cfg(feature = "profiling")]
-        if self.settings.dev.show_profiler {
+        if self.core.settings.dev.show_profiler {
             puffin::GlobalProfiler::lock().new_frame();
 
             egui::Window::new(format!(
@@ -603,18 +579,18 @@ impl App for ThothApp {
 
 impl ThothApp {
     fn handle_shortcut_actions(&mut self, ctx: &egui::Context, actions: Vec<ShortcutAction>) {
-        let nav_capacity = self.settings.performance.navigation_history_size;
+        let nav_capacity = self.core.settings.performance.navigation_history_size;
 
         for action in actions {
             match action {
                 ShortcutAction::OpenFile => {
-                    if let Some(path) = file_picker::pick_file(self.settings.plugins.enabled) {
+                    if let Some(path) = file_picker::pick_file(self.core.settings.plugins.enabled) {
                         if let Some(path_str) = path.to_str() {
-                            self.persistent_state.add_recent_file(
+                            self.core.persistent_state.add_recent_file(
                                 path_str.to_string(),
-                                self.settings.performance.max_recent_files,
+                                self.core.settings.performance.max_recent_files,
                             );
-                            let _ = self.persistent_state.save();
+                            let _ = self.core.persistent_state.save();
                         }
                         self.window_state.tab_manager.open_file(path, nav_capacity);
                     }
@@ -626,12 +602,12 @@ impl ThothApp {
                     self.open_settings_window(ctx);
                 }
                 ShortcutAction::ToggleTheme => {
-                    self.settings.dark_mode = !self.settings.dark_mode;
-                    self.settings_changed = true;
+                    self.core.settings.dark_mode = !self.core.settings.dark_mode;
+                    self.core.settings_changed = true;
                 }
                 ShortcutAction::ToggleProfiler => {
-                    self.settings.dev.show_profiler = !self.settings.dev.show_profiler;
-                    self.settings_changed = true;
+                    self.core.settings.dev.show_profiler = !self.core.settings.dev.show_profiler;
+                    self.core.settings_changed = true;
                 }
                 ShortcutAction::FocusSearch => {
                     let section = components::sidebar::SidebarSection::Search;
@@ -644,10 +620,11 @@ impl ThothApp {
                         self.window_state.sidebar_selected_section = Some(section);
                     }
 
-                    if self.settings.ui.remember_sidebar_state {
-                        self.persistent_state
+                    if self.core.settings.ui.remember_sidebar_state {
+                        self.core
+                            .persistent_state
                             .set_sidebar_expanded(self.window_state.sidebar_expanded);
-                        let _ = self.persistent_state.save();
+                        let _ = self.core.persistent_state.save();
                     }
                 }
                 ShortcutAction::NextMatch => {}
@@ -670,9 +647,9 @@ impl ThothApp {
                     if self.window_state.sidebar_expanded {
                         self.window_state.sidebar_expanded = false;
 
-                        if self.settings.ui.remember_sidebar_state {
-                            self.persistent_state.set_sidebar_expanded(false);
-                            let _ = self.persistent_state.save();
+                        if self.core.settings.ui.remember_sidebar_state {
+                            self.core.persistent_state.set_sidebar_expanded(false);
+                            let _ = self.core.persistent_state.save();
                         }
                     }
                 }
@@ -687,9 +664,10 @@ impl ThothApp {
                             Some((path, file_path))
                         });
                     if let Some((selected_path, file_path_str)) = info {
-                        self.persistent_state
+                        self.core
+                            .persistent_state
                             .toggle_bookmark(selected_path, file_path_str);
-                        if let Err(e) = self.persistent_state.save() {
+                        if let Err(e) = self.core.persistent_state.save() {
                             eprintln!("Failed to save bookmarks: {}", e);
                         }
                     }
@@ -699,9 +677,9 @@ impl ThothApp {
                     self.window_state.sidebar_selected_section =
                         Some(components::sidebar::SidebarSection::Bookmarks);
 
-                    if self.settings.ui.remember_sidebar_state {
-                        self.persistent_state.set_sidebar_expanded(true);
-                        let _ = self.persistent_state.save();
+                    if self.core.settings.ui.remember_sidebar_state {
+                        self.core.persistent_state.set_sidebar_expanded(true);
+                        let _ = self.core.persistent_state.save();
                     }
                 }
                 ShortcutAction::ExpandNode => {
@@ -771,7 +749,7 @@ impl ThothApp {
                     } else {
                         self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                     }
-                    self.session_dirty = true;
+                    self.core.session_dirty = true;
                 }
                 ShortcutAction::NewTab => {
                     self.window_state.tab_manager.open_new_tab(nav_capacity);
@@ -873,7 +851,7 @@ impl ThothApp {
         // SQL, switched database), so mark the session dirty. The actual write is
         // skipped by `save_session_if_dirty` when the serialized tabs are unchanged.
         if handled {
-            self.session_dirty = true;
+            self.core.session_dirty = true;
         }
     }
 
@@ -919,7 +897,8 @@ impl ThothApp {
         let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) else {
             return;
         };
-        let Some(loader) = Self::build_plugin_loader(manager, plugin_id, &self.settings) else {
+        let Some(loader) = Self::build_plugin_loader(manager, plugin_id, &self.core.settings)
+        else {
             if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
                 tab.error = Some(crate::error::ThothError::Unknown {
                     message: format!("Failed to load plugin '{plugin_id}'"),
@@ -937,7 +916,7 @@ impl ThothApp {
             return;
         };
         let sidebar_output = ui.render_sidebar().ok().flatten();
-        let nav_capacity = self.settings.performance.navigation_history_size;
+        let nav_capacity = self.core.settings.performance.navigation_history_size;
         let tab_id = if self
             .window_state
             .tab_manager
@@ -956,7 +935,7 @@ impl ThothApp {
             ));
             t.plugin_sidebar_output = sidebar_output;
         }
-        self.session_dirty = true;
+        self.core.session_dirty = true;
     }
 
     /// Handle a plugin-initiated `open-tab` request: always open a fresh instance
@@ -968,7 +947,7 @@ impl ThothApp {
         let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) else {
             return;
         };
-        let Some(loader) = Self::build_plugin_loader(manager, &req.plugin_id, &self.settings)
+        let Some(loader) = Self::build_plugin_loader(manager, &req.plugin_id, &self.core.settings)
         else {
             return;
         };
@@ -982,7 +961,7 @@ impl ThothApp {
             return;
         };
         let sidebar_output = ui.render_sidebar().ok().flatten();
-        let nav_capacity = self.settings.performance.navigation_history_size;
+        let nav_capacity = self.core.settings.performance.navigation_history_size;
         let tab_id = self.window_state.tab_manager.open_new_tab(nav_capacity);
         if let Some(t) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
             let mut pane = Self::make_plugin_pane(req.plugin_id.clone(), loader, ui_output);
@@ -997,7 +976,7 @@ impl ThothApp {
             t.active_plugin_pane = Some(pane);
             t.plugin_sidebar_output = sidebar_output;
         }
-        self.session_dirty = true;
+        self.core.session_dirty = true;
     }
 
     /// Ensure a tab-independent sidebar runtime is mounted for `plugin_id`,
@@ -1013,7 +992,8 @@ impl ThothApp {
         let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) else {
             return;
         };
-        let Some(loader) = Self::build_plugin_loader(manager, plugin_id, &self.settings) else {
+        let Some(loader) = Self::build_plugin_loader(manager, plugin_id, &self.core.settings)
+        else {
             return;
         };
         let output = loader
@@ -1054,19 +1034,27 @@ impl ThothApp {
     pub fn poll_os_open_requests(&mut self) {
         let paths = crate::platform::drain_open_requests();
         if let Some(path) = paths.into_iter().last() {
-            // Add to recent files (same as toolbar / sidebar open-file paths)
-            if let Some(path_str) = path.to_str() {
-                self.persistent_state.add_recent_file(
-                    path_str.to_string(),
-                    self.settings.performance.max_recent_files,
-                );
-                let _ = self.persistent_state.save();
-            }
+            self.core.dispatch_event(CoreEvent::OpenFile(path));
+        }
 
-            let nav_capacity = self.settings.performance.navigation_history_size;
-            self.window_state.tab_manager.open_file(path, nav_capacity);
-            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
-                tab.error = None;
+        for action in self.core.tick() {
+            match action {
+                CoreAction::OpenFile(path) => {
+                    // Add to recent files (same as toolbar / sidebar open-file paths)
+                    if let Some(path_str) = path.to_str() {
+                        self.core.persistent_state.add_recent_file(
+                            path_str.to_string(),
+                            self.core.settings.performance.max_recent_files,
+                        );
+                        let _ = self.core.persistent_state.save();
+                    }
+
+                    let nav_capacity = self.core.settings.performance.navigation_history_size;
+                    self.window_state.tab_manager.open_file(path, nav_capacity);
+                    if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                        tab.error = None;
+                    }
+                }
             }
         }
     }
@@ -1209,8 +1197,8 @@ impl ThothApp {
 
         // Tab focus/blur lifecycle: notify plugins when the active tab changes.
         let active = self.window_state.tab_manager.active_tab_id();
-        if active != self.last_active_plugin_tab {
-            if let Some(prev) = self.last_active_plugin_tab
+        if active != self.core.last_active_plugin_tab {
+            if let Some(prev) = self.core.last_active_plugin_tab
                 && let Some(tab) = self.window_state.tab_manager.tabs.get(&prev)
                 && let Some(pane) = tab.active_plugin_pane.as_ref()
             {
@@ -1222,7 +1210,7 @@ impl ThothApp {
             {
                 pane.loader.on_tab_focused();
             }
-            self.last_active_plugin_tab = active;
+            self.core.last_active_plugin_tab = active;
         }
 
         if needs_repaint {
@@ -1252,29 +1240,29 @@ impl ThothApp {
             ui,
             components::toolbar::ToolbarProps {
                 file_type: &file_type,
-                dark_mode: self.settings.dark_mode,
-                shortcuts: &self.settings.shortcuts,
+                dark_mode: self.core.settings.dark_mode,
+                shortcuts: &self.core.settings.shortcuts,
                 file_path: file_path_opt.as_deref(),
                 is_fullscreen: ui
                     .ctx()
                     .input(|i: &egui::InputState| i.viewport().fullscreen.unwrap_or(false)),
                 can_go_back,
                 can_go_forward,
-                plugins_enabled: self.settings.plugins.enabled,
+                plugins_enabled: self.core.settings.plugins.enabled,
             },
         );
 
-        let nav_capacity = self.settings.performance.navigation_history_size;
+        let nav_capacity = self.core.settings.performance.navigation_history_size;
 
         for event in output.events {
             match event {
                 components::toolbar::ToolbarEvent::FileOpen { path, file_type } => {
                     if let Some(path_str) = path.to_str() {
-                        self.persistent_state.add_recent_file(
+                        self.core.persistent_state.add_recent_file(
                             path_str.to_string(),
-                            self.settings.performance.max_recent_files,
+                            self.core.settings.performance.max_recent_files,
                         );
-                        let _ = self.persistent_state.save();
+                        let _ = self.core.persistent_state.save();
                     }
                     let id = self.window_state.tab_manager.open_file(path, nav_capacity);
                     if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&id) {
@@ -1290,14 +1278,14 @@ impl ThothApp {
                     } else {
                         self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                     }
-                    self.session_dirty = true;
+                    self.core.session_dirty = true;
                 }
                 components::toolbar::ToolbarEvent::NewWindow => {
                     self.create_new_window();
                 }
                 components::toolbar::ToolbarEvent::ToggleTheme => {
-                    self.settings.dark_mode = !self.settings.dark_mode;
-                    self.settings_changed = true;
+                    self.core.settings.dark_mode = !self.core.settings.dark_mode;
+                    self.core.settings_changed = true;
                 }
                 components::toolbar::ToolbarEvent::OpenSettings => {
                     self.open_settings_window(ui.ctx());
@@ -1326,17 +1314,17 @@ impl ThothApp {
             use crate::platform::native_menu::MenuAction;
             match action {
                 MenuAction::OpenFile => {
-                    let plugins_enabled = self.settings.plugins.enabled;
+                    let plugins_enabled = self.core.settings.plugins.enabled;
                     if let Some(path) = crate::app::pick_file(plugins_enabled)
                         && let Some(file_type) =
                             crate::components::toolbar::infer_file_type_pub(&path)
                     {
                         if let Some(path_str) = path.to_str() {
-                            self.persistent_state.add_recent_file(
+                            self.core.persistent_state.add_recent_file(
                                 path_str.to_string(),
-                                self.settings.performance.max_recent_files,
+                                self.core.settings.performance.max_recent_files,
                             );
-                            let _ = self.persistent_state.save();
+                            let _ = self.core.persistent_state.save();
                         }
                         let id = self.window_state.tab_manager.open_file(path, nav_capacity);
                         if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&id) {
@@ -1354,7 +1342,7 @@ impl ThothApp {
                     } else {
                         self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                     }
-                    self.session_dirty = true;
+                    self.core.session_dirty = true;
                 }
                 MenuAction::OpenSettings => self.open_settings_window(ui.ctx()),
             }
@@ -1362,11 +1350,11 @@ impl ThothApp {
     }
 
     fn save_settings_if_changed(&mut self) {
-        if self.settings_changed {
-            if let Err(e) = self.settings.save() {
+        if self.core.settings_changed {
+            if let Err(e) = self.core.settings.save() {
                 eprintln!("Failed to save settings: {}", e);
             }
-            self.settings_changed = false;
+            self.core.settings_changed = false;
         }
     }
 
@@ -1481,14 +1469,14 @@ impl ThothApp {
     /// `pending_plugin_restores` and opens each plugin tab, then applies the
     /// saved active-tab index.
     fn poll_pending_plugin_restores(&mut self) {
-        if self.pending_plugin_restores.is_empty() {
+        if self.core.pending_plugin_restores.is_empty() {
             return;
         }
         // Wait until the background init thread has called PLUGIN_MANAGER.set().
         let Some(manager_opt) = PLUGIN_MANAGER.get() else {
             return;
         };
-        let plugin_ids = std::mem::take(&mut self.pending_plugin_restores);
+        let plugin_ids = std::mem::take(&mut self.core.pending_plugin_restores);
         if let Some(manager) = manager_opt.as_ref() {
             for (plugin_id, state) in &plugin_ids {
                 Self::open_plugin_tab(
@@ -1496,22 +1484,22 @@ impl ThothApp {
                     manager,
                     plugin_id,
                     state.as_deref(),
-                    &self.settings,
+                    &self.core.settings,
                 );
             }
-            self.session_dirty = true;
+            self.core.session_dirty = true;
         }
         // If manager is None (plugins disabled), plugin_ids is simply dropped.
 
         // All deferred tabs are now open — apply the saved active-tab index.
-        if let Some(idx) = self.session_restore_active_index.take() {
+        if let Some(idx) = self.core.session_restore_active_index.take() {
             self.window_state.tab_manager.switch_to_tab_by_index(idx);
         }
     }
 
     /// Snapshot the current open tabs and write them to persistent_state, then save to disk.
     fn save_session_if_dirty(&mut self) {
-        if !self.session_dirty {
+        if !self.core.session_dirty {
             return;
         }
 
@@ -1563,18 +1551,20 @@ impl ThothApp {
         // Nothing structural or state-wise changed since the last write (a plugin
         // event that didn't touch persisted state, e.g. opening a dropdown) — clear
         // the flag without touching disk so typing/interaction doesn't churn I/O.
-        if tabs == self.persistent_state.get_open_tabs()
-            && active_tab_index == self.persistent_state.get_active_tab_index()
+        if tabs == self.core.persistent_state.get_open_tabs()
+            && active_tab_index == self.core.persistent_state.get_active_tab_index()
         {
-            self.session_dirty = false;
+            self.core.session_dirty = false;
             return;
         }
 
-        self.persistent_state.set_open_tabs(tabs, active_tab_index);
-        if let Err(e) = self.persistent_state.save() {
+        self.core
+            .persistent_state
+            .set_open_tabs(tabs, active_tab_index);
+        if let Err(e) = self.core.persistent_state.save() {
             eprintln!("Failed to save tab session: {e}");
         } else {
-            self.session_dirty = false;
+            self.core.session_dirty = false;
         }
     }
 
@@ -1711,7 +1701,7 @@ impl ThothApp {
         #[cfg(feature = "profiling")]
         puffin::profile_function!();
 
-        let nav_capacity = self.settings.performance.navigation_history_size;
+        let nav_capacity = self.core.settings.performance.navigation_history_size;
         let focused_id = self.window_state.tab_manager.active_tab_id();
 
         let colors = ui.ctx().memory(|m| {
@@ -1731,8 +1721,8 @@ impl ThothApp {
 
         let mut viewer = crate::app::tab_manager::ThothTabViewer {
             tabs,
-            settings: &self.settings,
-            persistent_state: &mut self.persistent_state,
+            settings: &self.core.settings,
+            persistent_state: &mut self.core.persistent_state,
             nav_capacity,
             search_msg: search_message.zip(focused_id).map(|(msg, id)| (id, msg)),
             events: Vec::new(),
@@ -1771,11 +1761,11 @@ impl ThothApp {
                 total_items,
             } => {
                 if let Some(path_str) = path.to_str() {
-                    self.persistent_state.add_recent_file(
+                    self.core.persistent_state.add_recent_file(
                         path_str.to_string(),
-                        self.settings.performance.max_recent_files,
+                        self.core.settings.performance.max_recent_files,
                     );
-                    let _ = self.persistent_state.save();
+                    let _ = self.core.persistent_state.save();
                 }
                 if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
                     tab.file_path = Some(path);
@@ -1787,7 +1777,7 @@ impl ThothApp {
                         tab.central_panel.navigate_to_path(pending_path);
                     }
                 }
-                self.session_dirty = true;
+                self.core.session_dirty = true;
             }
             TabEvent::FileOpenError { tab_id, error } => {
                 if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
@@ -1799,7 +1789,7 @@ impl ThothApp {
                     tab.file_path = None;
                     tab.total_items = 0;
                 }
-                self.session_dirty = true;
+                self.core.session_dirty = true;
             }
             TabEvent::FileTypeChanged { tab_id, file_type } => {
                 if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&tab_id) {
@@ -1822,11 +1812,11 @@ impl ThothApp {
             TabEvent::TabClosed(id) => {
                 self.window_state.tab_manager.ensure_non_empty(nav_capacity);
                 let _ = id;
-                self.session_dirty = true;
+                self.core.session_dirty = true;
             }
             TabEvent::OpenFilePicker => {
-                let nav_cap = self.settings.performance.navigation_history_size;
-                if let Some(path) = pick_file(self.settings.plugins.enabled) {
+                let nav_cap = self.core.settings.performance.navigation_history_size;
+                if let Some(path) = pick_file(self.core.settings.plugins.enabled) {
                     self.window_state.tab_manager.open_file(path, nav_cap);
                 }
             }
@@ -1847,10 +1837,10 @@ impl ThothApp {
             TabEvent::ClearRecentFiles => {
                 // `PersistentState` exposes no `clear_recent_files`, so the list is
                 // emptied through the existing per-path removal and saved once.
-                for path in self.persistent_state.get_recent_files().to_vec() {
-                    self.persistent_state.remove_recent_file(&path);
+                for path in self.core.persistent_state.get_recent_files().to_vec() {
+                    self.core.persistent_state.remove_recent_file(&path);
                 }
-                let _ = self.persistent_state.save();
+                let _ = self.core.persistent_state.save();
             }
             TabEvent::ChartAction { tab_id, action } => {
                 use crate::components::chart_studio::ChartTabAction;
@@ -1955,11 +1945,11 @@ impl ThothApp {
         let output = self.window_state.sidebar.render(
             ui,
             components::sidebar::SidebarProps {
-                recent_files: self.persistent_state.get_recent_files(),
-                bookmarks: self.persistent_state.get_bookmarks(),
+                recent_files: self.core.persistent_state.get_recent_files(),
+                bookmarks: self.core.persistent_state.get_bookmarks(),
                 current_file_path: current_file_path.as_ref().and_then(|p| p.to_str()),
                 expanded: self.window_state.sidebar_expanded,
-                sidebar_width: self.persistent_state.get_sidebar_width(),
+                sidebar_width: self.core.persistent_state.get_sidebar_width(),
                 selected_section: self.window_state.sidebar_selected_section.clone(),
                 focus_search,
                 search_state: &search_state_clone,
@@ -1977,7 +1967,7 @@ impl ThothApp {
         }
         self.window_state.previous_sidebar_expanded = self.window_state.sidebar_expanded;
 
-        let nav_capacity = self.settings.performance.navigation_history_size;
+        let nav_capacity = self.core.settings.performance.navigation_history_size;
 
         for event in output.events {
             match event {
@@ -1986,19 +1976,19 @@ impl ThothApp {
                     self.window_state.tab_manager.open_file(path, nav_capacity);
                 }
                 components::sidebar::SidebarEvent::RemoveRecentFile(file_path) => {
-                    self.persistent_state.remove_recent_file(&file_path);
-                    if let Err(e) = self.persistent_state.save() {
+                    self.core.persistent_state.remove_recent_file(&file_path);
+                    if let Err(e) = self.core.persistent_state.save() {
                         eprintln!("Failed to save recent files: {}", e);
                     }
                 }
                 components::sidebar::SidebarEvent::OpenFilePicker => {
-                    if let Some(path) = pick_file(self.settings.plugins.enabled) {
+                    if let Some(path) = pick_file(self.core.settings.plugins.enabled) {
                         if let Some(path_str) = path.to_str() {
-                            self.persistent_state.add_recent_file(
+                            self.core.persistent_state.add_recent_file(
                                 path_str.to_string(),
-                                self.settings.performance.max_recent_files,
+                                self.core.settings.performance.max_recent_files,
                             );
-                            let _ = self.persistent_state.save();
+                            let _ = self.core.persistent_state.save();
                         }
                         self.window_state.tab_manager.open_file(path, nav_capacity);
                     }
@@ -2047,18 +2037,19 @@ impl ThothApp {
                         }
                     }
 
-                    if self.settings.ui.remember_sidebar_state {
-                        self.persistent_state
+                    if self.core.settings.ui.remember_sidebar_state {
+                        self.core
+                            .persistent_state
                             .set_sidebar_expanded(self.window_state.sidebar_expanded);
-                        let _ = self.persistent_state.save();
+                        let _ = self.core.persistent_state.save();
                     }
                 }
                 components::sidebar::SidebarEvent::OpenUiComponentTab(plugin_id) => {
                     self.open_ui_component_tab(&plugin_id, None);
                 }
                 components::sidebar::SidebarEvent::WidthChanged(new_width) => {
-                    self.persistent_state.set_sidebar_width(new_width);
-                    let _ = self.persistent_state.save();
+                    self.core.persistent_state.set_sidebar_width(new_width);
+                    let _ = self.core.persistent_state.save();
                 }
                 components::sidebar::SidebarEvent::Search(msg) => {
                     if let Some(tab) = self.window_state.tab_manager.active_tab_mut()
@@ -2109,11 +2100,11 @@ impl ThothApp {
                             tab.error = None;
                             tab.pending_navigation = Some(path.clone());
                         }
-                        self.persistent_state.add_recent_file(
+                        self.core.persistent_state.add_recent_file(
                             file_path.clone(),
-                            self.settings.performance.max_recent_files,
+                            self.core.settings.performance.max_recent_files,
                         );
-                        let _ = self.persistent_state.save();
+                        let _ = self.core.persistent_state.save();
                     } else {
                         if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
                             tab.navigation_history.push(path.clone());
@@ -2122,8 +2113,8 @@ impl ThothApp {
                     }
                 }
                 components::sidebar::SidebarEvent::RemoveBookmark(index) => {
-                    self.persistent_state.remove_bookmark(index);
-                    if let Err(e) = self.persistent_state.save() {
+                    self.core.persistent_state.remove_bookmark(index);
+                    if let Err(e) = self.core.persistent_state.save() {
                         eprintln!("Failed to save bookmarks: {}", e);
                     }
                 }
@@ -2156,7 +2147,7 @@ impl ThothApp {
                     self.dispatch_sidebar_event(evt);
                 }
                 components::sidebar::SidebarEvent::OpenSettings => {
-                    self.settings_dialog.open(&self.settings);
+                    self.settings_dialog.open(&self.core.settings);
                 }
                 components::sidebar::SidebarEvent::ChartSelectSource(tab_id) => {
                     self.chart_select_source(tab_id);
@@ -2280,14 +2271,14 @@ impl ThothApp {
         };
         let columns = columns_info(&cols, &rows);
         let colnames = cols.into_iter().map(|(n, _)| n).collect();
-        self.chart_source = Some((tab_id, colnames, rows));
+        self.core.chart_source = Some((tab_id, colnames, rows));
         self.window_state.sidebar.set_chart_columns(columns);
     }
 
     /// Build a chart from a spec: either update the edited tab in place or open
     /// a new dock tab.
     fn chart_generate(&mut self, spec: crate::components::chart_studio::ChartSpec) {
-        let resolved = match &self.chart_source {
+        let resolved = match &self.core.chart_source {
             Some((t, cols, rows)) if *t == spec.source_tab => Some((cols.clone(), rows.clone())),
             _ => self
                 .resolve_dataset(spec.source_tab)
@@ -2297,15 +2288,15 @@ impl ThothApp {
             Self::notify_dataset_unavailable();
             return;
         };
-        self.chart_counter += 1;
+        self.core.chart_counter += 1;
         let chart = crate::components::chart_studio::ChartTab::from_spec(
             &spec,
             colnames,
             rows,
-            self.chart_counter,
+            self.core.chart_counter,
         );
         // Creating/updating a chart changes the persisted session.
-        self.session_dirty = true;
+        self.core.session_dirty = true;
         // Editing: replace the target tab's chart in place.
         if let Some(target) = spec.edit_target
             && let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&target)
@@ -2315,7 +2306,7 @@ impl ThothApp {
             self.window_state.tab_manager.focus_tab(target);
             return;
         }
-        let nav_capacity = self.settings.performance.navigation_history_size;
+        let nav_capacity = self.core.settings.performance.navigation_history_size;
         let id = self.window_state.tab_manager.open_new_tab(nav_capacity);
         if let Some(tab) = self.window_state.tab_manager.tabs.get_mut(&id) {
             tab.chart = Some(chart);
@@ -2342,7 +2333,7 @@ impl ThothApp {
             Some((_n, cols, rows)) => {
                 let ci = columns_info(&cols, &rows);
                 let colnames = cols.into_iter().map(|(n, _)| n).collect();
-                self.chart_source = Some((spec.source_tab, colnames, rows));
+                self.core.chart_source = Some((spec.source_tab, colnames, rows));
                 ci
             }
             None => Vec::new(),
@@ -2373,7 +2364,7 @@ impl ThothApp {
             && let Some(chart) = tab.chart.as_mut()
         {
             chart.update_data(colnames, rows);
-            self.session_dirty = true;
+            self.core.session_dirty = true;
         }
     }
 
@@ -2628,13 +2619,16 @@ impl ThothApp {
 
     fn render_update_consent_modal(&mut self, ui: &mut egui::Ui) {
         use super::update_handler::ConsentAction;
-        match UpdateHandler::render_consent_modal(ui, &self.update_state, self.show_update_consent)
-        {
+        match UpdateHandler::render_consent_modal(
+            ui,
+            &self.core.update_state,
+            self.show_update_consent,
+        ) {
             Some(ConsentAction::RemindLater) => self.show_update_consent = false,
             Some(ConsentAction::UpdateNow) => {
                 self.show_update_consent = false;
                 if !self.settings_dialog.open {
-                    self.settings_dialog.open_updates(&self.settings);
+                    self.settings_dialog.open_updates(&self.core.settings);
                 }
             }
             None => {}

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -2,7 +2,7 @@ use eframe::{App, Frame, egui};
 use std::path::PathBuf;
 
 use crate::{
-    NOTIFICATION_MANAGER, PLUGIN_MANAGER,
+    NOTIFICATION_MANAGER,
     app::{file_picker, pick_file, tab_manager::TabEvent},
     components::{self, traits::ContextComponent},
     core::{CoreAction, CoreEvent, ThothCore},
@@ -169,7 +169,7 @@ impl ThothApp {
             } else {
                 // Restore the previous session (file tabs whose paths still exist, plugin tabs
                 // that can be re-instantiated). Plugin tabs that can't be opened yet (because
-                // PLUGIN_MANAGER is still initializing on a background thread) are returned
+                // the core plugin runtime is still initializing) are returned
                 // here and retried via poll_pending_plugin_restores() each frame.
                 let (deferred, active_index) = Self::restore_tab_session(
                     &mut window_state.tab_manager,
@@ -234,7 +234,7 @@ impl ThothApp {
             self.window_state.sidebar_expanded = self.core.persistent_state.get_sidebar_expanded();
         }
 
-        if let Some(Some(pm)) = PLUGIN_MANAGER.get() {
+        if let Some(pm) = self.core.plugins.manager() {
             pm.update_plugin_settings(self.core.settings.plugins.plugin_settings.clone());
         }
 
@@ -339,7 +339,7 @@ impl App for ThothApp {
             nm.show_notifications(ctx);
         }
 
-        // Restore plugin tabs that were deferred at startup (PLUGIN_MANAGER not ready yet).
+        // Restore plugin tabs that were deferred while the core runtime initialized.
         self.poll_pending_plugin_restores();
 
         // Handle OS-dispatched file opens (e.g. macOS Apple Events / Finder)
@@ -894,10 +894,10 @@ impl ThothApp {
     }
 
     fn open_ui_component_tab(&mut self, plugin_id: &str, initial_state: Option<&str>) {
-        let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) else {
+        let Some(manager) = self.core.plugins.manager() else {
             return;
         };
-        let Some(loader) = Self::build_plugin_loader(manager, plugin_id, &self.core.settings)
+        let Some(loader) = Self::build_plugin_loader(&manager, plugin_id, &self.core.settings)
         else {
             if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
                 tab.error = Some(crate::error::ThothError::Unknown {
@@ -944,10 +944,10 @@ impl ThothApp {
         &mut self,
         req: crate::plugin::plugin_ui_host::TabOpenRequest,
     ) {
-        let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) else {
+        let Some(manager) = self.core.plugins.manager() else {
             return;
         };
-        let Some(loader) = Self::build_plugin_loader(manager, &req.plugin_id, &self.core.settings)
+        let Some(loader) = Self::build_plugin_loader(&manager, &req.plugin_id, &self.core.settings)
         else {
             return;
         };
@@ -989,10 +989,10 @@ impl ThothApp {
         {
             return;
         }
-        let Some(manager) = PLUGIN_MANAGER.get().and_then(|m| m.as_ref()) else {
+        let Some(manager) = self.core.plugins.manager() else {
             return;
         };
-        let Some(loader) = Self::build_plugin_loader(manager, plugin_id, &self.core.settings)
+        let Some(loader) = Self::build_plugin_loader(&manager, plugin_id, &self.core.settings)
         else {
             return;
         };
@@ -1361,7 +1361,8 @@ impl ThothApp {
     /// Re-open tabs saved from the previous session.
     /// Returns `(deferred_plugin_ids, active_tab_index)`.
     /// - `deferred_plugin_ids`: plugin IDs that couldn't be opened yet because
-    ///   PLUGIN_MANAGER was still initializing; retried via `poll_pending_plugin_restores()`.
+    ///   the core plugin runtime was still initializing; retried via
+    ///   `poll_pending_plugin_restores()`.
     /// - `active_tab_index`: the dock-order index to switch to after all tabs are open.
     fn restore_tab_session(
         tab_manager: &mut crate::app::TabManager,
@@ -1398,25 +1399,9 @@ impl ThothApp {
                     }
                 }
                 PersistedTabKind::Plugin { plugin_id, state } => {
-                    // PLUGIN_MANAGER is set by a background thread; it may not be ready yet.
-                    match PLUGIN_MANAGER.get() {
-                        Some(manager_opt) => {
-                            if let Some(manager) = manager_opt.as_ref() {
-                                Self::open_plugin_tab(
-                                    tab_manager,
-                                    manager,
-                                    plugin_id,
-                                    state.as_deref(),
-                                    settings,
-                                );
-                            }
-                            // manager_opt == None means plugins are disabled — skip silently.
-                        }
-                        None => {
-                            // Manager not initialized yet — defer to poll loop.
-                            deferred_plugins.push((plugin_id.clone(), state.clone()));
-                        }
-                    }
+                    // Plugin initialization begins after the app core is installed,
+                    // so plugin tabs are restored by the non-blocking poll loop.
+                    deferred_plugins.push((plugin_id.clone(), state.clone()));
                 }
             }
         }
@@ -1465,23 +1450,25 @@ impl ThothApp {
         }
     }
 
-    /// Called each frame from `update()`. Once PLUGIN_MANAGER is ready, drains
+    /// Called each frame from `update()`. Once the core plugin runtime is ready, drains
     /// `pending_plugin_restores` and opens each plugin tab, then applies the
     /// saved active-tab index.
     fn poll_pending_plugin_restores(&mut self) {
         if self.core.pending_plugin_restores.is_empty() {
             return;
         }
-        // Wait until the background init thread has called PLUGIN_MANAGER.set().
-        let Some(manager_opt) = PLUGIN_MANAGER.get() else {
-            return;
+        use crate::plugin::runtime::PluginRuntimeState;
+        let manager = match self.core.plugins.state() {
+            PluginRuntimeState::Loading => return,
+            PluginRuntimeState::Disabled => None,
+            PluginRuntimeState::Ready(manager) => Some(manager),
         };
         let plugin_ids = std::mem::take(&mut self.core.pending_plugin_restores);
-        if let Some(manager) = manager_opt.as_ref() {
+        if let Some(manager) = manager {
             for (plugin_id, state) in &plugin_ids {
                 Self::open_plugin_tab(
                     &mut self.window_state.tab_manager,
-                    manager,
+                    &manager,
                     plugin_id,
                     state.as_deref(),
                     &self.core.settings,
@@ -1489,7 +1476,6 @@ impl ThothApp {
             }
             self.core.session_dirty = true;
         }
-        // If manager is None (plugins disabled), plugin_ids is simply dropped.
 
         // All deferred tabs are now open — apply the saved active-tab index.
         if let Some(idx) = self.core.session_restore_active_index.take() {
@@ -1871,15 +1857,14 @@ impl ThothApp {
 
         let focus_search = section_changed_to_search || sidebar_reopened_with_search;
 
-        let ds_plugins: Vec<&crate::plugin::Plugin> = PLUGIN_MANAGER
-            .get()
-            .and_then(|m| m.as_ref())
+        let plugin_manager = self.core.plugins.manager();
+        let ds_plugins: Vec<&crate::plugin::Plugin> = plugin_manager
+            .as_deref()
             .map(|m| m.get_data_source_plugins())
             .unwrap_or_default();
 
-        let ui_plugins: Vec<&crate::plugin::Plugin> = PLUGIN_MANAGER
-            .get()
-            .and_then(|m| m.as_ref())
+        let ui_plugins: Vec<&crate::plugin::Plugin> = plugin_manager
+            .as_deref()
             .map(|m| m.get_ui_component_plugins())
             .unwrap_or_default();
 
@@ -1901,9 +1886,8 @@ impl ThothApp {
 
         let plugin_sidebar_strings: Option<(String, String, Option<String>)> =
             sidebar_plugin_id.as_ref().and_then(|plugin_id| {
-                PLUGIN_MANAGER
-                    .get()
-                    .and_then(|m| m.as_ref())
+                plugin_manager
+                    .as_deref()
                     .and_then(|m| m.registry.get_by_id(plugin_id))
                     .map(|p| (p.id.clone(), p.name.clone(), p.icon.clone()))
             });
@@ -2216,10 +2200,12 @@ impl ThothApp {
     /// Whether the plugin with `plugin_id` declares the `data-producer`
     /// capability in its manifest.
     fn plugin_declares_producer(&self, plugin_id: &str) -> bool {
-        matches!(PLUGIN_MANAGER.get(), Some(Some(pm))
-            if pm
-                .get_plugin_by_id(plugin_id)
-                .is_some_and(|p| p.capabilities.contains(&crate::plugin::Capability::DataProducer)))
+        self.core.plugins.manager().is_some_and(|pm| {
+            pm.get_plugin_by_id(plugin_id).is_some_and(|p| {
+                p.capabilities
+                    .contains(&crate::plugin::Capability::DataProducer)
+            })
+        })
     }
 
     /// Resolve a producer tab's data directly (no registry): file tabs read
@@ -2451,7 +2437,7 @@ impl ThothApp {
         let records = dataset_records_json(handle);
 
         // Resolve the exporter plugin + engine, then run it.
-        let Some(Some(pm)) = crate::PLUGIN_MANAGER.get() else {
+        let Some(pm) = self.core.plugins.manager() else {
             NotificationManager::notify_error(Notification::new(
                 "Export failed",
                 "The plugin manager is not available.",
@@ -2684,7 +2670,7 @@ fn sanitize_filename(name: &str) -> String {
 
 /// Enumerate installed exporter plugins for the DataView's Export dropdown.
 pub fn list_exporters_for_view() -> Vec<thoth_plugin_sdk::dataset::ExporterInfo> {
-    let Some(Some(pm)) = crate::PLUGIN_MANAGER.get() else {
+    let Some(pm) = crate::plugin::runtime::active_manager() else {
         return Vec::new();
     };
     pm.get_all_plugin_by_capability(crate::plugin::Capability::Exporter)
@@ -2703,7 +2689,7 @@ pub fn list_exporters_for_view() -> Vec<thoth_plugin_sdk::dataset::ExporterInfo>
 
 /// Enumerate installed renderer plugins for the DataView's view dropdown.
 pub fn list_renderers_for_view() -> Vec<thoth_plugin_sdk::dataset::RendererInfo> {
-    let Some(Some(pm)) = crate::PLUGIN_MANAGER.get() else {
+    let Some(pm) = crate::plugin::runtime::active_manager() else {
         return Vec::new();
     };
     pm.get_all_plugin_by_capability(crate::plugin::Capability::Renderer)
@@ -2815,7 +2801,7 @@ pub fn render_dataset_with_plugin(
     // Miss / stale: run the plugin. Structural failures (no manager / plugin /
     // path) aren't cached, so they retry once those resolve.
     let records = dataset_records_json(handle);
-    let Some(Some(pm)) = crate::PLUGIN_MANAGER.get() else {
+    let Some(pm) = crate::plugin::runtime::active_manager() else {
         return PluginRenderResult::Unavailable;
     };
     let Some(plugin) = pm.get_plugin_by_id(plugin_id) else {

--- a/src/app/thoth_app.rs
+++ b/src/app/thoth_app.rs
@@ -910,10 +910,21 @@ impl ThothApp {
             let _ = loader.init_with_state(state);
         }
         let Some(ui) = loader.as_ui() else {
+            if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                tab.error = Some(crate::error::ThothError::Unknown {
+                    message: format!("Plugin '{plugin_id}' does not expose a UI component"),
+                });
+            }
             return;
         };
-        let Ok(ui_output) = ui.render_ui() else {
-            return;
+        let ui_output = match ui.render_ui() {
+            Ok(output) => output,
+            Err(error) => {
+                if let Some(tab) = self.window_state.tab_manager.active_tab_mut() {
+                    tab.error = Some(error);
+                }
+                return;
+            }
         };
         let sidebar_output = ui.render_sidebar().ok().flatten();
         let nav_capacity = self.core.settings.performance.navigation_history_size;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,11 +7,7 @@ use clap_complete::{Shell, generate};
 use serde_json::{Map, Value};
 use thoth_plugin_sdk::cli::{CliArgKind, CliInvocation, CliSchema, PluginCli};
 
-use crate::{
-    headless::{CliCommand, HeadlessRuntime},
-    plugin::plugin_ui_host::PluginCore,
-    settings::Settings,
-};
+use crate::{headless::HeadlessRuntime, plugin::plugin_ui_host::PluginCore, settings::Settings};
 
 /// Fully rendered output from one CLI invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,7 +18,7 @@ pub struct CliOutput {
 }
 
 enum Action {
-    Runtime(CliCommand),
+    ListCliPlugins,
     Plugin {
         plugin_id: String,
         invocation: CliInvocation,
@@ -64,7 +60,7 @@ where
 
     match action {
         Action::Completions(shell) => completion_output(shell, command(&schemas)),
-        Action::Runtime(command) => runtime_output(runtime.run(command)),
+        Action::ListCliPlugins => cli_plugins_output(&schemas),
         Action::Plugin {
             plugin_id,
             invocation,
@@ -83,7 +79,7 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let mut runtime = HeadlessRuntime::with_adapters(settings, core_plugins, cli_plugins);
+    let runtime = HeadlessRuntime::with_adapters(settings, core_plugins, cli_plugins);
     let schemas = runtime.cli_schemas();
     let cli = command(&schemas);
     let action = match parse(args, cli, &schemas) {
@@ -93,7 +89,7 @@ where
 
     match action {
         Action::Completions(shell) => completion_output(shell, command(&schemas)),
-        Action::Runtime(command) => runtime_output(runtime.run(command)),
+        Action::ListCliPlugins => cli_plugins_output(&schemas),
         Action::Plugin {
             plugin_id,
             invocation,
@@ -107,7 +103,7 @@ fn command(schemas: &[CliSchema]) -> Command {
         .about("Explore data from the terminal or desktop")
         .subcommand_required(true)
         .after_help("Plugin commands: thoth <plugin-id> <subcommand> [options]")
-        .subcommand(Command::new("plugins").about("List discovered plugins as JSON"))
+        .subcommand(Command::new("plugins").about("List available CLI plugin names"))
         .subcommand(
             Command::new("completions")
                 .about("Generate shell completion definitions")
@@ -122,8 +118,14 @@ fn command(schemas: &[CliSchema]) -> Command {
         let mut plugin = Command::new(schema.id.clone())
             .about(schema.about.clone())
             .subcommand_required(true);
+        if !schema.examples.is_empty() {
+            plugin = plugin.after_help(format_examples(&schema.examples));
+        }
         for declared in &schema.subcommands {
             let mut subcommand = Command::new(declared.name.clone()).about(declared.about.clone());
+            if !declared.examples.is_empty() {
+                subcommand = subcommand.after_help(format_examples(&declared.examples));
+            }
             for declared_arg in &declared.args {
                 let mut arg = Arg::new(declared_arg.id.clone())
                     .help(declared_arg.help.clone())
@@ -152,6 +154,10 @@ fn command(schemas: &[CliSchema]) -> Command {
     command
 }
 
+fn format_examples(examples: &[String]) -> String {
+    format!("Examples:\n  {}", examples.join("\n  "))
+}
+
 fn parse<I, T>(args: I, command: Command, schemas: &[CliSchema]) -> Result<Action, clap::Error>
 where
     I: IntoIterator<Item = T>,
@@ -162,7 +168,7 @@ where
         unreachable!("clap requires a top-level subcommand");
     };
     match top_level {
-        "plugins" => Ok(Action::Runtime(CliCommand::ListPlugins)),
+        "plugins" => Ok(Action::ListCliPlugins),
         "completions" => Ok(Action::Completions(
             *matches
                 .get_one::<Shell>("shell")
@@ -221,17 +227,14 @@ fn completion_output(shell: Shell, mut command: Command) -> CliOutput {
     }
 }
 
-fn runtime_output(result: crate::headless::HeadlessResult) -> CliOutput {
+fn cli_plugins_output(schemas: &[CliSchema]) -> CliOutput {
     CliOutput {
-        exit_code: result.exit_code,
-        stdout: result
-            .stdout
-            .map(|value| format!("{value}\n"))
-            .unwrap_or_default(),
-        stderr: result
-            .stderr
-            .map(|value| format!("{value}\n"))
-            .unwrap_or_default(),
+        exit_code: 0,
+        stdout: schemas
+            .iter()
+            .map(|schema| format!("{}\n", schema.id))
+            .collect(),
+        stderr: String::new(),
     }
 }
 
@@ -241,11 +244,7 @@ fn plugin_output(
     match result {
         Ok(output) => CliOutput {
             exit_code: 0,
-            stdout: output
-                .records
-                .into_iter()
-                .map(|record| format!("{record}\n"))
-                .collect(),
+            stdout: render_table(&output.records),
             stderr: String::new(),
         },
         Err(error) => CliOutput {
@@ -254,6 +253,120 @@ fn plugin_output(
             stderr: format!("{error}\n"),
         },
     }
+}
+
+fn render_table(records: &[Value]) -> String {
+    if records.is_empty() {
+        return "No results.\n".to_string();
+    }
+
+    let all_objects = records.iter().all(Value::is_object);
+    let columns = if all_objects {
+        let mut columns = Vec::new();
+        for record in records {
+            for key in record.as_object().expect("all records are objects").keys() {
+                if !columns.contains(key) {
+                    columns.push(key.clone());
+                }
+            }
+        }
+        columns
+    } else {
+        vec!["value".to_string()]
+    };
+
+    if columns.is_empty() {
+        return "No fields.\n".to_string();
+    }
+
+    let rows: Vec<Vec<String>> = records
+        .iter()
+        .map(|record| {
+            if all_objects {
+                let object = record.as_object().expect("all records are objects");
+                columns
+                    .iter()
+                    .map(|column| object.get(column).map(format_value).unwrap_or_default())
+                    .collect()
+            } else {
+                vec![format_value(record)]
+            }
+        })
+        .collect();
+    let widths: Vec<usize> = columns
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            rows.iter()
+                .map(|row| display_width(&row[index]))
+                .max()
+                .unwrap_or_default()
+                .max(display_width(column))
+        })
+        .collect();
+
+    let border = table_border(&widths);
+    let mut output = String::new();
+    output.push_str(&border);
+    write_table_row(&mut output, &columns, &widths);
+    output.push_str(&border);
+    for row in &rows {
+        write_table_row(&mut output, row, &widths);
+    }
+    output.push_str(&border);
+    output
+}
+
+fn format_value(value: &Value) -> String {
+    match value {
+        Value::Null => "—".to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => single_line(value),
+        Value::Array(values) => values
+            .iter()
+            .map(format_value)
+            .collect::<Vec<_>>()
+            .join(", "),
+        Value::Object(values) => values
+            .iter()
+            .map(|(key, value)| format!("{key}={}", format_value(value)))
+            .collect::<Vec<_>>()
+            .join("; "),
+    }
+}
+
+fn single_line(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}
+
+fn display_width(value: &str) -> usize {
+    value.chars().count()
+}
+
+fn table_border(widths: &[usize]) -> String {
+    let mut border = String::from("+");
+    for width in widths {
+        border.push_str(&"-".repeat(width + 2));
+        border.push('+');
+    }
+    border.push('\n');
+    border
+}
+
+fn write_table_row(output: &mut String, cells: &[String], widths: &[usize]) {
+    output.push('|');
+    for (cell, width) in cells.iter().zip(widths) {
+        output.push(' ');
+        output.push_str(cell);
+        output.push_str(&" ".repeat(width.saturating_sub(display_width(cell)) + 1));
+        output.push('|');
+    }
+    output.push('\n');
 }
 
 fn clap_error(error: clap::Error) -> CliOutput {
@@ -276,7 +389,7 @@ fn clap_error(error: clap::Error) -> CliOutput {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{Value, json};
+    use serde_json::json;
     use thoth_plugin_sdk::cli::{
         CliArg, CliArgKind, CliInvocation, CliOutput as PluginOutput, CliSchema, CliSubcommand,
         PluginCli,
@@ -292,6 +405,7 @@ mod tests {
             CliSchema {
                 id: "demo".into(),
                 about: "Demo plugin commands".into(),
+                examples: vec!["thoth demo query --index logs".into()],
                 subcommands: vec![CliSubcommand {
                     name: "query".into(),
                     about: "Query demo data".into(),
@@ -316,6 +430,7 @@ mod tests {
                             },
                         },
                     ],
+                    examples: vec!["thoth demo query --index logs".into()],
                 }],
             }
         }
@@ -364,10 +479,30 @@ mod tests {
             vec![Box::new(DemoCli)],
         );
         assert_eq!(output.exit_code, 0);
-        let value: Value = serde_json::from_str(output.stdout.trim()).unwrap();
-        assert_eq!(value["command"], "query");
-        assert_eq!(value["values"]["index"], "logs");
-        assert_eq!(value["values"]["pretty"], true);
+        assert_eq!(
+            output.stdout,
+            concat!(
+                "+---------+-------------------------+\n",
+                "| command | values                  |\n",
+                "+---------+-------------------------+\n",
+                "| query   | index=logs; pretty=true |\n",
+                "+---------+-------------------------+\n",
+            )
+        );
+    }
+
+    #[test]
+    fn plugins_lists_only_registered_cli_command_names() {
+        let output = run_with_plugins(
+            ["thoth", "plugins"],
+            disabled_settings(),
+            vec![],
+            vec![Box::new(DemoCli)],
+        );
+
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout, "demo\n");
+        assert!(output.stderr.is_empty());
     }
 
     #[test]
@@ -400,5 +535,27 @@ mod tests {
         assert_eq!(exit_code, 0);
         assert!(stdout.contains("#compdef thoth"));
         assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn plugin_records_render_as_a_table_without_json_syntax() {
+        let output = super::plugin_output(Ok(PluginOutput {
+            records: vec![
+                json!({ "name": "primary", "count": 2, "active": true }),
+                json!({ "name": "archive", "count": null, "active": false }),
+            ],
+        }));
+
+        assert!(output.stdout.contains("| active | count | name"));
+        assert!(output.stdout.contains("| true   | 2     | primary"));
+        assert!(output.stdout.contains("| false  | —     | archive"));
+        assert!(!output.stdout.contains("\"name\""));
+        assert!(!output.stdout.contains("{"));
+    }
+
+    #[test]
+    fn empty_plugin_output_is_human_readable() {
+        let output = super::plugin_output(Ok(PluginOutput::default()));
+        assert_eq!(output.stdout, "No results.\n");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,12 +2,14 @@
 
 use std::ffi::OsString;
 
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{Arg, ArgAction, ArgMatches, Command, value_parser};
 use clap_complete::{Shell, generate};
-use serde_json::json;
+use serde_json::{Map, Value};
+use thoth_plugin_sdk::cli::{CliArgKind, CliInvocation, CliSchema, PluginCli};
 
 use crate::{
     headless::{CliCommand, HeadlessRuntime},
+    plugin::plugin_ui_host::PluginCore,
     settings::Settings,
 };
 
@@ -19,34 +21,12 @@ pub struct CliOutput {
     pub stderr: String,
 }
 
-#[derive(Debug, Parser)]
-#[command(
-    name = "thoth",
-    version,
-    about = "Explore data from the terminal or desktop",
-    after_help = "Plugin commands: thoth <plugin-id> <subcommand> [options]"
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: TopLevelCommand,
-}
-
-#[derive(Debug, Subcommand)]
-enum TopLevelCommand {
-    /// List discovered plugins as JSON.
-    Plugins,
-    /// Generate shell completion definitions.
-    Completions {
-        /// Shell to generate completions for.
-        shell: Shell,
-    },
-    /// A command owned by an installed plugin.
-    #[command(external_subcommand)]
-    Plugin(Vec<OsString>),
-}
-
 enum Action {
     Runtime(CliCommand),
+    Plugin {
+        plugin_id: String,
+        invocation: CliInvocation,
+    },
     Completions(Shell),
 }
 
@@ -67,96 +47,286 @@ where
     T: Into<OsString> + Clone,
     F: FnOnce() -> Settings,
 {
-    let action = match parse(args) {
+    let mut runtime = HeadlessRuntime::new(load_settings());
+    if let Err(error) = runtime.discover_cli_plugins() {
+        return CliOutput {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: format!("{error}\n"),
+        };
+    }
+    let schemas = runtime.cli_schemas();
+    let parser = command(&schemas);
+    let action = match parse(args, parser, &schemas) {
         Ok(action) => action,
-        Err(error) => {
-            let exit_code = error.exit_code();
-            let message = error.to_string();
-            return if error.use_stderr() {
-                CliOutput {
-                    exit_code,
-                    stdout: String::new(),
-                    stderr: message,
-                }
-            } else {
-                CliOutput {
-                    exit_code,
-                    stdout: message,
-                    stderr: String::new(),
-                }
-            };
-        }
+        Err(error) => return clap_error(error),
     };
 
     match action {
-        Action::Completions(shell) => {
-            let mut bytes = Vec::new();
-            let mut command = Cli::command();
-            generate(shell, &mut command, "thoth", &mut bytes);
-            CliOutput {
-                exit_code: 0,
-                stdout: String::from_utf8(bytes)
-                    .expect("clap completion generators only emit UTF-8"),
-                stderr: String::new(),
-            }
-        }
-        Action::Runtime(command) => {
-            let result = HeadlessRuntime::new(load_settings()).run(command);
-            CliOutput {
-                exit_code: result.exit_code,
-                stdout: result
-                    .stdout
-                    .map(|value| format!("{value}\n"))
-                    .unwrap_or_default(),
-                stderr: result
-                    .stderr
-                    .map(|value| format!("{value}\n"))
-                    .unwrap_or_default(),
-            }
-        }
+        Action::Completions(shell) => completion_output(shell, command(&schemas)),
+        Action::Runtime(command) => runtime_output(runtime.run(command)),
+        Action::Plugin {
+            plugin_id,
+            invocation,
+        } => plugin_output(runtime.run_cli(&plugin_id, &invocation)),
     }
 }
 
-fn parse<I, T>(args: I) -> Result<Action, clap::Error>
+/// Run with explicit live plugin adapters, used by the WASM registry and tests.
+pub fn run_with_plugins<I, T>(
+    args: I,
+    settings: Settings,
+    core_plugins: Vec<Box<dyn PluginCore>>,
+    cli_plugins: Vec<Box<dyn PluginCli>>,
+) -> CliOutput
 where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    match Cli::try_parse_from(args)?.command {
-        TopLevelCommand::Plugins => Ok(Action::Runtime(CliCommand::ListPlugins)),
-        TopLevelCommand::Completions { shell } => Ok(Action::Completions(shell)),
-        TopLevelCommand::Plugin(parts) => parse_plugin_command(parts),
+    let mut runtime = HeadlessRuntime::with_adapters(settings, core_plugins, cli_plugins);
+    let schemas = runtime.cli_schemas();
+    let cli = command(&schemas);
+    let action = match parse(args, cli, &schemas) {
+        Ok(action) => action,
+        Err(error) => return clap_error(error),
+    };
+
+    match action {
+        Action::Completions(shell) => completion_output(shell, command(&schemas)),
+        Action::Runtime(command) => runtime_output(runtime.run(command)),
+        Action::Plugin {
+            plugin_id,
+            invocation,
+        } => plugin_output(runtime.run_cli(&plugin_id, &invocation)),
     }
 }
 
-fn parse_plugin_command(parts: Vec<OsString>) -> Result<Action, clap::Error> {
-    let mut parts = parts.into_iter();
-    let plugin_id = parts
-        .next()
-        .expect("external subcommands always contain their command name")
-        .to_string_lossy()
-        .into_owned();
-    let Some(command) = parts.next() else {
-        return Err(Cli::command().error(
-            clap::error::ErrorKind::MissingRequiredArgument,
-            format!("plugin '{plugin_id}' requires a subcommand"),
-        ));
-    };
-    let argv: Vec<String> = parts
-        .map(|part| part.to_string_lossy().into_owned())
-        .collect();
+fn command(schemas: &[CliSchema]) -> Command {
+    let mut command = Command::new("thoth")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("Explore data from the terminal or desktop")
+        .subcommand_required(true)
+        .after_help("Plugin commands: thoth <plugin-id> <subcommand> [options]")
+        .subcommand(Command::new("plugins").about("List discovered plugins as JSON"))
+        .subcommand(
+            Command::new("completions")
+                .about("Generate shell completion definitions")
+                .arg(
+                    Arg::new("shell")
+                        .required(true)
+                        .value_parser(value_parser!(Shell)),
+                ),
+        );
 
-    Ok(Action::Runtime(CliCommand::Plugin {
-        plugin_id,
-        command: command.to_string_lossy().into_owned(),
-        args: json!({ "argv": argv }),
-    }))
+    for schema in schemas {
+        let mut plugin = Command::new(schema.id.clone())
+            .about(schema.about.clone())
+            .subcommand_required(true);
+        for declared in &schema.subcommands {
+            let mut subcommand = Command::new(declared.name.clone()).about(declared.about.clone());
+            for declared_arg in &declared.args {
+                let mut arg = Arg::new(declared_arg.id.clone())
+                    .help(declared_arg.help.clone())
+                    .required(declared_arg.required);
+                arg = match &declared_arg.kind {
+                    CliArgKind::Positional { value_name } => arg.value_name(value_name.clone()),
+                    CliArgKind::Option {
+                        long,
+                        short,
+                        value_name,
+                    } => {
+                        let arg = arg.long(long.clone()).value_name(value_name.clone());
+                        short.map_or(arg.clone(), |short| arg.short(short))
+                    }
+                    CliArgKind::Flag { long, short } => {
+                        let arg = arg.long(long.clone()).action(ArgAction::SetTrue);
+                        short.map_or(arg.clone(), |short| arg.short(short))
+                    }
+                };
+                subcommand = subcommand.arg(arg);
+            }
+            plugin = plugin.subcommand(subcommand);
+        }
+        command = command.subcommand(plugin);
+    }
+    command
+}
+
+fn parse<I, T>(args: I, command: Command, schemas: &[CliSchema]) -> Result<Action, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let matches = command.try_get_matches_from(args)?;
+    let Some((top_level, matches)) = matches.subcommand() else {
+        unreachable!("clap requires a top-level subcommand");
+    };
+    match top_level {
+        "plugins" => Ok(Action::Runtime(CliCommand::ListPlugins)),
+        "completions" => Ok(Action::Completions(
+            *matches
+                .get_one::<Shell>("shell")
+                .expect("shell is required by clap"),
+        )),
+        plugin_id => parse_plugin(plugin_id, matches, schemas),
+    }
+}
+
+fn parse_plugin(
+    plugin_id: &str,
+    matches: &ArgMatches,
+    schemas: &[CliSchema],
+) -> Result<Action, clap::Error> {
+    let schema = schemas
+        .iter()
+        .find(|schema| schema.id == plugin_id)
+        .expect("clap only accepts registered plugin ids");
+    let (subcommand, matches) = matches
+        .subcommand()
+        .expect("plugin subcommands are required by clap");
+    let declared = schema
+        .subcommands
+        .iter()
+        .find(|declared| declared.name == subcommand)
+        .expect("clap only accepts registered plugin subcommands");
+    let mut values = Map::new();
+    for arg in &declared.args {
+        match arg.kind {
+            CliArgKind::Flag { .. } => {
+                values.insert(arg.id.clone(), Value::Bool(matches.get_flag(&arg.id)));
+            }
+            _ => {
+                if let Some(value) = matches.get_one::<String>(&arg.id) {
+                    values.insert(arg.id.clone(), Value::String(value.clone()));
+                }
+            }
+        }
+    }
+    Ok(Action::Plugin {
+        plugin_id: plugin_id.to_string(),
+        invocation: CliInvocation {
+            subcommand: subcommand.to_string(),
+            values,
+        },
+    })
+}
+
+fn completion_output(shell: Shell, mut command: Command) -> CliOutput {
+    let mut bytes = Vec::new();
+    generate(shell, &mut command, "thoth", &mut bytes);
+    CliOutput {
+        exit_code: 0,
+        stdout: String::from_utf8(bytes).expect("completion generators only emit UTF-8"),
+        stderr: String::new(),
+    }
+}
+
+fn runtime_output(result: crate::headless::HeadlessResult) -> CliOutput {
+    CliOutput {
+        exit_code: result.exit_code,
+        stdout: result
+            .stdout
+            .map(|value| format!("{value}\n"))
+            .unwrap_or_default(),
+        stderr: result
+            .stderr
+            .map(|value| format!("{value}\n"))
+            .unwrap_or_default(),
+    }
+}
+
+fn plugin_output(
+    result: std::result::Result<thoth_plugin_sdk::cli::CliOutput, String>,
+) -> CliOutput {
+    match result {
+        Ok(output) => CliOutput {
+            exit_code: 0,
+            stdout: output
+                .records
+                .into_iter()
+                .map(|record| format!("{record}\n"))
+                .collect(),
+            stderr: String::new(),
+        },
+        Err(error) => CliOutput {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: format!("{error}\n"),
+        },
+    }
+}
+
+fn clap_error(error: clap::Error) -> CliOutput {
+    let exit_code = error.exit_code();
+    let message = error.to_string();
+    if error.use_stderr() {
+        CliOutput {
+            exit_code,
+            stdout: String::new(),
+            stderr: message,
+        }
+    } else {
+        CliOutput {
+            exit_code,
+            stdout: message,
+            stderr: String::new(),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Action, CliOutput, parse, run};
-    use crate::{headless::CliCommand, settings::Settings};
+    use serde_json::{Value, json};
+    use thoth_plugin_sdk::cli::{
+        CliArg, CliArgKind, CliInvocation, CliOutput as PluginOutput, CliSchema, CliSubcommand,
+        PluginCli,
+    };
+
+    use super::{CliOutput, run, run_with_plugins};
+    use crate::settings::Settings;
+
+    struct DemoCli;
+
+    impl PluginCli for DemoCli {
+        fn cli_schema(&self) -> CliSchema {
+            CliSchema {
+                id: "demo".into(),
+                about: "Demo plugin commands".into(),
+                subcommands: vec![CliSubcommand {
+                    name: "query".into(),
+                    about: "Query demo data".into(),
+                    args: vec![
+                        CliArg {
+                            id: "index".into(),
+                            help: "Index name".into(),
+                            required: true,
+                            kind: CliArgKind::Option {
+                                long: "index".into(),
+                                short: Some('i'),
+                                value_name: "INDEX".into(),
+                            },
+                        },
+                        CliArg {
+                            id: "pretty".into(),
+                            help: "Pretty output".into(),
+                            required: false,
+                            kind: CliArgKind::Flag {
+                                long: "pretty".into(),
+                                short: Some('p'),
+                            },
+                        },
+                    ],
+                }],
+            }
+        }
+
+        fn run_cli(&self, invocation: &CliInvocation) -> Result<PluginOutput, String> {
+            Ok(PluginOutput::one(json!({
+                "command": invocation.subcommand,
+                "values": invocation.values,
+            })))
+        }
+    }
 
     fn disabled_settings() -> Settings {
         let mut settings = Settings::default();
@@ -167,7 +337,6 @@ mod tests {
     #[test]
     fn help_documents_plugin_command_shape() {
         let output = run(["thoth", "--help"], disabled_settings());
-
         assert_eq!(output.exit_code, 0);
         assert!(
             output
@@ -178,45 +347,47 @@ mod tests {
     }
 
     #[test]
-    fn parses_plugin_commands_and_preserves_options() {
-        let action = parse([
-            "thoth",
-            "seshat",
-            "query",
-            "--index",
-            "logs",
-            "-q",
-            "level:error",
-        ])
-        .unwrap();
-        let Action::Runtime(CliCommand::Plugin {
-            plugin_id,
-            command,
-            args,
-        }) = action
-        else {
-            panic!("expected a plugin command");
-        };
-
-        assert_eq!(plugin_id, "seshat");
-        assert_eq!(command, "query");
-        assert_eq!(
-            args,
-            serde_json::json!({ "argv": ["--index", "logs", "-q", "level:error"] })
+    fn registered_plugin_appears_in_help_and_routes_values() {
+        let help = run_with_plugins(
+            ["thoth", "--help"],
+            disabled_settings(),
+            vec![],
+            vec![Box::new(DemoCli)],
         );
+        assert!(help.stdout.contains("demo"));
+        assert!(help.stdout.contains("Demo plugin commands"));
+
+        let output = run_with_plugins(
+            ["thoth", "demo", "query", "--index", "logs", "--pretty"],
+            disabled_settings(),
+            vec![],
+            vec![Box::new(DemoCli)],
+        );
+        assert_eq!(output.exit_code, 0);
+        let value: Value = serde_json::from_str(output.stdout.trim()).unwrap();
+        assert_eq!(value["command"], "query");
+        assert_eq!(value["values"]["index"], "logs");
+        assert_eq!(value["values"]["pretty"], true);
     }
 
     #[test]
-    fn missing_plugin_subcommand_is_a_clear_error() {
-        let output = run(["thoth", "seshat"], disabled_settings());
-
+    fn unknown_plugin_is_a_clear_clap_error() {
+        let output = run(["thoth", "missing", "query"], disabled_settings());
         assert_ne!(output.exit_code, 0);
         assert!(output.stdout.is_empty());
-        assert!(
-            output
-                .stderr
-                .contains("plugin 'seshat' requires a subcommand")
+        assert!(output.stderr.contains("unrecognized subcommand 'missing'"));
+    }
+
+    #[test]
+    fn registered_plugin_requires_a_subcommand() {
+        let output = run_with_plugins(
+            ["thoth", "demo"],
+            disabled_settings(),
+            vec![],
+            vec![Box::new(DemoCli)],
         );
+        assert_ne!(output.exit_code, 0);
+        assert!(output.stderr.contains("subcommand"));
     }
 
     #[test]
@@ -226,7 +397,6 @@ mod tests {
             stdout,
             stderr,
         } = run(["thoth", "completions", "zsh"], disabled_settings());
-
         assert_eq!(exit_code, 0);
         assert!(stdout.contains("#compdef thoth"));
         assert!(stderr.is_empty());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,24 @@ pub struct CliOutput {
     pub stderr: String,
 }
 
+/// Return whether an argument selects a built-in or discovered CLI command.
+pub fn is_known_command(argument: &str, plugin_ids: &[String]) -> bool {
+    argument.starts_with('-')
+        || matches!(argument, "plugins" | "completions" | "help")
+        || plugin_ids.iter().any(|id| id == argument)
+}
+
+/// Discover plugin command IDs for resolving a command/file name collision.
+pub fn discover_command_ids(settings: Settings) -> Result<Vec<String>, String> {
+    let mut runtime = HeadlessRuntime::new(settings);
+    runtime.discover_cli_plugins()?;
+    Ok(runtime
+        .cli_schemas()
+        .into_iter()
+        .map(|schema| schema.id)
+        .collect())
+}
+
 enum Action {
     ListCliPlugins,
     Plugin {
@@ -35,8 +53,8 @@ where
     run_with(args, || settings)
 }
 
-/// Parse a CLI invocation and load settings only when it reaches the runtime.
-/// Help and completion generation therefore remain side-effect free.
+/// Load settings, discover plugin command schemas, then parse and run a CLI
+/// invocation. Discovery also runs for help and completion generation.
 pub fn run_with<I, T, F>(args: I, load_settings: F) -> CliOutput
 where
     I: IntoIterator<Item = T>,
@@ -345,7 +363,7 @@ fn single_line(value: &str) -> String {
 }
 
 fn display_width(value: &str) -> usize {
-    value.chars().count()
+    unicode_width::UnicodeWidthStr::width(value)
 }
 
 fn table_border(widths: &[usize]) -> String {
@@ -557,5 +575,20 @@ mod tests {
     fn empty_plugin_output_is_human_readable() {
         let output = super::plugin_output(Ok(PluginOutput::default()));
         assert_eq!(output.stdout, "No results.\n");
+    }
+
+    #[test]
+    fn recognizes_built_in_flags_and_discovered_commands() {
+        let plugins = vec!["seshat".to_string()];
+        assert!(super::is_known_command("--help", &plugins));
+        assert!(super::is_known_command("completions", &plugins));
+        assert!(super::is_known_command("seshat", &plugins));
+        assert!(!super::is_known_command("data.json", &plugins));
+    }
+
+    #[test]
+    fn table_width_uses_terminal_cells() {
+        assert_eq!(super::display_width("界"), 2);
+        assert_eq!(super::display_width("e\u{301}"), 1);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,234 @@
+//! Command-line entry point for Thoth's display-free runtime.
+
+use std::ffi::OsString;
+
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
+use serde_json::json;
+
+use crate::{
+    headless::{CliCommand, HeadlessRuntime},
+    settings::Settings,
+};
+
+/// Fully rendered output from one CLI invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "thoth",
+    version,
+    about = "Explore data from the terminal or desktop",
+    after_help = "Plugin commands: thoth <plugin-id> <subcommand> [options]"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: TopLevelCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum TopLevelCommand {
+    /// List discovered plugins as JSON.
+    Plugins,
+    /// Generate shell completion definitions.
+    Completions {
+        /// Shell to generate completions for.
+        shell: Shell,
+    },
+    /// A command owned by an installed plugin.
+    #[command(external_subcommand)]
+    Plugin(Vec<OsString>),
+}
+
+enum Action {
+    Runtime(CliCommand),
+    Completions(Shell),
+}
+
+/// Parse and run a CLI invocation without initializing a native window.
+pub fn run<I, T>(args: I, settings: Settings) -> CliOutput
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    run_with(args, || settings)
+}
+
+/// Parse a CLI invocation and load settings only when it reaches the runtime.
+/// Help and completion generation therefore remain side-effect free.
+pub fn run_with<I, T, F>(args: I, load_settings: F) -> CliOutput
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+    F: FnOnce() -> Settings,
+{
+    let action = match parse(args) {
+        Ok(action) => action,
+        Err(error) => {
+            let exit_code = error.exit_code();
+            let message = error.to_string();
+            return if error.use_stderr() {
+                CliOutput {
+                    exit_code,
+                    stdout: String::new(),
+                    stderr: message,
+                }
+            } else {
+                CliOutput {
+                    exit_code,
+                    stdout: message,
+                    stderr: String::new(),
+                }
+            };
+        }
+    };
+
+    match action {
+        Action::Completions(shell) => {
+            let mut bytes = Vec::new();
+            let mut command = Cli::command();
+            generate(shell, &mut command, "thoth", &mut bytes);
+            CliOutput {
+                exit_code: 0,
+                stdout: String::from_utf8(bytes)
+                    .expect("clap completion generators only emit UTF-8"),
+                stderr: String::new(),
+            }
+        }
+        Action::Runtime(command) => {
+            let result = HeadlessRuntime::new(load_settings()).run(command);
+            CliOutput {
+                exit_code: result.exit_code,
+                stdout: result
+                    .stdout
+                    .map(|value| format!("{value}\n"))
+                    .unwrap_or_default(),
+                stderr: result
+                    .stderr
+                    .map(|value| format!("{value}\n"))
+                    .unwrap_or_default(),
+            }
+        }
+    }
+}
+
+fn parse<I, T>(args: I) -> Result<Action, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    match Cli::try_parse_from(args)?.command {
+        TopLevelCommand::Plugins => Ok(Action::Runtime(CliCommand::ListPlugins)),
+        TopLevelCommand::Completions { shell } => Ok(Action::Completions(shell)),
+        TopLevelCommand::Plugin(parts) => parse_plugin_command(parts),
+    }
+}
+
+fn parse_plugin_command(parts: Vec<OsString>) -> Result<Action, clap::Error> {
+    let mut parts = parts.into_iter();
+    let plugin_id = parts
+        .next()
+        .expect("external subcommands always contain their command name")
+        .to_string_lossy()
+        .into_owned();
+    let Some(command) = parts.next() else {
+        return Err(Cli::command().error(
+            clap::error::ErrorKind::MissingRequiredArgument,
+            format!("plugin '{plugin_id}' requires a subcommand"),
+        ));
+    };
+    let argv: Vec<String> = parts
+        .map(|part| part.to_string_lossy().into_owned())
+        .collect();
+
+    Ok(Action::Runtime(CliCommand::Plugin {
+        plugin_id,
+        command: command.to_string_lossy().into_owned(),
+        args: json!({ "argv": argv }),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Action, CliOutput, parse, run};
+    use crate::{headless::CliCommand, settings::Settings};
+
+    fn disabled_settings() -> Settings {
+        let mut settings = Settings::default();
+        settings.plugins.enabled = false;
+        settings
+    }
+
+    #[test]
+    fn help_documents_plugin_command_shape() {
+        let output = run(["thoth", "--help"], disabled_settings());
+
+        assert_eq!(output.exit_code, 0);
+        assert!(
+            output
+                .stdout
+                .contains("thoth <plugin-id> <subcommand> [options]")
+        );
+        assert!(output.stderr.is_empty());
+    }
+
+    #[test]
+    fn parses_plugin_commands_and_preserves_options() {
+        let action = parse([
+            "thoth",
+            "seshat",
+            "query",
+            "--index",
+            "logs",
+            "-q",
+            "level:error",
+        ])
+        .unwrap();
+        let Action::Runtime(CliCommand::Plugin {
+            plugin_id,
+            command,
+            args,
+        }) = action
+        else {
+            panic!("expected a plugin command");
+        };
+
+        assert_eq!(plugin_id, "seshat");
+        assert_eq!(command, "query");
+        assert_eq!(
+            args,
+            serde_json::json!({ "argv": ["--index", "logs", "-q", "level:error"] })
+        );
+    }
+
+    #[test]
+    fn missing_plugin_subcommand_is_a_clear_error() {
+        let output = run(["thoth", "seshat"], disabled_settings());
+
+        assert_ne!(output.exit_code, 0);
+        assert!(output.stdout.is_empty());
+        assert!(
+            output
+                .stderr
+                .contains("plugin 'seshat' requires a subcommand")
+        );
+    }
+
+    #[test]
+    fn generates_zsh_completions() {
+        let CliOutput {
+            exit_code,
+            stdout,
+            stderr,
+        } = run(["thoth", "completions", "zsh"], disabled_settings());
+
+        assert_eq!(exit_code, 0);
+        assert!(stdout.contains("#compdef thoth"));
+        assert!(stderr.is_empty());
+    }
+}

--- a/src/components/drag_and_drop.rs
+++ b/src/components/drag_and_drop.rs
@@ -102,7 +102,7 @@ impl app::ThothApp {
 
         let dropped_files = ctx.input(|i| i.raw.dropped_files.clone());
         if !dropped_files.is_empty() {
-            let nav_capacity = self.settings.performance.navigation_history_size;
+            let nav_capacity = self.core.settings.performance.navigation_history_size;
             for file in dropped_files {
                 if let Some(path) = file.path {
                     match sniff_file_type(&path) {

--- a/src/components/file_viewer/mod.rs
+++ b/src/components/file_viewer/mod.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 
 use self::types::ViewerState;
 use self::viewer_type::ViewerType;
-use crate::PLUGIN_MANAGER;
 use crate::file::loaders::{FileKind, FileType, load_file_auto};
 use crate::helpers::LruCache;
 use crate::plugin::Capability;
@@ -89,24 +88,22 @@ impl FileViewer {
         // Check if a plugin is registered for this extension.
         // If one is registered, its result (success or error) is used — we do NOT
         // silently fall through to JSON parsing when a plugin claims the format.
-        let plugin_result = PLUGIN_MANAGER
-            .get()
-            .and_then(|opt| opt.as_ref())
-            .and_then(|pm| {
-                if pm.find_loader_for_extension(ext_str).is_some() {
-                    let result: crate::error::Result<(FileType, FileKind)> =
-                        if pm.plugin_has_capability(ext_str, &Capability::FileViewer) {
-                            pm.open_file_with_viewer(ext_str, path)
-                                .map(|wfl| (FileType::PluginWithViewer(wfl), FileKind::PluginTable))
-                        } else {
-                            pm.open_file(ext_str, path)
-                                .map(|wfl| (FileType::Plugin(wfl), FileKind::Plugin))
-                        };
-                    Some(result)
-                } else {
-                    None
-                }
-            });
+        let plugin_manager = crate::plugin::runtime::active_manager();
+        let plugin_result = plugin_manager.as_deref().and_then(|pm| {
+            if pm.find_loader_for_extension(ext_str).is_some() {
+                let result: crate::error::Result<(FileType, FileKind)> =
+                    if pm.plugin_has_capability(ext_str, &Capability::FileViewer) {
+                        pm.open_file_with_viewer(ext_str, path)
+                            .map(|wfl| (FileType::PluginWithViewer(wfl), FileKind::PluginTable))
+                    } else {
+                        pm.open_file(ext_str, path)
+                            .map(|wfl| (FileType::Plugin(wfl), FileKind::Plugin))
+                    };
+                Some(result)
+            } else {
+                None
+            }
+        });
 
         let (loader, kind) = match plugin_result {
             Some(Ok((file_type, file_kind))) => (file_type, file_kind),

--- a/src/components/settings_dialog/mod.rs
+++ b/src/components/settings_dialog/mod.rs
@@ -478,7 +478,7 @@ impl SettingsDialog {
                             }
                         }
                         PluginsTabEvent::UninstallPlugin(id) => {
-                            if let Some(Some(pm)) = crate::PLUGIN_MANAGER.get() {
+                            if let Some(pm) = crate::plugin::runtime::active_manager() {
                                 let wasm_path =
                                     pm.registry.get_by_id(&id).and_then(|p| p.location.clone());
                                 if let Some(location) = wasm_path {

--- a/src/components/settings_dialog/plugins.rs
+++ b/src/components/settings_dialog/plugins.rs
@@ -1,6 +1,5 @@
 use eframe::egui;
 
-use crate::PLUGIN_MANAGER;
 use crate::components::common::traits::StatelessComponent;
 use crate::components::settings_dialog::helpers::{group_rows, section_header, setting_row};
 use crate::error::ErrorHandler;
@@ -56,7 +55,7 @@ impl StatelessComponent for PluginsTab {
                 .unwrap_or_else(|| Theme::default().colors())
         });
 
-        let Some(Some(pm)) = PLUGIN_MANAGER.get() else {
+        let Some(pm) = crate::plugin::runtime::active_manager() else {
             egui::ScrollArea::vertical()
                 .auto_shrink([false; 2])
                 .show(ui, |ui| {
@@ -75,7 +74,7 @@ impl StatelessComponent for PluginsTab {
                         None => PluginNetworkPolicy::default(),
                     };
 
-                Self::render_settings(ui, plugin, pm, colors, &plugin_network_setting)
+                Self::render_settings(ui, plugin, &pm, colors, &plugin_network_setting)
             } else {
                 vec![]
             }

--- a/src/components/toolbar.rs
+++ b/src/components/toolbar.rs
@@ -232,7 +232,7 @@ fn infer_file_type(path: &Path) -> Option<FileKind> {
         _ => {
             // Ask the plugin registry whether any plugin handles this extension
             // so we don't fall back to a stale file-type from the previous file.
-            if let Some(Some(pm)) = crate::PLUGIN_MANAGER.get()
+            if let Some(pm) = crate::plugin::runtime::active_manager()
                 && pm.find_loader_for_extension(&ext).is_some()
             {
                 return Some(

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,0 +1,100 @@
+//! Display-independent application state and event processing.
+//!
+//! [`ThothCore`] can be constructed and ticked without creating an egui context
+//! or a native window. The desktop app owns one core and applies the actions it
+//! emits to its window-specific state. A headless runtime can drive the same
+//! event queue directly.
+
+use std::{collections::VecDeque, path::PathBuf};
+
+use crate::{
+    app::{persistent_state::PersistentState, tab_manager::TabId},
+    settings::Settings,
+    state::ApplicationUpdateState,
+};
+
+/// An input delivered to the application core.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CoreEvent {
+    /// Request that the host open a local file.
+    OpenFile(PathBuf),
+}
+
+/// Work emitted by [`ThothCore::tick`] for a host runtime to perform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CoreAction {
+    /// Open a local file in the active host surface.
+    OpenFile(PathBuf),
+}
+
+/// Non-render state shared by GUI and future headless runtimes.
+pub struct ThothCore {
+    pub settings: Settings,
+    pub persistent_state: PersistentState,
+    pub update_state: ApplicationUpdateState,
+    pub(crate) settings_changed: bool,
+    pub(crate) session_dirty: bool,
+    pub(crate) pending_plugin_restores: Vec<(String, Option<String>)>,
+    pub(crate) session_restore_active_index: Option<usize>,
+    pub(crate) last_active_plugin_tab: Option<TabId>,
+    pub(crate) chart_counter: usize,
+    pub(crate) chart_source: Option<(TabId, Vec<String>, Vec<Vec<String>>)>,
+    events: VecDeque<CoreEvent>,
+}
+
+impl ThothCore {
+    /// Initialize application state without creating a graphics context or window.
+    pub fn init(settings: Settings) -> Self {
+        Self::with_persistent_state(settings, PersistentState::default())
+    }
+
+    pub(crate) fn with_persistent_state(
+        settings: Settings,
+        persistent_state: PersistentState,
+    ) -> Self {
+        Self {
+            settings,
+            persistent_state,
+            update_state: ApplicationUpdateState::default(),
+            settings_changed: false,
+            session_dirty: false,
+            pending_plugin_restores: Vec::new(),
+            session_restore_active_index: None,
+            last_active_plugin_tab: None,
+            chart_counter: 0,
+            chart_source: None,
+            events: VecDeque::new(),
+        }
+    }
+
+    /// Queue an event for processing on the next tick.
+    pub fn dispatch_event(&mut self, event: CoreEvent) {
+        self.events.push_back(event);
+    }
+
+    /// Process all queued events without blocking and return host actions.
+    pub fn tick(&mut self) -> Vec<CoreAction> {
+        self.events
+            .drain(..)
+            .map(|event| match event {
+                CoreEvent::OpenFile(path) => CoreAction::OpenFile(path),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CoreAction, CoreEvent, ThothCore};
+
+    #[test]
+    fn initializes_and_ticks_without_a_display() {
+        let mut core = ThothCore::init(crate::settings::Settings::default());
+        let path = std::path::PathBuf::from("headless.json");
+
+        core.dispatch_event(CoreEvent::OpenFile(path.clone()));
+
+        assert_eq!(core.tick(), vec![CoreAction::OpenFile(path)]);
+        assert!(core.tick().is_empty());
+    }
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -9,6 +9,7 @@ use std::{collections::VecDeque, path::PathBuf};
 
 use crate::{
     app::{persistent_state::PersistentState, tab_manager::TabId},
+    plugin::{datasets::DatasetStore, runtime::PluginRuntime},
     settings::Settings,
     state::ApplicationUpdateState,
 };
@@ -32,6 +33,10 @@ pub struct ThothCore {
     pub settings: Settings,
     pub persistent_state: PersistentState,
     pub update_state: ApplicationUpdateState,
+    /// Asynchronously initialized plugin manager owned by the application core.
+    pub plugins: PluginRuntime,
+    /// Host-owned dataset registry shared with plugin WIT and SDK callbacks.
+    pub datasets: DatasetStore,
     pub(crate) settings_changed: bool,
     pub(crate) session_dirty: bool,
     pub(crate) pending_plugin_restores: Vec<(String, Option<String>)>,
@@ -56,6 +61,8 @@ impl ThothCore {
             settings,
             persistent_state,
             update_state: ApplicationUpdateState::default(),
+            plugins: PluginRuntime::new(),
+            datasets: DatasetStore::new(),
             settings_changed: false,
             session_dirty: false,
             pending_plugin_restores: Vec::new(),

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -4,10 +4,12 @@ use std::{collections::HashSet, time::Duration};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use thoth_plugin_sdk::cli::{CliInvocation, CliOutput, CliSchema, PluginCli};
 
 use crate::{
     core::ThothCore,
     plugin::{
+        Capability,
         plugin_ui_host::{PluginCore, PluginCoreEvent},
         runtime::PluginRuntimeState,
     },
@@ -68,6 +70,7 @@ pub struct HeadlessRuntime {
     /// Display-independent application state and services.
     pub core: ThothCore,
     plugins: Vec<Box<dyn PluginCore>>,
+    cli_plugins: Vec<Box<dyn PluginCli>>,
     initialized: HashSet<String>,
     plugin_init_timeout: Duration,
 }
@@ -82,6 +85,15 @@ impl HeadlessRuntime {
     ///
     /// This is the integration seam used by plugin CLI adapters and tests.
     pub fn with_plugins(settings: Settings, plugins: Vec<Box<dyn PluginCore>>) -> Self {
+        Self::with_adapters(settings, plugins, Vec::new())
+    }
+
+    /// Bootstrap with explicit core and CLI adapters.
+    pub fn with_adapters(
+        settings: Settings,
+        plugins: Vec<Box<dyn PluginCore>>,
+        cli_plugins: Vec<Box<dyn PluginCli>>,
+    ) -> Self {
         let core = ThothCore::init(settings);
         core.plugins.install_as_active();
         core.datasets.install_as_active();
@@ -92,9 +104,73 @@ impl HeadlessRuntime {
         Self {
             core,
             plugins,
+            cli_plugins,
             initialized: HashSet::new(),
             plugin_init_timeout: Duration::from_secs(10),
         }
+    }
+
+    /// Collect the schemas declared by all opt-in CLI adapters.
+    pub fn cli_schemas(&self) -> Vec<CliSchema> {
+        self.cli_plugins
+            .iter()
+            .map(|plugin| plugin.cli_schema())
+            .collect()
+    }
+
+    /// Discover every manifest that declares the CLI capability and load its
+    /// adapter through the `plugin-cli` WIT interface.
+    pub fn discover_cli_plugins(&mut self) -> std::result::Result<(), String> {
+        let deadline = std::time::Instant::now() + self.plugin_init_timeout;
+        let manager = loop {
+            match self.core.plugins.state() {
+                PluginRuntimeState::Ready(manager) => break Some(manager),
+                PluginRuntimeState::Disabled => break None,
+                PluginRuntimeState::Loading if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                PluginRuntimeState::Loading => {
+                    return Err("plugin initialization timed out".into());
+                }
+            }
+        };
+
+        self.cli_plugins.clear();
+        let Some(manager) = manager else {
+            return Ok(());
+        };
+        let mut command_ids = HashSet::new();
+        for plugin in manager.get_all_plugin_by_capability(Capability::Cli) {
+            let adapter = manager.open_cli(&plugin.id).map_err(|error| {
+                format!("failed to load CLI for plugin '{}': {error}", plugin.id)
+            })?;
+            let schema = adapter.cli_schema();
+            if matches!(schema.id.as_str(), "plugins" | "completions" | "help") {
+                return Err(format!(
+                    "plugin '{}' uses reserved CLI id '{}'",
+                    plugin.id, schema.id
+                ));
+            }
+            if !command_ids.insert(schema.id.clone()) {
+                return Err(format!("duplicate plugin CLI id '{}'", schema.id));
+            }
+            self.cli_plugins.push(Box::new(adapter));
+        }
+        Ok(())
+    }
+
+    /// Route one validated invocation to its plugin CLI adapter.
+    pub fn run_cli(
+        &self,
+        plugin_id: &str,
+        invocation: &CliInvocation,
+    ) -> std::result::Result<CliOutput, String> {
+        let plugin = self
+            .cli_plugins
+            .iter()
+            .find(|plugin| plugin.cli_schema().id == plugin_id)
+            .ok_or_else(|| format!("plugin '{plugin_id}' has no CLI commands"))?;
+        plugin.run_cli(invocation)
     }
 
     /// Execute one command to completion without a frame loop.

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -17,6 +17,22 @@ use crate::{
     settings::Settings,
 };
 
+fn accept_cli_id(
+    plugin_id: &str,
+    cli_id: &str,
+    command_ids: &mut HashSet<String>,
+) -> std::result::Result<(), String> {
+    if matches!(cli_id, "plugins" | "completions" | "help") {
+        return Err(format!(
+            "plugin '{plugin_id}' uses reserved CLI id '{cli_id}'"
+        ));
+    }
+    if !command_ids.insert(cli_id.to_string()) {
+        return Err(format!("duplicate plugin CLI id '{cli_id}'"));
+    }
+    Ok(())
+}
+
 /// A command accepted by [`HeadlessRuntime`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -119,14 +135,15 @@ impl HeadlessRuntime {
             .collect()
     }
 
-    /// Discover every manifest that declares the CLI capability and load its
-    /// adapter through the `plugin-cli` WIT interface.
-    pub fn discover_cli_plugins(&mut self) -> std::result::Result<(), String> {
+    fn wait_for_manager(
+        &self,
+    ) -> std::result::Result<Option<std::sync::Arc<crate::plugin::manager::PluginManager>>, String>
+    {
         let deadline = std::time::Instant::now() + self.plugin_init_timeout;
-        let manager = loop {
+        loop {
             match self.core.plugins.state() {
-                PluginRuntimeState::Ready(manager) => break Some(manager),
-                PluginRuntimeState::Disabled => break None,
+                PluginRuntimeState::Ready(manager) => return Ok(Some(manager)),
+                PluginRuntimeState::Disabled => return Ok(None),
                 PluginRuntimeState::Loading if std::time::Instant::now() < deadline => {
                     std::thread::sleep(Duration::from_millis(1));
                 }
@@ -134,7 +151,13 @@ impl HeadlessRuntime {
                     return Err("plugin initialization timed out".into());
                 }
             }
-        };
+        }
+    }
+
+    /// Discover every manifest that declares the CLI capability and load its
+    /// adapter through the `plugin-cli` WIT interface.
+    pub fn discover_cli_plugins(&mut self) -> std::result::Result<(), String> {
+        let manager = self.wait_for_manager()?;
 
         self.cli_plugins.clear();
         let Some(manager) = manager else {
@@ -157,18 +180,17 @@ impl HeadlessRuntime {
                     .unwrap_or(&NetworkDeclarations::default()),
                 &user_policy,
             );
-            let adapter = manager.open_cli(&plugin.id, policy).map_err(|error| {
-                format!("failed to load CLI for plugin '{}': {error}", plugin.id)
-            })?;
+            let adapter = match manager.open_cli(&plugin.id, policy) {
+                Ok(adapter) => adapter,
+                Err(error) => {
+                    eprintln!("Skipping CLI plugin '{}': {error}", plugin.id);
+                    continue;
+                }
+            };
             let schema = adapter.cli_schema();
-            if matches!(schema.id.as_str(), "plugins" | "completions" | "help") {
-                return Err(format!(
-                    "plugin '{}' uses reserved CLI id '{}'",
-                    plugin.id, schema.id
-                ));
-            }
-            if !command_ids.insert(schema.id.clone()) {
-                return Err(format!("duplicate plugin CLI id '{}'", schema.id));
+            if let Err(error) = accept_cli_id(&plugin.id, &schema.id, &mut command_ids) {
+                eprintln!("Skipping CLI plugin '{}': {error}", plugin.id);
+                continue;
             }
             self.cli_plugins.push(Box::new(adapter));
         }
@@ -206,35 +228,24 @@ impl HeadlessRuntime {
     }
 
     fn list_plugins(&self) -> HeadlessResult {
-        let deadline = std::time::Instant::now() + self.plugin_init_timeout;
-        loop {
-            match self.core.plugins.state() {
-                PluginRuntimeState::Ready(manager) => {
-                    let plugins: Vec<Value> = manager
-                        .get_all_plugin()
-                        .into_iter()
-                        .map(|plugin| {
-                            serde_json::json!({
-                                "id": plugin.id,
-                                "name": plugin.name,
-                                "version": plugin.version,
-                                "capabilities": plugin.capabilities,
-                            })
-                        })
-                        .collect();
-                    return HeadlessResult::success(serde_json::json!({ "plugins": plugins }));
-                }
-                PluginRuntimeState::Disabled => {
-                    return HeadlessResult::success(serde_json::json!({ "plugins": [] }));
-                }
-                PluginRuntimeState::Loading if std::time::Instant::now() < deadline => {
-                    std::thread::sleep(Duration::from_millis(1));
-                }
-                PluginRuntimeState::Loading => {
-                    return HeadlessResult::failure("plugin initialization timed out");
-                }
-            }
-        }
+        let manager = match self.wait_for_manager() {
+            Ok(Some(manager)) => manager,
+            Ok(None) => return HeadlessResult::success(serde_json::json!({ "plugins": [] })),
+            Err(error) => return HeadlessResult::failure(error),
+        };
+        let plugins: Vec<Value> = manager
+            .get_all_plugin()
+            .into_iter()
+            .map(|plugin| {
+                serde_json::json!({
+                    "id": plugin.id,
+                    "name": plugin.name,
+                    "version": plugin.version,
+                    "capabilities": plugin.capabilities,
+                })
+            })
+            .collect();
+        HeadlessResult::success(serde_json::json!({ "plugins": plugins }))
     }
 
     fn run_plugin_command(
@@ -283,7 +294,7 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
 
-    use super::{CliCommand, HeadlessRuntime};
+    use super::{CliCommand, HeadlessRuntime, accept_cli_id};
     use crate::plugin::plugin_ui_host::{PluginCore, PluginCoreEvent};
 
     struct MockPlugin {
@@ -364,5 +375,21 @@ mod tests {
 
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout.unwrap(), serde_json::json!({ "plugins": [] }));
+    }
+
+    #[test]
+    fn rejects_reserved_cli_ids() {
+        let mut ids = std::collections::HashSet::new();
+        let error = accept_cli_id("test.plugin", "plugins", &mut ids).unwrap_err();
+        assert!(error.contains("reserved CLI id"));
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn rejects_duplicate_cli_ids() {
+        let mut ids = std::collections::HashSet::new();
+        accept_cli_id("first", "demo", &mut ids).unwrap();
+        let error = accept_cli_id("second", "demo", &mut ids).unwrap_err();
+        assert!(error.contains("duplicate plugin CLI id 'demo'"));
     }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,0 +1,276 @@
+//! Display-free command runtime for CLI and agent callers.
+
+use std::{collections::HashSet, time::Duration};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    core::ThothCore,
+    plugin::{
+        plugin_ui_host::{PluginCore, PluginCoreEvent},
+        runtime::PluginRuntimeState,
+    },
+    settings::Settings,
+};
+
+/// A command accepted by [`HeadlessRuntime`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CliCommand {
+    /// Return metadata for every discovered plugin.
+    ListPlugins,
+    /// Route a structured command to one live plugin adapter.
+    Plugin {
+        /// Target plugin id.
+        plugin_id: String,
+        /// Plugin-defined command name.
+        command: String,
+        /// Structured command arguments.
+        #[serde(default)]
+        args: Value,
+    },
+}
+
+/// Machine-readable result of a headless invocation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HeadlessResult {
+    /// Process exit code: zero for success, non-zero for failure.
+    pub exit_code: i32,
+    /// JSON value intended for stdout on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<Value>,
+    /// Human-readable diagnostic intended for stderr on failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+}
+
+impl HeadlessResult {
+    fn success(value: Value) -> Self {
+        Self {
+            exit_code: 0,
+            stdout: Some(value),
+            stderr: None,
+        }
+    }
+
+    fn failure(message: impl Into<String>) -> Self {
+        Self {
+            exit_code: 1,
+            stdout: None,
+            stderr: Some(message.into()),
+        }
+    }
+}
+
+/// Runs core and plugin commands without constructing an egui context or window.
+pub struct HeadlessRuntime {
+    /// Display-independent application state and services.
+    pub core: ThothCore,
+    plugins: Vec<Box<dyn PluginCore>>,
+    initialized: HashSet<String>,
+    plugin_init_timeout: Duration,
+}
+
+impl HeadlessRuntime {
+    /// Bootstrap a headless core and begin plugin discovery.
+    pub fn new(settings: Settings) -> Self {
+        Self::with_plugins(settings, Vec::new())
+    }
+
+    /// Bootstrap with explicit live plugin adapters.
+    ///
+    /// This is the integration seam used by plugin CLI adapters and tests.
+    pub fn with_plugins(settings: Settings, plugins: Vec<Box<dyn PluginCore>>) -> Self {
+        let core = ThothCore::init(settings);
+        core.plugins.install_as_active();
+        core.datasets.install_as_active();
+        core.plugins.start(
+            core.settings.plugins.enabled,
+            core.settings.plugins.plugin_settings.clone(),
+        );
+        Self {
+            core,
+            plugins,
+            initialized: HashSet::new(),
+            plugin_init_timeout: Duration::from_secs(10),
+        }
+    }
+
+    /// Execute one command to completion without a frame loop.
+    pub fn run(&mut self, command: CliCommand) -> HeadlessResult {
+        // Drive pending core events before command dispatch. CLI file actions are
+        // added by the routing layer in #143; no window-specific action is run here.
+        let _ = self.core.tick();
+
+        match command {
+            CliCommand::ListPlugins => self.list_plugins(),
+            CliCommand::Plugin {
+                plugin_id,
+                command,
+                args,
+            } => self.run_plugin_command(&plugin_id, command, args),
+        }
+    }
+
+    fn list_plugins(&self) -> HeadlessResult {
+        let deadline = std::time::Instant::now() + self.plugin_init_timeout;
+        loop {
+            match self.core.plugins.state() {
+                PluginRuntimeState::Ready(manager) => {
+                    let plugins: Vec<Value> = manager
+                        .get_all_plugin()
+                        .into_iter()
+                        .map(|plugin| {
+                            serde_json::json!({
+                                "id": plugin.id,
+                                "name": plugin.name,
+                                "version": plugin.version,
+                                "capabilities": plugin.capabilities,
+                            })
+                        })
+                        .collect();
+                    return HeadlessResult::success(serde_json::json!({ "plugins": plugins }));
+                }
+                PluginRuntimeState::Disabled => {
+                    return HeadlessResult::success(serde_json::json!({ "plugins": [] }));
+                }
+                PluginRuntimeState::Loading if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                PluginRuntimeState::Loading => {
+                    return HeadlessResult::failure("plugin initialization timed out");
+                }
+            }
+        }
+    }
+
+    fn run_plugin_command(
+        &mut self,
+        plugin_id: &str,
+        command: String,
+        args: Value,
+    ) -> HeadlessResult {
+        let Some(index) = self
+            .plugins
+            .iter()
+            .position(|plugin| plugin.plugin_id() == plugin_id)
+        else {
+            return HeadlessResult::failure(format!("plugin '{plugin_id}' is not available"));
+        };
+
+        if self.initialized.insert(plugin_id.to_string())
+            && let Err(error) = self.plugins[index].init()
+        {
+            self.initialized.remove(plugin_id);
+            return HeadlessResult::failure(format!(
+                "failed to initialize plugin '{plugin_id}': {error}"
+            ));
+        }
+
+        let event = PluginCoreEvent::Command {
+            name: command,
+            args,
+        };
+        match self.plugins[index].on_event(&event) {
+            Ok(Some(value)) => HeadlessResult::success(value),
+            Ok(None) => HeadlessResult::failure(format!(
+                "plugin '{plugin_id}' does not support this command"
+            )),
+            Err(error) => {
+                HeadlessResult::failure(format!("plugin '{plugin_id}' command failed: {error}"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::{CliCommand, HeadlessRuntime};
+    use crate::plugin::plugin_ui_host::{PluginCore, PluginCoreEvent};
+
+    struct MockPlugin {
+        init_calls: Arc<AtomicUsize>,
+        event_calls: Arc<AtomicUsize>,
+    }
+
+    impl PluginCore for MockPlugin {
+        fn plugin_id(&self) -> &str {
+            "test.mock"
+        }
+
+        fn init(&self) -> crate::error::Result<()> {
+            self.init_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn on_event(
+            &self,
+            event: &PluginCoreEvent,
+        ) -> crate::error::Result<Option<serde_json::Value>> {
+            self.event_calls.fetch_add(1, Ordering::Relaxed);
+            let PluginCoreEvent::Command { name, args } = event;
+            Ok(Some(serde_json::json!({ "command": name, "args": args })))
+        }
+    }
+
+    fn disabled_settings() -> crate::settings::Settings {
+        let mut settings = crate::settings::Settings::default();
+        settings.plugins.enabled = false;
+        settings
+    }
+
+    #[test]
+    fn runs_plugin_lifecycle_end_to_end_without_a_display() {
+        let init_calls = Arc::new(AtomicUsize::new(0));
+        let event_calls = Arc::new(AtomicUsize::new(0));
+        let plugin = MockPlugin {
+            init_calls: Arc::clone(&init_calls),
+            event_calls: Arc::clone(&event_calls),
+        };
+        let mut runtime =
+            HeadlessRuntime::with_plugins(disabled_settings(), vec![Box::new(plugin)]);
+
+        let command = || CliCommand::Plugin {
+            plugin_id: "test.mock".into(),
+            command: "ping".into(),
+            args: serde_json::json!({ "value": 42 }),
+        };
+        let first = runtime.run(command());
+        let second = runtime.run(command());
+
+        assert_eq!(first.exit_code, 0);
+        assert_eq!(first.stdout.unwrap()["command"], "ping");
+        assert_eq!(second.exit_code, 0);
+        assert_eq!(init_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(event_calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn reports_machine_safe_failure_without_stdout() {
+        let mut runtime = HeadlessRuntime::new(disabled_settings());
+        let result = runtime.run(CliCommand::Plugin {
+            plugin_id: "missing".into(),
+            command: "ping".into(),
+            args: serde_json::json!({}),
+        });
+
+        assert_ne!(result.exit_code, 0);
+        assert!(result.stdout.is_none());
+        assert!(result.stderr.unwrap().contains("missing"));
+    }
+
+    #[test]
+    fn lists_plugins_with_plugins_disabled() {
+        let mut runtime = HeadlessRuntime::new(disabled_settings());
+        let result = runtime.run(CliCommand::ListPlugins);
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.unwrap(), serde_json::json!({ "plugins": [] }));
+    }
+}

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -9,7 +9,8 @@ use thoth_plugin_sdk::cli::{CliInvocation, CliOutput, CliSchema, PluginCli};
 use crate::{
     core::ThothCore,
     plugin::{
-        Capability,
+        Capability, NetworkDeclarations,
+        network_policy::NetworkPolicy,
         plugin_ui_host::{PluginCore, PluginCoreEvent},
         runtime::PluginRuntimeState,
     },
@@ -141,7 +142,22 @@ impl HeadlessRuntime {
         };
         let mut command_ids = HashSet::new();
         for plugin in manager.get_all_plugin_by_capability(Capability::Cli) {
-            let adapter = manager.open_cli(&plugin.id).map_err(|error| {
+            let user_policy = self
+                .core
+                .settings
+                .plugins
+                .network_policies
+                .get(&plugin.id)
+                .cloned()
+                .unwrap_or_default();
+            let policy = NetworkPolicy::from_plugin_and_settings(
+                plugin
+                    .network
+                    .as_ref()
+                    .unwrap_or(&NetworkDeclarations::default()),
+                &user_policy,
+            );
+            let adapter = manager.open_cli(&plugin.id, policy).map_err(|error| {
                 format!("failed to load CLI for plugin '{}': {error}", plugin.id)
             })?;
             let schema = adapter.cli_schema();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod constants;
 pub mod core;
 pub mod error;
 pub mod file;
+pub mod headless;
 pub mod helpers;
 pub mod mcp;
 pub mod notification;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod app;
 pub mod components;
 pub mod consent;
 pub mod constants;
+pub mod core;
 pub mod error;
 pub mod file;
 pub mod helpers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 use std::sync::{OnceLock, atomic::AtomicBool};
 
 pub mod app;
+pub mod cli;
 pub mod components;
 pub mod consent;
 pub mod constants;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 
 use std::sync::{OnceLock, atomic::AtomicBool};
 
-use crate::plugin::manager::PluginManager;
-
 pub mod app;
 pub mod components;
 pub mod consent;
@@ -26,7 +24,6 @@ pub mod state;
 pub mod theme;
 pub mod update;
 
-pub static PLUGIN_MANAGER: OnceLock<Option<PluginManager>> = OnceLock::new();
 pub static NOTIFICATION_MANAGER: OnceLock<std::sync::Mutex<notification::NotificationManager>> =
     OnceLock::new();
 pub static CONSENT_MANAGER: OnceLock<std::sync::Mutex<consent::manager::ConsentManager>> =

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,10 @@ fn parse_file_argument(args: &[String]) -> Result<Option<PathBuf>> {
 
 /// File-association launches still use the desktop app. Every other argument
 /// selects the command-line interface.
-fn is_file_invocation(args: &[String]) -> bool {
-    args.len() == 2 && PathBuf::from(&args[1]).is_file()
+fn is_file_invocation(args: &[String], plugin_commands: &[String]) -> bool {
+    args.len() == 2
+        && !thoth::cli::is_known_command(&args[1], plugin_commands)
+        && PathBuf::from(&args[1]).is_file()
 }
 
 fn main() -> Result<()> {
@@ -93,27 +95,35 @@ fn main() -> Result<()> {
             .map_err(|e| format!("MCP error: {e}").into());
     }
 
+    let settings = settings::Settings::load().unwrap_or_else(|e| {
+        eprintln!("Warning: Failed to load settings: {}. Using defaults.", e);
+        settings::Settings::default()
+    });
+    // Only discover plugin command names when a single argument is also an
+    // existing file. This resolves collisions in favour of commands without
+    // adding a second discovery pass to ordinary CLI or file launches.
+    let plugin_commands = if args.len() == 2
+        && PathBuf::from(&args[1]).is_file()
+        && !thoth::cli::is_known_command(&args[1], &[])
+    {
+        thoth::cli::discover_command_ids(settings.clone()).unwrap_or_else(|error| {
+            eprintln!("Warning: failed to discover plugin commands: {error}");
+            Vec::new()
+        })
+    } else {
+        Vec::new()
+    };
+
     // Any non-file arguments select the display-free CLI. Keep this before
     // notification, consent, icon, and eframe initialization.
-    if args.len() > 1 && !is_file_invocation(&args) {
-        let output = thoth::cli::run_with(args, || {
-            settings::Settings::load().unwrap_or_else(|e| {
-                eprintln!("Warning: Failed to load settings: {}. Using defaults.", e);
-                settings::Settings::default()
-            })
-        });
+    if args.len() > 1 && !is_file_invocation(&args, &plugin_commands) {
+        let output = thoth::cli::run(args, settings.clone());
         print!("{}", output.stdout);
         eprint!("{}", output.stderr);
         std::process::exit(output.exit_code);
     }
 
     let file_to_open = parse_file_argument(&args)?;
-
-    // Load settings first
-    let settings = settings::Settings::load().unwrap_or_else(|e| {
-        eprintln!("Warning: Failed to load settings: {}. Using defaults.", e);
-        settings::Settings::default()
-    });
 
     NOTIFICATION_MANAGER
         .set(std::sync::Mutex::new(NotificationManager::new()))
@@ -221,13 +231,24 @@ mod tests {
             test_file.path().to_string_lossy().into_owned(),
         ];
 
-        assert!(is_file_invocation(&args));
+        assert!(is_file_invocation(&args, &[]));
     }
 
     #[test]
     fn command_arguments_are_not_file_invocations() {
         let args = vec!["thoth".to_string(), "plugins".to_string()];
-        assert!(!is_file_invocation(&args));
+        assert!(!is_file_invocation(&args, &[]));
+    }
+
+    #[test]
+    fn discovered_command_takes_precedence_over_same_named_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("seshat");
+        std::fs::write(&path, "not a data file").unwrap();
+        let command = path.to_string_lossy().into_owned();
+        let args = vec!["thoth".to_string(), command.clone()];
+
+        assert!(!is_file_invocation(&args, &[command]));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,12 @@ fn parse_file_argument(args: &[String]) -> Result<Option<PathBuf>> {
     Ok(Some(canonical_path))
 }
 
+/// File-association launches still use the desktop app. Every other argument
+/// selects the command-line interface.
+fn is_file_invocation(args: &[String]) -> bool {
+    args.len() == 2 && PathBuf::from(&args[1]).is_file()
+}
+
 fn main() -> Result<()> {
     // Initialize dhat heap profiler (only when profiling feature is enabled)
     // When the app exits, dhat writes 'dhat-heap.json' which can be viewed at:
@@ -85,6 +91,20 @@ fn main() -> Result<()> {
         let mcp_args: Vec<String> = args[2..].to_vec();
         return thoth::mcp::run_mcp_command(&mcp_args)
             .map_err(|e| format!("MCP error: {e}").into());
+    }
+
+    // Any non-file arguments select the display-free CLI. Keep this before
+    // notification, consent, icon, and eframe initialization.
+    if args.len() > 1 && !is_file_invocation(&args) {
+        let output = thoth::cli::run_with(args, || {
+            settings::Settings::load().unwrap_or_else(|e| {
+                eprintln!("Warning: Failed to load settings: {}. Using defaults.", e);
+                settings::Settings::default()
+            })
+        });
+        print!("{}", output.stdout);
+        eprint!("{}", output.stderr);
+        std::process::exit(output.exit_code);
     }
 
     let file_to_open = parse_file_argument(&args)?;
@@ -191,6 +211,23 @@ mod tests {
         let args = vec!["thoth".to_string()];
         let result = parse_file_argument(&args).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn existing_file_is_a_gui_invocation() {
+        let test_file = tempfile::NamedTempFile::new().unwrap();
+        let args = vec![
+            "thoth".to_string(),
+            test_file.path().to_string_lossy().into_owned(),
+        ];
+
+        assert!(is_file_invocation(&args));
+    }
+
+    #[test]
+    fn command_arguments_are_not_file_invocations() {
+        let args = vec!["thoth".to_string(), "plugins".to_string()];
+        assert!(!is_file_invocation(&args));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,8 @@ use eframe::{
 };
 use std::path::PathBuf;
 use thoth::{
-    CONSENT_MANAGER, NOTIFICATION_MANAGER, PLUGIN_MANAGER, app, consent::manager::ConsentManager,
-    error::Result, helpers::load_icon, notification::NotificationManager,
-    plugin::manager::PluginManager, settings,
+    CONSENT_MANAGER, NOTIFICATION_MANAGER, app, consent::manager::ConsentManager, error::Result,
+    helpers::load_icon, notification::NotificationManager, settings,
 };
 
 /// Parse command-line arguments to extract file path
@@ -103,23 +102,6 @@ fn main() -> Result<()> {
         .set(std::sync::Mutex::new(ConsentManager::new()))
         .ok();
 
-    let plugin_settings = settings.plugins.plugin_settings.clone();
-
-    // Load Plugins
-    if settings.plugins.enabled {
-        std::thread::spawn(move || {
-            PLUGIN_MANAGER
-                .set(
-                    PluginManager::init(&plugin_settings)
-                        .map_err(|err| {
-                            eprintln!("Warning Unable to load plugins: {}", err);
-                        })
-                        .ok(),
-                )
-                .unwrap();
-        });
-    }
-
     let icon = load_icon(include_bytes!("../assets/thoth_icon_256.png"));
 
     // Configure window from settings
@@ -176,6 +158,12 @@ fn main() -> Result<()> {
             thoth_plugin_sdk::dataset::set_plugin_renderer(app::render_dataset_with_plugin);
 
             let mut app = app::ThothApp::new(settings, file_to_open);
+            app.core.plugins.install_as_active();
+            app.core.datasets.install_as_active();
+            app.core.plugins.start(
+                app.core.settings.plugins.enabled,
+                app.core.settings.plugins.plugin_settings.clone(),
+            );
             app.setup_native_menu(cc);
             Ok(Box::new(app))
         }),

--- a/src/plugin/datasets.rs
+++ b/src/plugin/datasets.rs
@@ -14,7 +14,7 @@
 //! without changing the public shape.
 
 use std::collections::HashMap;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, RwLock, Weak};
 use std::time::Instant;
 
 /// Most datasets kept before LRU eviction of the least-recently-accessed.
@@ -145,7 +145,47 @@ fn dataset_bytes(meta: &DatasetMeta, rows: &[Vec<String>]) -> usize {
     cells + cols + tags + meta.name.len() + meta.source_plugin.len() + meta.source_instance.len()
 }
 
-static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(Registry::default()));
+type SharedRegistry = Arc<Mutex<Registry>>;
+
+/// Core-owned dataset store.
+pub struct DatasetStore {
+    registry: SharedRegistry,
+}
+
+impl DatasetStore {
+    /// Create an empty dataset store.
+    pub fn new() -> Self {
+        Self {
+            registry: Arc::new(Mutex::new(Registry::default())),
+        }
+    }
+
+    /// Install this store as the weak bridge used by WIT and SDK callbacks.
+    pub fn install_as_active(&self) {
+        if let Ok(mut active) = ACTIVE_REGISTRY.write() {
+            *active = Arc::downgrade(&self.registry);
+        }
+    }
+}
+
+impl Default for DatasetStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+static ACTIVE_REGISTRY: LazyLock<RwLock<Weak<Mutex<Registry>>>> =
+    LazyLock::new(|| RwLock::new(Weak::new()));
+static FALLBACK_REGISTRY: LazyLock<SharedRegistry> =
+    LazyLock::new(|| Arc::new(Mutex::new(Registry::default())));
+
+fn registry() -> SharedRegistry {
+    ACTIVE_REGISTRY
+        .read()
+        .ok()
+        .and_then(|active| active.upgrade())
+        .unwrap_or_else(|| Arc::clone(&FALLBACK_REGISTRY))
+}
 
 /// Store a dataset published by `source_plugin` (instance `source_instance`),
 /// returning its assigned id. Evicts the least-recently-accessed dataset when
@@ -160,7 +200,8 @@ pub fn publish(
     columns: Vec<DatasetColumn>,
     rows: Vec<Vec<String>>,
 ) -> String {
-    let Ok(mut reg) = REGISTRY.lock() else {
+    let registry = registry();
+    let Ok(mut reg) = registry.lock() else {
         return String::new();
     };
     // A fresh publish from an instance replaces that instance's previous
@@ -211,13 +252,15 @@ pub fn publish(
 
 /// Metadata (no rows) for a single dataset by id; `None` if unknown.
 pub fn meta(id: &str) -> Option<DatasetMeta> {
-    let reg = REGISTRY.lock().ok()?;
+    let registry = registry();
+    let reg = registry.lock().ok()?;
     reg.map.get(id).map(|s| s.meta.clone())
 }
 
 /// Metadata for all published datasets, in publish order.
 pub fn list() -> Vec<DatasetMeta> {
-    let Ok(reg) = REGISTRY.lock() else {
+    let registry = registry();
+    let Ok(reg) = registry.lock() else {
         return Vec::new();
     };
     reg.order
@@ -229,7 +272,8 @@ pub fn list() -> Vec<DatasetMeta> {
 /// Read rows `[offset, offset + limit)` of dataset `id`; `limit` is capped by
 /// [`MAX_READ_LIMIT`]. Returns `None` if the id is unknown.
 pub fn read(id: &str, offset: u64, limit: u32) -> Option<Page> {
-    let Ok(mut reg) = REGISTRY.lock() else {
+    let registry = registry();
+    let Ok(mut reg) = registry.lock() else {
         return None;
     };
     let stored = reg.map.get_mut(id)?;
@@ -250,7 +294,8 @@ pub fn read(id: &str, offset: u64, limit: u32) -> Option<Page> {
 /// id, source, and byte-budget accounting current). No-op unless the handle is
 /// known and owned by `instance` — a producer can only mutate its own datasets.
 pub fn update(instance: &str, id: &str, columns: Vec<DatasetColumn>, rows: Vec<Vec<String>>) {
-    if let Ok(mut reg) = REGISTRY.lock() {
+    let registry = registry();
+    if let Ok(mut reg) = registry.lock() {
         let Some(stored) = reg.map.get(id) else {
             return;
         };
@@ -290,7 +335,8 @@ pub fn append(instance: &str, id: &str, rows: Vec<Vec<String>>) {
     if rows.is_empty() {
         return;
     }
-    if let Ok(mut reg) = REGISTRY.lock() {
+    let registry = registry();
+    if let Ok(mut reg) = registry.lock() {
         match reg.map.get(id) {
             Some(s) if s.meta.source_instance == instance => {}
             _ => return,
@@ -327,7 +373,8 @@ pub fn append(instance: &str, id: &str, rows: Vec<Vec<String>>) {
 /// Remove a dataset (idempotent). No-op unless the handle is owned by
 /// `instance`, so a producer can only release its own datasets.
 pub fn release(instance: &str, id: &str) {
-    if let Ok(mut reg) = REGISTRY.lock()
+    let registry = registry();
+    if let Ok(mut reg) = registry.lock()
         && reg
             .map
             .get(id)
@@ -340,7 +387,8 @@ pub fn release(instance: &str, id: &str) {
 /// Drop datasets whose producing instance is no longer open. Called each frame
 /// with the set of live plugin-instance ids (same set signals uses).
 pub fn retain_instances(open: &std::collections::HashSet<String>) {
-    if let Ok(mut reg) = REGISTRY.lock() {
+    let registry = registry();
+    if let Ok(mut reg) = registry.lock() {
         let dropped: Vec<String> = reg
             .map
             .values()
@@ -361,7 +409,8 @@ mod tests {
 
     fn reset() -> std::sync::MutexGuard<'static, ()> {
         let guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        if let Ok(mut reg) = REGISTRY.lock() {
+        let registry = registry();
+        if let Ok(mut reg) = registry.lock() {
             reg.map.clear();
             reg.order.clear();
             reg.bytes = 0;

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -349,10 +349,9 @@ impl PluginManager {
         for (dir, is_bundled) in self.plugin_directories() {
             if let Ok(dir) = dir
                 && dir.exists()
+                && let Err(e) = self.scan_directory(dir, is_bundled)
             {
-                if let Err(e) = self.scan_directory(dir, is_bundled) {
-                    eprintln!("Failed to scan plugin directory: {e:?}");
-                }
+                eprintln!("Failed to scan plugin directory: {e:?}");
             }
         }
 
@@ -361,10 +360,9 @@ impl PluginManager {
         // call scan_instances_dir directly instead.
         if let Ok(installs_dir) = PersistentState::plugin_install_dir()
             && installs_dir.exists()
+            && let Err(e) = self.scan_instances_dir(&installs_dir, false)
         {
-            if let Err(e) = self.scan_instances_dir(&installs_dir, false) {
-                eprintln!("Failed to scan marketplace installs: {e:?}");
-            }
+            eprintln!("Failed to scan marketplace installs: {e:?}");
         }
 
         Ok(())

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -13,6 +13,7 @@ use crate::notification::{Notification, NotificationManager, NotificationStatus}
 use crate::plugin::Capability;
 use crate::plugin::network_policy::NetworkPolicy;
 use crate::plugin::plugin_registry::PluginRegistry;
+use crate::plugin::wasm_cli::WasmCliLoader;
 use crate::plugin::wasm_data_source::WasmDataSourceLoader;
 use crate::plugin::wasm_file_viewer_loader::WasmFileViewerLoader;
 use crate::plugin::wasm_loader::WasmFileLoader;
@@ -193,6 +194,37 @@ impl PluginManager {
 
     pub fn get_data_source_plugins(&self) -> Vec<&Plugin> {
         self.registry.get_by_capability(Capability::DataSource)
+    }
+
+    /// Instantiate the display-free WIT CLI adapter for an opted-in plugin.
+    pub fn open_cli(&self, plugin_id: &str) -> Result<WasmCliLoader> {
+        let plugin = self
+            .registry
+            .get_by_id(plugin_id)
+            .ok_or_else(|| ThothError::Unknown {
+                message: format!("Plugin '{plugin_id}' not found"),
+            })?;
+        if !plugin.capabilities.contains(&Capability::Cli) {
+            return Err(ThothError::Unknown {
+                message: format!("Plugin '{plugin_id}' does not expose CLI commands"),
+            });
+        }
+        let wasm_path =
+            plugin
+                .location
+                .as_deref()
+                .map(Path::new)
+                .ok_or_else(|| ThothError::Unknown {
+                    message: format!("Plugin '{plugin_id}' has no wasm path"),
+                })?;
+        let settings = self
+            .plugin_settings
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .get(plugin_id)
+            .cloned()
+            .unwrap_or_default();
+        WasmCliLoader::open(&self.engine, wasm_path, &settings)
     }
 
     pub fn open_data_source(

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -197,7 +197,7 @@ impl PluginManager {
     }
 
     /// Instantiate the display-free WIT CLI adapter for an opted-in plugin.
-    pub fn open_cli(&self, plugin_id: &str) -> Result<WasmCliLoader> {
+    pub fn open_cli(&self, plugin_id: &str, policy: NetworkPolicy) -> Result<WasmCliLoader> {
         let plugin = self
             .registry
             .get_by_id(plugin_id)
@@ -224,7 +224,7 @@ impl PluginManager {
             .get(plugin_id)
             .cloned()
             .unwrap_or_default();
-        WasmCliLoader::open(&self.engine, wasm_path, &settings)
+        WasmCliLoader::open(&self.engine, wasm_path, plugin_id, policy, &settings)
     }
 
     pub fn open_data_source(
@@ -350,7 +350,6 @@ impl PluginManager {
             if let Ok(dir) = dir
                 && dir.exists()
             {
-                eprintln!("Checking {}", dir.display());
                 if let Err(e) = self.scan_directory(dir, is_bundled) {
                     eprintln!("Failed to scan plugin directory: {e:?}");
                 }
@@ -363,7 +362,6 @@ impl PluginManager {
         if let Ok(installs_dir) = PersistentState::plugin_install_dir()
             && installs_dir.exists()
         {
-            eprintln!("Checking marketplace installs {}", installs_dir.display());
             if let Err(e) = self.scan_instances_dir(&installs_dir, false) {
                 eprintln!("Failed to scan marketplace installs: {e:?}");
             }

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -7,7 +7,6 @@ use wasmtime::component::ResourceTable;
 use wasmtime::{Cache, CacheConfig, Config, Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView};
 
-use crate::PLUGIN_MANAGER;
 use crate::app::persistent_state::PersistentState;
 use crate::error::Result;
 use crate::notification::{Notification, NotificationManager, NotificationStatus};
@@ -307,7 +306,7 @@ impl PluginManager {
     }
 
     pub fn get_installed_plugin() -> HashMap<String, Plugin> {
-        if let Some(Some(pm)) = PLUGIN_MANAGER.get() {
+        if let Some(pm) = crate::plugin::runtime::active_manager() {
             return pm.registry.get_installed_plugins();
         }
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -11,6 +11,7 @@ pub mod network_policy;
 pub mod plugin_registry;
 pub mod plugin_ui_host;
 pub mod render_node;
+pub mod runtime;
 pub mod signals;
 pub mod theme_plugin;
 pub mod wasm_data_source;

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -14,6 +14,7 @@ pub mod render_node;
 pub mod runtime;
 pub mod signals;
 pub mod theme_plugin;
+pub mod wasm_cli;
 pub mod wasm_data_source;
 pub mod wasm_exporter;
 pub mod wasm_file_viewer_loader;
@@ -88,6 +89,8 @@ pub enum Capability {
     /// Opts the plugin in as a dataset renderer (#135): it presents a host-owned
     /// dataset as an extra view format in a DataView.
     Renderer,
+    /// Exposes display-free commands through the `plugin-cli` WIT interface.
+    Cli,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -150,6 +153,7 @@ impl Display for Capability {
                 Capability::Theme => "Theme",
                 Capability::DataProducer => "Data Producer",
                 Capability::Renderer => "Renderer",
+                Capability::Cli => "CLI",
             }
         )
     }

--- a/src/plugin/plugin_ui_host.rs
+++ b/src/plugin/plugin_ui_host.rs
@@ -97,6 +97,21 @@ impl TabOpenRequest {
 pub trait PluginCore: Send {
     fn plugin_id(&self) -> &str;
 
+    /// Initialize this live instance for core/headless use.
+    ///
+    /// WASM UI loaders already run their WIT lifecycle during construction, so
+    /// their default implementation is a no-op. Headless adapters can override
+    /// this to perform explicit initialization.
+    fn init(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Handle a display-independent event. Returning `None` means the event is
+    /// not supported by this plugin instance.
+    fn on_event(&self, _event: &PluginCoreEvent) -> Result<Option<serde_json::Value>> {
+        Ok(None)
+    }
+
     /// Return the optional UI facet implemented by this plugin instance.
     /// Headless-only plugins keep the default `None` implementation.
     fn as_ui(&self) -> Option<&dyn PluginUi> {
@@ -196,6 +211,18 @@ pub trait PluginCore: Send {
             message: "plugin is not a data producer".to_string(),
         })
     }
+}
+
+/// A display-independent event routed to a [`PluginCore`] instance.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PluginCoreEvent {
+    /// Invoke a named command with structured arguments.
+    Command {
+        /// Plugin-defined command name.
+        name: String,
+        /// JSON arguments supplied by the CLI layer.
+        args: serde_json::Value,
+    },
 }
 
 /// Rendering facet for plugins that expose an interactive UI.

--- a/src/plugin/plugin_ui_host.rs
+++ b/src/plugin/plugin_ui_host.rs
@@ -1,11 +1,11 @@
-//! Shared abstraction over plugin loaders that render an interactive UI inside a
-//! dock tab.
+//! Shared abstractions over live plugin instances.
 //!
 //! Both [`WasmDataSourceLoader`](crate::plugin::wasm_data_source::WasmDataSourceLoader)
 //! and [`WasmUiComponentLoader`](crate::plugin::wasm_ui_component::WasmUiComponentLoader)
-//! implement [`PluginUiHost`], so an [`ActivePluginPane`](crate::state::ActivePluginPane)
-//! can hold either behind a `Box<dyn PluginUiHost>` and the app's poll/dispatch loop
-//! can drive both uniformly.
+//! implement [`PluginCore`] and [`PluginUi`]. Runtime owners keep the core facet
+//! behind a `Box<dyn PluginCore>` so headless code can drive lifecycle, async I/O,
+//! and datasets without depending on rendering. GUI paths explicitly request the
+//! optional [`PluginUi`] facet when they need to render or dispatch a widget event.
 //!
 //! The tab-state / lifecycle methods (`tab_title`, `get_state`, `on_tab_*`, …) map to
 //! the `tab-host` WIT export, which both the `ui-component-plugin` and
@@ -89,9 +89,19 @@ impl TabOpenRequest {
     }
 }
 
-/// Common interface for plugin loaders rendered inside a dock tab.
-pub trait PluginUiHost: Send {
+/// Headless-safe interface shared by every live plugin instance.
+///
+/// This trait deliberately contains no egui types or render callbacks. It is
+/// object-safe so the host's core runtime can store heterogeneous plugins as
+/// `Box<dyn PluginCore>`.
+pub trait PluginCore: Send {
     fn plugin_id(&self) -> &str;
+
+    /// Return the optional UI facet implemented by this plugin instance.
+    /// Headless-only plugins keep the default `None` implementation.
+    fn as_ui(&self) -> Option<&dyn PluginUi> {
+        None
+    }
 
     /// Unique id for this plugin *instance* (pane). Defaults to `plugin_id` for
     /// loaders that don't need per-instance identity; data-source loaders
@@ -99,10 +109,6 @@ pub trait PluginUiHost: Send {
     fn instance_id(&self) -> &str {
         self.plugin_id()
     }
-
-    fn render_ui(&self) -> Result<UiOutput>;
-    fn handle_event(&self, event: UiEvent) -> Result<UiOutput>;
-    fn render_sidebar(&self) -> Result<Option<UiOutput>>;
 
     /// True when the plugin's Store is currently held by a background worker (a
     /// blocking DB query is running). Callers use this to defer work that would
@@ -192,6 +198,16 @@ pub trait PluginUiHost: Send {
     }
 }
 
+/// Rendering facet for plugins that expose an interactive UI.
+///
+/// A CLI-only plugin implements [`PluginCore`] without implementing this trait.
+/// The host obtains this facet through [`PluginCore::as_ui`] only in GUI paths.
+pub trait PluginUi: PluginCore {
+    fn render_ui(&self) -> Result<UiOutput>;
+    fn handle_event(&self, event: UiEvent) -> Result<UiOutput>;
+    fn render_sidebar(&self) -> Result<Option<UiOutput>>;
+}
+
 /// A dataset returned by a producer's `provide-dataset` export, in plain
 /// host-side types (no bindgen dependency) so it can cross into the bus.
 pub struct ProvidedDataset {
@@ -200,4 +216,24 @@ pub struct ProvidedDataset {
     /// `(column name, SQL-ish type hint)` pairs.
     pub columns: Vec<(String, String)>,
     pub rows: Vec<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PluginCore;
+
+    struct HeadlessPlugin;
+
+    impl PluginCore for HeadlessPlugin {
+        fn plugin_id(&self) -> &str {
+            "test.headless"
+        }
+    }
+
+    #[test]
+    fn core_is_object_safe_without_a_ui_facet() {
+        let plugin: Box<dyn PluginCore> = Box::new(HeadlessPlugin);
+        assert_eq!(plugin.plugin_id(), "test.headless");
+        assert!(plugin.as_ui().is_none());
+    }
 }

--- a/src/plugin/runtime.rs
+++ b/src/plugin/runtime.rs
@@ -1,0 +1,131 @@
+//! Shared ownership and asynchronous initialization for the plugin manager.
+//!
+//! The application core owns [`PluginRuntime`]. A weak process bridge is kept
+//! only for legacy host callbacks that cannot receive state directly (for
+//! example SDK-installed function pointers); it does not keep the runtime alive.
+
+use std::sync::{
+    Arc, LazyLock, RwLock, Weak,
+    atomic::{AtomicBool, Ordering},
+};
+
+use crate::{plugin::manager::PluginManager, settings::PluginSettingData};
+
+type SharedState = Arc<RwLock<PluginRuntimeState>>;
+
+/// Current plugin-manager initialization state.
+#[derive(Clone)]
+pub enum PluginRuntimeState {
+    /// Initialization has not completed yet.
+    Loading,
+    /// Plugins are disabled or initialization failed.
+    Disabled,
+    /// The initialized manager, shared by GUI and headless consumers.
+    Ready(Arc<PluginManager>),
+}
+
+/// Core-owned plugin-manager runtime.
+pub struct PluginRuntime {
+    state: SharedState,
+    started: Arc<AtomicBool>,
+}
+
+impl PluginRuntime {
+    /// Create an unstarted plugin runtime.
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(RwLock::new(PluginRuntimeState::Loading)),
+            started: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Start plugin discovery once. Initialization runs off the caller thread.
+    pub fn start(
+        &self,
+        enabled: bool,
+        plugin_settings: std::collections::HashMap<String, Vec<PluginSettingData>>,
+    ) {
+        if self.started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        if !enabled {
+            self.set_state(PluginRuntimeState::Disabled);
+            return;
+        }
+
+        let state = Arc::clone(&self.state);
+        std::thread::spawn(move || {
+            let next = match PluginManager::init(&plugin_settings) {
+                Ok(manager) => PluginRuntimeState::Ready(Arc::new(manager)),
+                Err(err) => {
+                    eprintln!("Warning Unable to load plugins: {err}");
+                    PluginRuntimeState::Disabled
+                }
+            };
+            if let Ok(mut current) = state.write() {
+                *current = next;
+            }
+        });
+    }
+
+    /// Snapshot the current initialization state.
+    pub fn state(&self) -> PluginRuntimeState {
+        self.state
+            .read()
+            .map(|state| state.clone())
+            .unwrap_or(PluginRuntimeState::Disabled)
+    }
+
+    /// Return the initialized manager, if ready.
+    pub fn manager(&self) -> Option<Arc<PluginManager>> {
+        match self.state() {
+            PluginRuntimeState::Ready(manager) => Some(manager),
+            PluginRuntimeState::Loading | PluginRuntimeState::Disabled => None,
+        }
+    }
+
+    /// Install this runtime as the weak bridge used by state-less host callbacks.
+    pub fn install_as_active(&self) {
+        if let Ok(mut active) = ACTIVE_RUNTIME.write() {
+            *active = Arc::downgrade(&self.state);
+        }
+    }
+
+    fn set_state(&self, state: PluginRuntimeState) {
+        if let Ok(mut current) = self.state.write() {
+            *current = state;
+        }
+    }
+}
+
+impl Default for PluginRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+static ACTIVE_RUNTIME: LazyLock<RwLock<Weak<RwLock<PluginRuntimeState>>>> =
+    LazyLock::new(|| RwLock::new(Weak::new()));
+
+/// Resolve the active core's plugin manager for legacy state-less callbacks.
+pub fn active_manager() -> Option<Arc<PluginManager>> {
+    let state = ACTIVE_RUNTIME.read().ok()?.upgrade()?;
+    let snapshot = state.read().ok()?.clone();
+    match snapshot {
+        PluginRuntimeState::Ready(manager) => Some(manager),
+        PluginRuntimeState::Loading | PluginRuntimeState::Disabled => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PluginRuntime, PluginRuntimeState};
+
+    #[test]
+    fn disabled_runtime_finishes_without_starting_a_worker() {
+        let runtime = PluginRuntime::new();
+        runtime.start(false, Default::default());
+        assert!(matches!(runtime.state(), PluginRuntimeState::Disabled));
+        assert!(runtime.manager().is_none());
+    }
+}

--- a/src/plugin/theme_plugin.rs
+++ b/src/plugin/theme_plugin.rs
@@ -1,64 +1,49 @@
 use std::{collections::HashMap, fs::File, io::BufReader};
 
-use crate::{plugin::Plugin, theme::Theme};
+use crate::theme::Theme;
 
-// TODO: Optimise theme plugin mod
-pub fn all_theme_plugins() -> Vec<Plugin> {
+pub fn get_plugin_theme_catalog() -> Vec<(String, bool, String)> {
     super::runtime::active_manager()
-        .map(|pm| {
-            pm.get_all_plugin_by_capability(super::Capability::Theme)
+        .map(|manager| {
+            manager
+                .get_all_plugin_by_capability(super::Capability::Theme)
                 .into_iter()
-                .cloned()
+                .filter_map(|plugin| plugin.theme.as_ref())
+                .flat_map(|theme| {
+                    theme
+                        .catalog
+                        .iter()
+                        .map(|entry| (entry.0.clone(), entry.1, theme.family.clone()))
+                })
                 .collect()
         })
         .unwrap_or_default()
 }
 
-pub fn get_plugin_theme_catalog() -> Vec<(String, bool, String)> {
-    all_theme_plugins()
-        .iter()
-        .flat_map(|plugin| {
-            if let Some(theme_plugin) = &plugin.theme {
-                let family = &theme_plugin.family;
-
-                theme_plugin
-                    .catalog
-                    .iter()
-                    .map(|c| (c.0.clone(), c.1, family.clone()))
-                    .collect()
-            } else {
-                vec![]
-            }
-        })
-        .collect()
-}
-
 pub fn get_plugin_theme_by_name(name: &str) -> Option<Theme> {
-    let mut theme: Option<Theme> = None;
-
-    all_theme_plugins().iter().for_each(|plugin| {
-        if let Some(theme_plugin) = &plugin.theme
-            && let Some(location) = &plugin.location
-            && theme_plugin.catalog.iter().any(|(n, _)| n == name)
-            && let Ok(file) = File::open(location).map_err(|err| {
-                eprintln!(
-                    "Error opening theme.json file for {} - {}",
-                    plugin.name, err
-                );
-            })
-        {
-            {
-                let rdr = BufReader::new(file);
-                if let Ok(value) = serde_json::from_reader::<_, HashMap<String, Theme>>(rdr)
-                    .map_err(|err| {
-                        eprintln!("Error parsing theme file for {} - {}", plugin.name, err);
-                    })
-                {
-                    theme = value.get(name).cloned();
-                };
-            };
-        }
-    });
-
-    theme
+    let manager = super::runtime::active_manager()?;
+    let plugin = manager
+        .get_all_plugin_by_capability(super::Capability::Theme)
+        .into_iter()
+        .find(|plugin| {
+            plugin
+                .theme
+                .as_ref()
+                .is_some_and(|theme| theme.catalog.iter().any(|(entry, _)| entry == name))
+        })?;
+    let location = plugin.location.as_ref()?;
+    let file = File::open(location)
+        .map_err(|error| {
+            eprintln!(
+                "Error opening theme.json file for {} - {}",
+                plugin.name, error
+            );
+        })
+        .ok()?;
+    let themes = serde_json::from_reader::<_, HashMap<String, Theme>>(BufReader::new(file))
+        .map_err(|error| {
+            eprintln!("Error parsing theme file for {} - {}", plugin.name, error);
+        })
+        .ok()?;
+    themes.get(name).cloned()
 }

--- a/src/plugin/theme_plugin.rs
+++ b/src/plugin/theme_plugin.rs
@@ -1,16 +1,17 @@
 use std::{collections::HashMap, fs::File, io::BufReader};
 
-use crate::{PLUGIN_MANAGER, plugin::Plugin, theme::Theme};
+use crate::{plugin::Plugin, theme::Theme};
 
 // TODO: Optimise theme plugin mod
-pub fn all_theme_plugins<'a>() -> Vec<&'a Plugin> {
-    if let Some(pm) = PLUGIN_MANAGER.get()
-        && let Some(pm) = pm
-    {
-        return pm.get_all_plugin_by_capability(super::Capability::Theme);
-    }
-
-    vec![]
+pub fn all_theme_plugins() -> Vec<Plugin> {
+    super::runtime::active_manager()
+        .map(|pm| {
+            pm.get_all_plugin_by_capability(super::Capability::Theme)
+                .into_iter()
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 pub fn get_plugin_theme_catalog() -> Vec<(String, bool, String)> {

--- a/src/plugin/wasm_cli.rs
+++ b/src/plugin/wasm_cli.rs
@@ -21,7 +21,10 @@ use crate::{
     app::persistent_state::PersistentState,
     plugin::{
         network_policy::{CheckOutcome, NetworkPolicy},
-        wasm_data_source::{BoxIo, ReadWrite, TCP_READ_CAP, secret_store, tcp_connect, tcp_tls},
+        wasm_data_source::{
+            BoxIo, ReadWrite, TCP_READ_CAP, execute_http_request, secret_store, tcp_connect,
+            tcp_tls,
+        },
     },
 };
 
@@ -31,6 +34,7 @@ wasmtime::component::bindgen!({
 });
 
 const CLI_FUEL_BUDGET: u64 = 5_000_000_000;
+const MAX_TCP_STREAMS: usize = 32;
 
 struct CliState {
     wasi: WasiCtx,
@@ -69,16 +73,26 @@ impl WasmCliLoader {
         wasm_path: &Path,
         plugin_id: &str,
         policy: NetworkPolicy,
-        _settings: &[crate::settings::PluginSettingData],
+        settings: &[crate::settings::PluginSettingData],
     ) -> Result<Self> {
         let load_error = |reason: String| ThothError::PluginLoadError {
             path: wasm_path.to_path_buf(),
             reason,
         };
+        let mut wasi = WasiCtxBuilder::new();
+        wasi.inherit_stderr();
+        // Passwords supplied for Seshat connection URLs are deliberately
+        // whitelisted one variable at a time instead of exposing the host's
+        // complete environment to every plugin.
+        if plugin_id == "com.thoth.seshat"
+            && let Ok(password) = std::env::var("THOTH_SESHAT_PASSWORD")
+        {
+            wasi.env("THOTH_SESHAT_PASSWORD", password);
+        }
         let mut store = Store::new(
             engine,
             CliState {
-                wasi: WasiCtxBuilder::new().inherit_stderr().build(),
+                wasi: wasi.build(),
                 table: ResourceTable::new(),
                 plugin_id: plugin_id.to_string(),
                 policy,
@@ -115,6 +129,12 @@ impl WasmCliLoader {
         thoth::plugin::tcp_client::add_to_linker::<_, HasSelf<_>>(&mut linker, |state| state)
             .map_err(|error| load_error(error.to_string()))?;
         let bindings = CliPlugin::instantiate(&mut store, &component, &linker)
+            .map_err(|error| load_error(error.to_string()))?;
+        let settings_json = serde_json::to_string(settings)
+            .map_err(|error| load_error(format!("failed to encode plugin settings: {error}")))?;
+        bindings
+            .thoth_plugin_plugin_lifecycle()
+            .call_on_load(&mut store, &settings_json)
             .map_err(|error| load_error(error.to_string()))?;
         let schema_json = bindings
             .thoth_plugin_plugin_cli()
@@ -219,49 +239,6 @@ fn http_error(code: u32, message: impl Into<String>) -> thoth::plugin::http_clie
     }
 }
 
-fn execute_http_request(
-    req: thoth::plugin::http_client::HttpRequest,
-) -> std::result::Result<thoth::plugin::http_client::HttpResponse, String> {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|error| error.to_string())?;
-    let mut builder = match req.method.to_uppercase().as_str() {
-        "POST" => client.post(&req.url),
-        "PUT" => client.put(&req.url),
-        "PATCH" => client.patch(&req.url),
-        "DELETE" => client.delete(&req.url),
-        _ => client.get(&req.url),
-    };
-    for (key, value) in req.headers {
-        builder = builder.header(key, value);
-    }
-    if let Some(body) = req.body {
-        builder = builder.body(body);
-    }
-    let response = builder.send().map_err(|error| error.to_string())?;
-    let status = response.status().as_u16();
-    let headers = response
-        .headers()
-        .iter()
-        .map(|(key, value)| {
-            (
-                key.to_string(),
-                value.to_str().unwrap_or_default().to_string(),
-            )
-        })
-        .collect();
-    let body = response
-        .bytes()
-        .map_err(|error| error.to_string())?
-        .to_vec();
-    Ok(thoth::plugin::http_client::HttpResponse {
-        status,
-        headers,
-        body,
-    })
-}
-
 impl thoth::plugin::http_client::Host for CliState {
     fn fetch(
         &mut self,
@@ -272,7 +249,20 @@ impl thoth::plugin::http_client::Host for CliState {
     > {
         match self.policy.check_data_source(&req.url) {
             Ok(CheckOutcome::Allowed) => {
-                execute_http_request(req).map_err(|error| http_error(1, error))
+                let response = execute_http_request(
+                    crate::plugin::wasm_data_source::thoth::plugin::http_client::HttpRequest {
+                        url: req.url,
+                        method: req.method,
+                        headers: req.headers,
+                        body: req.body,
+                    },
+                )
+                .map_err(|error| http_error(1, error))?;
+                Ok(thoth::plugin::http_client::HttpResponse {
+                    status: response.status,
+                    headers: response.headers,
+                    body: response.body,
+                })
             }
             Ok(CheckOutcome::NeedsConsent { domain }) => Err(http_error(
                 403,
@@ -285,7 +275,7 @@ impl thoth::plugin::http_client::Host for CliState {
     }
 
     fn submit(&mut self, _req: thoth::plugin::http_client::HttpRequest) -> String {
-        "unsupported-in-cli".to_string()
+        panic!("asynchronous HTTP submit is unavailable in CLI mode")
     }
 }
 
@@ -303,6 +293,12 @@ impl thoth::plugin::tcp_client::Host for CliState {
         port: u16,
         tls: bool,
     ) -> std::result::Result<u64, thoth::plugin::tcp_client::PluginError> {
+        if self.tcp_streams.len() >= MAX_TCP_STREAMS {
+            return Err(tcp_error(
+                429,
+                format!("maximum of {MAX_TCP_STREAMS} concurrent TCP streams reached"),
+            ));
+        }
         match self.policy.check_tcp(&host) {
             Ok(CheckOutcome::Allowed) => {}
             Ok(CheckOutcome::NeedsConsent { domain }) => {

--- a/src/plugin/wasm_cli.rs
+++ b/src/plugin/wasm_cli.rs
@@ -4,15 +4,26 @@
 //! authoring API. This module is the actual process boundary: schemas and
 //! invocations cross the WASM component interface as versioned JSON payloads.
 
-use std::{path::Path, sync::Mutex};
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+    path::Path,
+    sync::Mutex,
+};
 
 use thoth_plugin_sdk::cli::{CliInvocation, CliOutput, CliSchema, PluginCli};
-use wasmtime::component::{Component, Linker};
+use wasmtime::component::{Component, HasSelf, Linker};
 use wasmtime::{Engine, Store};
 use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView};
 
 use crate::error::{Result, ThothError};
-use crate::settings::PluginSettingData;
+use crate::{
+    app::persistent_state::PersistentState,
+    plugin::{
+        network_policy::{CheckOutcome, NetworkPolicy},
+        wasm_data_source::{BoxIo, ReadWrite, TCP_READ_CAP, secret_store, tcp_connect, tcp_tls},
+    },
+};
 
 wasmtime::component::bindgen!({
     path: "wit/thoth-plugin.wit",
@@ -24,6 +35,10 @@ const CLI_FUEL_BUDGET: u64 = 5_000_000_000;
 struct CliState {
     wasi: WasiCtx,
     table: ResourceTable,
+    plugin_id: String,
+    policy: NetworkPolicy,
+    tcp_streams: HashMap<u64, Box<dyn ReadWrite>>,
+    next_tcp_id: u64,
 }
 
 impl wasmtime_wasi::WasiView for CliState {
@@ -49,7 +64,13 @@ pub struct WasmCliLoader {
 impl WasmCliLoader {
     /// Instantiate a component that exports the opt-in `cli-plugin` world and
     /// validate its schema before registering any clap commands.
-    pub fn open(engine: &Engine, wasm_path: &Path, settings: &[PluginSettingData]) -> Result<Self> {
+    pub fn open(
+        engine: &Engine,
+        wasm_path: &Path,
+        plugin_id: &str,
+        policy: NetworkPolicy,
+        _settings: &[crate::settings::PluginSettingData],
+    ) -> Result<Self> {
         let load_error = |reason: String| ThothError::PluginLoadError {
             path: wasm_path.to_path_buf(),
             reason,
@@ -59,6 +80,10 @@ impl WasmCliLoader {
             CliState {
                 wasi: WasiCtxBuilder::new().inherit_stderr().build(),
                 table: ResourceTable::new(),
+                plugin_id: plugin_id.to_string(),
+                policy,
+                tcp_streams: HashMap::new(),
+                next_tcp_id: 1,
             },
         );
         store
@@ -67,21 +92,29 @@ impl WasmCliLoader {
         let component = Component::from_file(engine, wasm_path)
             .map_err(|error| load_error(error.to_string()))?;
         let mut linker = Linker::<CliState>::new(engine);
-        wasmtime_wasi::p2::add_to_linker_sync(&mut linker)
-            .map_err(|error| load_error(error.to_string()))?;
         // A combined plugin world can contain imports irrelevant to schema
         // discovery. They remain traps; a concrete adapter such as Seshat's
         // supplies the imports its CLI execution actually needs.
+        linker.allow_shadowing(true);
         linker
             .define_unknown_imports_as_traps(&component)
             .map_err(|error| load_error(error.to_string()))?;
-        let bindings = CliPlugin::instantiate(&mut store, &component, &linker)
+        // Register real services after the catch-all traps so their compatible
+        // interface versions shadow exact-version traps generated for the
+        // component. This matters for WASI: components currently import 0.2.3,
+        // while wasmtime-wasi exposes the compatible 0.2.6 host implementation.
+        wasmtime_wasi::p2::add_to_linker_sync(&mut linker)
             .map_err(|error| load_error(error.to_string()))?;
-        let settings_json = serde_json::to_string(settings)
-            .map_err(|error| load_error(format!("failed to encode plugin settings: {error}")))?;
-        bindings
-            .thoth_plugin_plugin_lifecycle()
-            .call_on_load(&mut store, &settings_json)
+        add_wasi_random_0_2_3(&mut linker).map_err(|error| load_error(error.to_string()))?;
+        thoth::plugin::plugin_storage::add_to_linker::<_, HasSelf<_>>(&mut linker, |state| state)
+            .map_err(|error| load_error(error.to_string()))?;
+        thoth::plugin::secure_storage::add_to_linker::<_, HasSelf<_>>(&mut linker, |state| state)
+            .map_err(|error| load_error(error.to_string()))?;
+        thoth::plugin::http_client::add_to_linker::<_, HasSelf<_>>(&mut linker, |state| state)
+            .map_err(|error| load_error(error.to_string()))?;
+        thoth::plugin::tcp_client::add_to_linker::<_, HasSelf<_>>(&mut linker, |state| state)
+            .map_err(|error| load_error(error.to_string()))?;
+        let bindings = CliPlugin::instantiate(&mut store, &component, &linker)
             .map_err(|error| load_error(error.to_string()))?;
         let schema_json = bindings
             .thoth_plugin_plugin_cli()
@@ -99,6 +132,253 @@ impl WasmCliLoader {
             inner: Mutex::new(Inner { store, bindings }),
             schema,
         })
+    }
+}
+
+/// cargo-component's Preview 1 adapter currently imports this exact WASI
+/// interface version. Wasmtime 43 registers 0.2.6, which is API-compatible but
+/// does not replace an exact-version fallback trap, so provide the two random
+/// functions under the component's exact import name as well.
+fn add_wasi_random_0_2_3(linker: &mut Linker<CliState>) -> wasmtime::Result<()> {
+    const MAX_RANDOM_BYTES: u64 = 64 << 20;
+    let mut random = linker.instance("wasi:random/random@0.2.3")?;
+    random.func_wrap(
+        "get-random-bytes",
+        |_store, (len,): (u64,)| -> wasmtime::Result<(Vec<u8>,)> {
+            if len > MAX_RANDOM_BYTES {
+                return Err(wasmtime::Error::msg(format!(
+                    "requested {len} random bytes, maximum is {MAX_RANDOM_BYTES}"
+                )));
+            }
+            let mut bytes = vec![0; len as usize];
+            getrandom::fill(&mut bytes).map_err(|error| wasmtime::Error::msg(error.to_string()))?;
+            Ok((bytes,))
+        },
+    )?;
+    random.func_wrap(
+        "get-random-u64",
+        |_store, (): ()| -> wasmtime::Result<(u64,)> {
+            getrandom::u64()
+                .map(|value| (value,))
+                .map_err(|error| wasmtime::Error::msg(error.to_string()))
+        },
+    )?;
+    Ok(())
+}
+
+impl thoth::plugin::plugin_storage::Host for CliState {
+    fn read(&mut self) -> String {
+        PersistentState::plugin_state_path(&self.plugin_id)
+            .ok()
+            .and_then(|path| std::fs::read_to_string(path).ok())
+            .unwrap_or_default()
+    }
+
+    fn write(&mut self, data: String) -> std::result::Result<(), String> {
+        let path = PersistentState::plugin_state_path(&self.plugin_id)
+            .map_err(|error| error.to_string())?;
+        std::fs::write(path, data).map_err(|error| error.to_string())
+    }
+}
+
+fn secure_error(message: impl Into<String>) -> thoth::plugin::secure_storage::PluginError {
+    thoth::plugin::secure_storage::PluginError {
+        code: 1,
+        message: message.into(),
+    }
+}
+
+impl thoth::plugin::secure_storage::Host for CliState {
+    fn write(
+        &mut self,
+        key: String,
+        secret: String,
+    ) -> std::result::Result<(), thoth::plugin::secure_storage::PluginError> {
+        secret_store::write(&format!("{}:{key}", self.plugin_id), &secret).map_err(secure_error)
+    }
+
+    fn read(
+        &mut self,
+        key: String,
+    ) -> std::result::Result<Option<String>, thoth::plugin::secure_storage::PluginError> {
+        secret_store::read(&format!("{}:{key}", self.plugin_id)).map_err(secure_error)
+    }
+
+    fn delete(
+        &mut self,
+        key: String,
+    ) -> std::result::Result<(), thoth::plugin::secure_storage::PluginError> {
+        secret_store::delete(&format!("{}:{key}", self.plugin_id)).map_err(secure_error)
+    }
+}
+
+fn http_error(code: u32, message: impl Into<String>) -> thoth::plugin::http_client::PluginError {
+    thoth::plugin::http_client::PluginError {
+        code,
+        message: message.into(),
+    }
+}
+
+fn execute_http_request(
+    req: thoth::plugin::http_client::HttpRequest,
+) -> std::result::Result<thoth::plugin::http_client::HttpResponse, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|error| error.to_string())?;
+    let mut builder = match req.method.to_uppercase().as_str() {
+        "POST" => client.post(&req.url),
+        "PUT" => client.put(&req.url),
+        "PATCH" => client.patch(&req.url),
+        "DELETE" => client.delete(&req.url),
+        _ => client.get(&req.url),
+    };
+    for (key, value) in req.headers {
+        builder = builder.header(key, value);
+    }
+    if let Some(body) = req.body {
+        builder = builder.body(body);
+    }
+    let response = builder.send().map_err(|error| error.to_string())?;
+    let status = response.status().as_u16();
+    let headers = response
+        .headers()
+        .iter()
+        .map(|(key, value)| {
+            (
+                key.to_string(),
+                value.to_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect();
+    let body = response
+        .bytes()
+        .map_err(|error| error.to_string())?
+        .to_vec();
+    Ok(thoth::plugin::http_client::HttpResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+impl thoth::plugin::http_client::Host for CliState {
+    fn fetch(
+        &mut self,
+        req: thoth::plugin::http_client::HttpRequest,
+    ) -> std::result::Result<
+        thoth::plugin::http_client::HttpResponse,
+        thoth::plugin::http_client::PluginError,
+    > {
+        match self.policy.check_data_source(&req.url) {
+            Ok(CheckOutcome::Allowed) => {
+                execute_http_request(req).map_err(|error| http_error(1, error))
+            }
+            Ok(CheckOutcome::NeedsConsent { domain }) => Err(http_error(
+                403,
+                format!(
+                    "host '{domain}' is not allowed; approve it in Thoth's plugin network settings"
+                ),
+            )),
+            Err(violation) => Err(http_error(403, format!("blocked: {violation:?}"))),
+        }
+    }
+
+    fn submit(&mut self, _req: thoth::plugin::http_client::HttpRequest) -> String {
+        "unsupported-in-cli".to_string()
+    }
+}
+
+fn tcp_error(code: u32, message: impl Into<String>) -> thoth::plugin::tcp_client::PluginError {
+    thoth::plugin::tcp_client::PluginError {
+        code,
+        message: message.into(),
+    }
+}
+
+impl thoth::plugin::tcp_client::Host for CliState {
+    fn connect(
+        &mut self,
+        host: String,
+        port: u16,
+        tls: bool,
+    ) -> std::result::Result<u64, thoth::plugin::tcp_client::PluginError> {
+        match self.policy.check_tcp(&host) {
+            Ok(CheckOutcome::Allowed) => {}
+            Ok(CheckOutcome::NeedsConsent { domain }) => {
+                return Err(tcp_error(
+                    403,
+                    format!(
+                        "host '{domain}' is not allowed; approve it in Thoth's plugin network settings"
+                    ),
+                ));
+            }
+            Err(violation) => {
+                return Err(tcp_error(403, format!("blocked: {violation:?}")));
+            }
+        }
+        let tcp = tcp_connect(&host, port)
+            .map_err(|error| tcp_error(1, format!("connect failed: {error}")))?;
+        let stream: Box<dyn ReadWrite> = if tls {
+            tcp_tls(tcp, &host).map_err(|error| tcp_error(2, error))?
+        } else {
+            Box::new(tcp)
+        };
+        let id = self.next_tcp_id;
+        self.next_tcp_id += 1;
+        self.tcp_streams.insert(id, stream);
+        Ok(id)
+    }
+
+    fn read(
+        &mut self,
+        stream: u64,
+        max: u32,
+    ) -> std::result::Result<Vec<u8>, thoth::plugin::tcp_client::PluginError> {
+        let stream = self
+            .tcp_streams
+            .get_mut(&stream)
+            .ok_or_else(|| tcp_error(4, "invalid stream id"))?;
+        let mut buffer = vec![0; (max as usize).min(TCP_READ_CAP)];
+        let read = stream
+            .read(&mut buffer)
+            .map_err(|error| tcp_error(2, error.to_string()))?;
+        buffer.truncate(read);
+        Ok(buffer)
+    }
+
+    fn write(
+        &mut self,
+        stream: u64,
+        bytes: Vec<u8>,
+    ) -> std::result::Result<u32, thoth::plugin::tcp_client::PluginError> {
+        let stream = self
+            .tcp_streams
+            .get_mut(&stream)
+            .ok_or_else(|| tcp_error(4, "invalid stream id"))?;
+        stream
+            .write_all(&bytes)
+            .and_then(|()| stream.flush())
+            .map_err(|error| tcp_error(2, error.to_string()))?;
+        Ok(bytes.len() as u32)
+    }
+
+    fn start_tls(
+        &mut self,
+        stream: u64,
+        host: String,
+    ) -> std::result::Result<(), thoth::plugin::tcp_client::PluginError> {
+        let plain = self
+            .tcp_streams
+            .remove(&stream)
+            .ok_or_else(|| tcp_error(4, "invalid stream id"))?;
+        let tls = tcp_tls(BoxIo(plain), &host).map_err(|error| tcp_error(2, error))?;
+        self.tcp_streams.insert(stream, tls);
+        Ok(())
+    }
+
+    fn close(&mut self, stream: u64) {
+        self.tcp_streams.remove(&stream);
     }
 }
 

--- a/src/plugin/wasm_cli.rs
+++ b/src/plugin/wasm_cli.rs
@@ -1,0 +1,126 @@
+//! WIT-backed adapter for a plugin's optional display-free CLI facet.
+//!
+//! The SDK's [`PluginCli`](thoth_plugin_sdk::cli::PluginCli) trait is an
+//! authoring API. This module is the actual process boundary: schemas and
+//! invocations cross the WASM component interface as versioned JSON payloads.
+
+use std::{path::Path, sync::Mutex};
+
+use thoth_plugin_sdk::cli::{CliInvocation, CliOutput, CliSchema, PluginCli};
+use wasmtime::component::{Component, Linker};
+use wasmtime::{Engine, Store};
+use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView};
+
+use crate::error::{Result, ThothError};
+use crate::settings::PluginSettingData;
+
+wasmtime::component::bindgen!({
+    path: "wit/thoth-plugin.wit",
+    world: "cli-plugin",
+});
+
+const CLI_FUEL_BUDGET: u64 = 5_000_000_000;
+
+struct CliState {
+    wasi: WasiCtx,
+    table: ResourceTable,
+}
+
+impl wasmtime_wasi::WasiView for CliState {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi,
+            table: &mut self.table,
+        }
+    }
+}
+
+struct Inner {
+    store: Store<CliState>,
+    bindings: CliPlugin,
+}
+
+/// Live adapter whose calls are backed exclusively by `plugin-cli` WIT exports.
+pub struct WasmCliLoader {
+    inner: Mutex<Inner>,
+    schema: CliSchema,
+}
+
+impl WasmCliLoader {
+    /// Instantiate a component that exports the opt-in `cli-plugin` world and
+    /// validate its schema before registering any clap commands.
+    pub fn open(engine: &Engine, wasm_path: &Path, settings: &[PluginSettingData]) -> Result<Self> {
+        let load_error = |reason: String| ThothError::PluginLoadError {
+            path: wasm_path.to_path_buf(),
+            reason,
+        };
+        let mut store = Store::new(
+            engine,
+            CliState {
+                wasi: WasiCtxBuilder::new().inherit_stderr().build(),
+                table: ResourceTable::new(),
+            },
+        );
+        store
+            .set_fuel(CLI_FUEL_BUDGET)
+            .map_err(|error| load_error(error.to_string()))?;
+        let component = Component::from_file(engine, wasm_path)
+            .map_err(|error| load_error(error.to_string()))?;
+        let mut linker = Linker::<CliState>::new(engine);
+        wasmtime_wasi::p2::add_to_linker_sync(&mut linker)
+            .map_err(|error| load_error(error.to_string()))?;
+        // A combined plugin world can contain imports irrelevant to schema
+        // discovery. They remain traps; a concrete adapter such as Seshat's
+        // supplies the imports its CLI execution actually needs.
+        linker
+            .define_unknown_imports_as_traps(&component)
+            .map_err(|error| load_error(error.to_string()))?;
+        let bindings = CliPlugin::instantiate(&mut store, &component, &linker)
+            .map_err(|error| load_error(error.to_string()))?;
+        let settings_json = serde_json::to_string(settings)
+            .map_err(|error| load_error(format!("failed to encode plugin settings: {error}")))?;
+        bindings
+            .thoth_plugin_plugin_lifecycle()
+            .call_on_load(&mut store, &settings_json)
+            .map_err(|error| load_error(error.to_string()))?;
+        let schema_json = bindings
+            .thoth_plugin_plugin_cli()
+            .call_schema(&mut store)
+            .map_err(|error| load_error(error.to_string()))?
+            .map_err(|error| load_error(error.message))?;
+        let schema: CliSchema = serde_json::from_str(&schema_json).map_err(|error| {
+            load_error(format!("plugin returned an invalid CLI schema: {error}"))
+        })?;
+        schema.validate().map_err(|error| {
+            load_error(format!("plugin returned an invalid CLI schema: {error}"))
+        })?;
+
+        Ok(Self {
+            inner: Mutex::new(Inner { store, bindings }),
+            schema,
+        })
+    }
+}
+
+impl PluginCli for WasmCliLoader {
+    fn cli_schema(&self) -> CliSchema {
+        self.schema.clone()
+    }
+
+    fn run_cli(&self, invocation: &CliInvocation) -> std::result::Result<CliOutput, String> {
+        let invocation_json = serde_json::to_string(invocation)
+            .map_err(|error| format!("failed to encode CLI invocation: {error}"))?;
+        let mut inner = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        let Inner { store, bindings } = &mut *inner;
+        store
+            .set_fuel(CLI_FUEL_BUDGET)
+            .map_err(|error| format!("failed to refuel plugin: {error}"))?;
+        let output_json = bindings
+            .thoth_plugin_plugin_cli()
+            .call_run(store, &invocation_json)
+            .map_err(|error| format!("plugin CLI trapped: {error}"))?
+            .map_err(|error| error.message)?;
+        serde_json::from_str(&output_json)
+            .map_err(|error| format!("plugin returned invalid CLI output: {error}"))
+    }
+}

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -53,9 +53,9 @@ pub struct ConsentRequest {
 // ── async HTTP result sent through the mpsc channel ──────────────────────────
 
 // These plain Send-safe types live in `plugin_ui_host` so they can be shared with
-// the `PluginUiHost` trait without depending on this loader's bindgen internals.
+// the `PluginCore` trait without depending on this loader's bindgen internals.
 pub use crate::plugin::plugin_ui_host::{HttpCallResult, HttpResponseRaw};
-use crate::plugin::plugin_ui_host::{PluginHttpRequest, PluginUiHost, TabOpenRequest};
+use crate::plugin::plugin_ui_host::{PluginCore, PluginHttpRequest, PluginUi, TabOpenRequest};
 
 // ── atomic counter so callers can know when requests are in flight ────────────
 
@@ -1080,7 +1080,7 @@ pub struct WasmDataSourceLoader {
     /// Receives WebSocket lifecycle + message events from connection tasks.
     ws_event_rx: std::sync::mpsc::Receiver<(String, WsEvent)>,
     plugin_id: String,
-    /// Unique per instance; exposed via `PluginUiHost::instance_id` so the host
+    /// Unique per instance; exposed via `PluginCore::instance_id` so the host
     /// can scope this pane's signals and reconcile them on close.
     instance_id: String,
     /// Last rendered sidebar/main-UI trees. When a query worker owns the Store
@@ -1712,7 +1712,7 @@ impl WasmDataSourceLoader {
     }
 }
 
-// ── PluginUiHost — lets an ActivePluginPane hold this loader as a trait object ──
+// ── PluginCore / PluginUi — split headless runtime from rendering ─────────────
 
 fn http_req_to_plugin(r: thoth::plugin::http_client::HttpRequest) -> PluginHttpRequest {
     PluginHttpRequest {
@@ -1732,25 +1732,17 @@ fn plugin_req_to_http(r: PluginHttpRequest) -> thoth::plugin::http_client::HttpR
     }
 }
 
-impl PluginUiHost for WasmDataSourceLoader {
+impl PluginCore for WasmDataSourceLoader {
     fn plugin_id(&self) -> &str {
         WasmDataSourceLoader::plugin_id(self)
     }
 
+    fn as_ui(&self) -> Option<&dyn PluginUi> {
+        Some(self)
+    }
+
     fn instance_id(&self) -> &str {
         &self.instance_id
-    }
-
-    fn render_ui(&self) -> Result<UiOutput> {
-        WasmDataSourceLoader::render_ui(self)
-    }
-
-    fn handle_event(&self, event: UiEvent) -> Result<UiOutput> {
-        WasmDataSourceLoader::handle_event(self, event)
-    }
-
-    fn render_sidebar(&self) -> Result<Option<UiOutput>> {
-        WasmDataSourceLoader::render_sidebar(self)
     }
 
     fn busy(&self) -> bool {
@@ -1839,6 +1831,20 @@ impl PluginUiHost for WasmDataSourceLoader {
 
     fn provide_dataset(&self) -> Result<crate::plugin::plugin_ui_host::ProvidedDataset> {
         WasmDataSourceLoader::provide_dataset(self)
+    }
+}
+
+impl PluginUi for WasmDataSourceLoader {
+    fn render_ui(&self) -> Result<UiOutput> {
+        WasmDataSourceLoader::render_ui(self)
+    }
+
+    fn handle_event(&self, event: UiEvent) -> Result<UiOutput> {
+        WasmDataSourceLoader::handle_event(self, event)
+    }
+
+    fn render_sidebar(&self) -> Result<Option<UiOutput>> {
+        WasmDataSourceLoader::render_sidebar(self)
     }
 }
 

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -1012,7 +1012,7 @@ impl thoth::plugin::file_dialog::Host for DataSourcePluginState {
 
 // ── reqwest bridge ────────────────────────────────────────────────────────────
 
-fn execute_http_request(
+pub(crate) fn execute_http_request(
     req: thoth::plugin::http_client::HttpRequest,
 ) -> std::result::Result<thoth::plugin::http_client::HttpResponse, String> {
     let client = reqwest::blocking::Client::builder()

--- a/src/plugin/wasm_data_source.rs
+++ b/src/plugin/wasm_data_source.rs
@@ -112,16 +112,16 @@ pub type QueryResult = std::result::Result<String, String>;
 const TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const TCP_IO_TIMEOUT: Duration = Duration::from_secs(60);
 /// Cap a single `read` allocation so a plugin can't request a huge buffer.
-const TCP_READ_CAP: usize = 1 << 20; // 1 MiB
+pub(crate) const TCP_READ_CAP: usize = 1 << 20; // 1 MiB
 
 /// A plaintext or TLS-wrapped stream the plugin reads/writes through `tcp-client`.
 /// TLS is terminated host-side so the plugin always sees decrypted bytes.
-trait ReadWrite: Read + Write + Send {}
+pub(crate) trait ReadWrite: Read + Write + Send {}
 impl<T: Read + Write + Send> ReadWrite for T {}
 
 /// Adapts an already-boxed stream back into a concrete `Read + Write` so it can
 /// be handed to `tcp_tls` for an in-place STARTTLS upgrade.
-struct BoxIo(Box<dyn ReadWrite>);
+pub(crate) struct BoxIo(pub(crate) Box<dyn ReadWrite>);
 impl Read for BoxIo {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.0.read(buf)
@@ -397,7 +397,7 @@ fn tcp_err(code: u32, message: impl Into<String>) -> thoth::plugin::tcp_client::
 }
 
 /// Open a plaintext TCP stream with connect/IO timeouts.
-fn tcp_connect(host: &str, port: u16) -> std::io::Result<TcpStream> {
+pub(crate) fn tcp_connect(host: &str, port: u16) -> std::io::Result<TcpStream> {
     use std::net::ToSocketAddrs;
     let mut last_err = std::io::Error::other("no addresses resolved");
     for addr in (host, port).to_socket_addrs()? {
@@ -416,7 +416,7 @@ fn tcp_connect(host: &str, port: u16) -> std::io::Result<TcpStream> {
 /// Wrap any byte stream with host-side TLS (rustls + Mozilla roots). Generic so
 /// it works both at connect time (a fresh `TcpStream`) and for an in-place
 /// STARTTLS upgrade of an already-open plaintext stream.
-fn tcp_tls<S: Read + Write + Send + 'static>(
+pub(crate) fn tcp_tls<S: Read + Write + Send + 'static>(
     stream: S,
     host: &str,
 ) -> std::result::Result<Box<dyn ReadWrite>, String> {
@@ -666,16 +666,16 @@ impl thoth::plugin::secure_storage::Host for DataSourcePluginState {
 /// `cfg(test)` — so unit tests never touch (or hang/prompt on) a real keychain,
 /// which keeps them reliable in CI (no D-Bus secret-service, no macOS prompt).
 #[cfg(not(test))]
-mod secret_store {
+pub(crate) mod secret_store {
     use super::KEYRING_SERVICE;
 
-    pub(super) fn write(account: &str, secret: &str) -> Result<(), String> {
+    pub(crate) fn write(account: &str, secret: &str) -> Result<(), String> {
         keyring::Entry::new(KEYRING_SERVICE, account)
             .and_then(|e| e.set_password(secret))
             .map_err(|e| e.to_string())
     }
 
-    pub(super) fn read(account: &str) -> Result<Option<String>, String> {
+    pub(crate) fn read(account: &str) -> Result<Option<String>, String> {
         let entry = keyring::Entry::new(KEYRING_SERVICE, account).map_err(|e| e.to_string())?;
         match entry.get_password() {
             Ok(p) => Ok(Some(p)),
@@ -684,7 +684,7 @@ mod secret_store {
         }
     }
 
-    pub(super) fn delete(account: &str) -> Result<(), String> {
+    pub(crate) fn delete(account: &str) -> Result<(), String> {
         let entry = keyring::Entry::new(KEYRING_SERVICE, account).map_err(|e| e.to_string())?;
         match entry.delete_credential() {
             Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
@@ -694,14 +694,14 @@ mod secret_store {
 }
 
 #[cfg(test)]
-mod secret_store {
+pub(crate) mod secret_store {
     use std::collections::HashMap;
     use std::sync::{LazyLock, Mutex};
 
     static STORE: LazyLock<Mutex<HashMap<String, String>>> =
         LazyLock::new(|| Mutex::new(HashMap::new()));
 
-    pub(super) fn write(account: &str, secret: &str) -> Result<(), String> {
+    pub(crate) fn write(account: &str, secret: &str) -> Result<(), String> {
         STORE
             .lock()
             .unwrap()
@@ -709,11 +709,11 @@ mod secret_store {
         Ok(())
     }
 
-    pub(super) fn read(account: &str) -> Result<Option<String>, String> {
+    pub(crate) fn read(account: &str) -> Result<Option<String>, String> {
         Ok(STORE.lock().unwrap().get(account).cloned())
     }
 
-    pub(super) fn delete(account: &str) -> Result<(), String> {
+    pub(crate) fn delete(account: &str) -> Result<(), String> {
         STORE.lock().unwrap().remove(account);
         Ok(())
     }

--- a/src/plugin/wasm_ui_component.rs
+++ b/src/plugin/wasm_ui_component.rs
@@ -16,7 +16,7 @@ use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiVie
 
 use crate::app::persistent_state::PersistentState;
 use crate::error::{Result, ThothError};
-use crate::plugin::plugin_ui_host::{PluginUiHost, TabOpenRequest};
+use crate::plugin::plugin_ui_host::{PluginCore, PluginUi, TabOpenRequest};
 use crate::plugin::render_node::{UiEvent, UiOutput};
 use crate::settings::PluginSettingData;
 
@@ -348,21 +348,13 @@ enum TabLifecycle {
     Closed,
 }
 
-impl PluginUiHost for WasmUiComponentLoader {
+impl PluginCore for WasmUiComponentLoader {
     fn plugin_id(&self) -> &str {
         WasmUiComponentLoader::plugin_id(self)
     }
 
-    fn render_ui(&self) -> Result<UiOutput> {
-        WasmUiComponentLoader::render_ui(self)
-    }
-
-    fn handle_event(&self, event: UiEvent) -> Result<UiOutput> {
-        WasmUiComponentLoader::handle_event(self, event)
-    }
-
-    fn render_sidebar(&self) -> Result<Option<UiOutput>> {
-        WasmUiComponentLoader::render_sidebar(self)
+    fn as_ui(&self) -> Option<&dyn PluginUi> {
+        Some(self)
     }
 
     fn on_setting_change(&self, settings: &[PluginSettingData]) -> Result<()> {
@@ -399,5 +391,19 @@ impl PluginUiHost for WasmUiComponentLoader {
 
     fn drain_tab_open_requests(&self) -> Vec<TabOpenRequest> {
         WasmUiComponentLoader::drain_tab_open_requests(self)
+    }
+}
+
+impl PluginUi for WasmUiComponentLoader {
+    fn render_ui(&self) -> Result<UiOutput> {
+        WasmUiComponentLoader::render_ui(self)
+    }
+
+    fn handle_event(&self, event: UiEvent) -> Result<UiOutput> {
+        WasmUiComponentLoader::handle_event(self, event)
+    }
+
+    fn render_sidebar(&self) -> Result<Option<UiOutput>> {
+        WasmUiComponentLoader::render_sidebar(self)
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use crate::{
     app::tab_manager::TabManager,
     components,
-    plugin::{plugin_ui_host::PluginUiHost, render_node::UiOutput},
+    plugin::{plugin_ui_host::PluginCore, render_node::UiOutput},
     search, update,
 };
 
@@ -17,7 +17,7 @@ pub struct ActivePluginPane {
     pub ui_output: UiOutput,
     /// The loader is kept here so the central panel can forward UI events.
     /// Boxed so a pane can hold either a data-source or a ui-component loader.
-    pub loader: Box<dyn PluginUiHost>,
+    pub loader: Box<dyn PluginCore>,
     /// Cached tab title/icon from the plugin's `tab-host` export, refreshed after
     /// `render_ui` and each `handle_event`. Read cheaply by the dock tab label
     /// (which is queried every frame, so it must not lock the WASM store).

--- a/thoth-plugin-sdk/README.md
+++ b/thoth-plugin-sdk/README.md
@@ -68,6 +68,15 @@ fn build_ui(state: &State) -> RenderNode {
 - **`plugin`** — adds the `ToNodeJson` wire trait and the `PluginMeta` derive.
 - **`egui`** — the host-only renderer; **do not** enable it in plugins.
 
+## Core and UI separation
+
+Thoth plugins cross the process boundary through WIT exports rather than Rust
+trait objects. The host maps those exports onto two runtime facets:
+`PluginCore` for lifecycle, state, transport, and data operations, and
+`PluginUi` for render and widget-event callbacks. The host stores the core
+facet and requests the optional UI facet only in GUI code, so a headless plugin
+does not need a graphics context or the SDK's `egui` feature.
+
 See [`docs/PLUGIN_SYSTEM.md`](https://github.com/anitnilay20/thoth/blob/main/docs/PLUGIN_SYSTEM.md)
 for the full guide.
 

--- a/thoth-plugin-sdk/src/cli.rs
+++ b/thoth-plugin-sdk/src/cli.rs
@@ -1,0 +1,261 @@
+//! Display-independent command-line contract for plugins.
+//!
+//! CLI support is opt-in: ordinary plugins do not implement [`PluginCli`]. A
+//! host reads [`CliSchema`] to construct its native argument parser, then sends
+//! a validated [`CliInvocation`] across the component boundary. Results remain
+//! structured until the host serializes each record as newline-delimited JSON.
+//!
+//! # Minimal plugin
+//!
+//! ```
+//! use serde_json::json;
+//! use thoth_plugin_sdk::cli::{
+//!     CliInvocation, CliOutput, CliSchema, CliSubcommand, PluginCli,
+//! };
+//!
+//! struct StatusCli;
+//!
+//! impl PluginCli for StatusCli {
+//!     fn cli_schema(&self) -> CliSchema {
+//!         CliSchema {
+//!             id: "status".into(),
+//!             about: "Inspect service status".into(),
+//!             subcommands: vec![CliSubcommand {
+//!                 name: "ping".into(),
+//!                 about: "Check connectivity".into(),
+//!                 args: vec![],
+//!             }],
+//!         }
+//!     }
+//!
+//!     fn run_cli(&self, invocation: &CliInvocation) -> Result<CliOutput, String> {
+//!         match invocation.subcommand.as_str() {
+//!             "ping" => Ok(CliOutput::one(json!({ "status": "ok" }))),
+//!             command => Err(format!("unsupported command '{command}'")),
+//!         }
+//!     }
+//! }
+//! ```
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashSet;
+
+/// A plugin's complete top-level CLI declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CliSchema {
+    /// Stable plugin command id, such as `seshat`.
+    pub id: String,
+    /// One-line description shown in top-level help.
+    pub about: String,
+    /// Commands offered beneath the plugin id.
+    pub subcommands: Vec<CliSubcommand>,
+}
+
+impl CliSchema {
+    /// Validate names and uniqueness before a host constructs native parser
+    /// objects from untrusted component data.
+    pub fn validate(&self) -> Result<(), String> {
+        validate_name("plugin id", &self.id)?;
+        if self.subcommands.is_empty() {
+            return Err(format!("plugin '{}' declares no CLI subcommands", self.id));
+        }
+        let mut subcommands = HashSet::new();
+        for subcommand in &self.subcommands {
+            validate_name("subcommand", &subcommand.name)?;
+            if !subcommands.insert(&subcommand.name) {
+                return Err(format!("duplicate subcommand '{}'", subcommand.name));
+            }
+            let mut ids = HashSet::new();
+            let mut longs = HashSet::new();
+            let mut shorts = HashSet::new();
+            for arg in &subcommand.args {
+                validate_name("argument id", &arg.id)?;
+                if !ids.insert(&arg.id) {
+                    return Err(format!(
+                        "duplicate argument '{}' in subcommand '{}'",
+                        arg.id, subcommand.name
+                    ));
+                }
+                let (long, short) = match &arg.kind {
+                    CliArgKind::Positional { .. } => (None, None),
+                    CliArgKind::Option { long, short, .. } | CliArgKind::Flag { long, short } => {
+                        (Some(long), *short)
+                    }
+                };
+                if let Some(long) = long {
+                    validate_name("long option", long)?;
+                    if !longs.insert(long) {
+                        return Err(format!(
+                            "duplicate option '--{long}' in subcommand '{}'",
+                            subcommand.name
+                        ));
+                    }
+                }
+                if let Some(short) = short
+                    && (!short.is_ascii_alphanumeric() || !shorts.insert(short))
+                {
+                    return Err(format!(
+                        "invalid or duplicate short option '-{short}' in subcommand '{}'",
+                        subcommand.name
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_name(kind: &str, value: &str) -> Result<(), String> {
+    if value.is_empty()
+        || !value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "._-".contains(character))
+    {
+        return Err(format!(
+            "invalid {kind} '{value}': use ASCII letters, numbers, '.', '_', or '-'"
+        ));
+    }
+    Ok(())
+}
+
+/// One command exposed by a plugin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CliSubcommand {
+    /// Command name, such as `query`.
+    pub name: String,
+    /// One-line description shown in help.
+    pub about: String,
+    /// Arguments accepted by this command.
+    #[serde(default)]
+    pub args: Vec<CliArg>,
+}
+
+/// One positional, option, or boolean flag in a plugin command.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CliArg {
+    /// Stable key used in [`CliInvocation::values`].
+    pub id: String,
+    /// Human-readable help text.
+    pub help: String,
+    /// Whether this argument must be provided.
+    #[serde(default)]
+    pub required: bool,
+    /// Argument shape and spelling.
+    pub kind: CliArgKind,
+}
+
+/// Shapes supported by the cross-language CLI schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum CliArgKind {
+    /// An ordered value without a flag name.
+    Positional {
+        /// Display name used in generated help.
+        value_name: String,
+    },
+    /// A named option that consumes one value.
+    Option {
+        /// Long spelling without the leading `--`.
+        long: String,
+        /// Optional one-character short spelling.
+        #[serde(default)]
+        short: Option<char>,
+        /// Display name used in generated help.
+        value_name: String,
+    },
+    /// A named boolean switch.
+    Flag {
+        /// Long spelling without the leading `--`.
+        long: String,
+        /// Optional one-character short spelling.
+        #[serde(default)]
+        short: Option<char>,
+    },
+}
+
+/// Validated values delivered to a plugin command.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CliInvocation {
+    /// Selected plugin subcommand.
+    pub subcommand: String,
+    /// Values keyed by [`CliArg::id`]. Flags are booleans; omitted optional
+    /// values are absent.
+    pub values: serde_json::Map<String, Value>,
+}
+
+/// Structured records produced by a plugin invocation.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CliOutput {
+    /// Each value is emitted as one JSON line, in order.
+    pub records: Vec<Value>,
+}
+
+impl CliOutput {
+    /// Build output containing one JSON record.
+    pub fn one(record: Value) -> Self {
+        Self {
+            records: vec![record],
+        }
+    }
+}
+
+/// Optional display-free command facet implemented by a plugin or WASM adapter.
+pub trait PluginCli: Send {
+    /// Describe commands so the host can build native help and completions.
+    fn cli_schema(&self) -> CliSchema;
+
+    /// Execute one host-validated invocation.
+    fn run_cli(&self, invocation: &CliInvocation) -> Result<CliOutput, String>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliArg, CliArgKind, CliSchema, CliSubcommand};
+
+    #[test]
+    fn schema_round_trips_over_the_component_boundary() {
+        let schema = CliSchema {
+            id: "demo".into(),
+            about: "Demo commands".into(),
+            subcommands: vec![CliSubcommand {
+                name: "show".into(),
+                about: "Show a record".into(),
+                args: vec![CliArg {
+                    id: "pretty".into(),
+                    help: "Pretty-print output".into(),
+                    required: false,
+                    kind: CliArgKind::Flag {
+                        long: "pretty".into(),
+                        short: Some('p'),
+                    },
+                }],
+            }],
+        };
+
+        let json = serde_json::to_string(&schema).unwrap();
+        assert_eq!(serde_json::from_str::<CliSchema>(&json).unwrap(), schema);
+        schema.validate().unwrap();
+    }
+
+    #[test]
+    fn schema_rejects_duplicate_subcommands() {
+        let command = CliSubcommand {
+            name: "show".into(),
+            about: String::new(),
+            args: vec![],
+        };
+        let schema = CliSchema {
+            id: "demo".into(),
+            about: String::new(),
+            subcommands: vec![command.clone(), command],
+        };
+
+        assert!(
+            schema
+                .validate()
+                .unwrap_err()
+                .contains("duplicate subcommand")
+        );
+    }
+}

--- a/thoth-plugin-sdk/src/cli.rs
+++ b/thoth-plugin-sdk/src/cli.rs
@@ -158,11 +158,13 @@ pub struct CliArg {
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum CliArgKind {
     /// An ordered value without a flag name.
+    #[serde(rename_all = "kebab-case")]
     Positional {
         /// Display name used in generated help.
         value_name: String,
     },
     /// A named option that consumes one value.
+    #[serde(rename_all = "kebab-case")]
     Option {
         /// Long spelling without the leading `--`.
         long: String,
@@ -173,6 +175,7 @@ pub enum CliArgKind {
         value_name: String,
     },
     /// A named boolean switch.
+    #[serde(rename_all = "kebab-case")]
     Flag {
         /// Long spelling without the leading `--`.
         long: String,
@@ -246,6 +249,17 @@ mod tests {
         let json = serde_json::to_string(&schema).unwrap();
         assert_eq!(serde_json::from_str::<CliSchema>(&json).unwrap(), schema);
         schema.validate().unwrap();
+
+        let positional = CliArgKind::Positional {
+            value_name: "PATH".into(),
+        };
+        let positional_json = serde_json::to_string(&positional).unwrap();
+        assert!(positional_json.contains("value-name"));
+        assert!(!positional_json.contains("value_name"));
+        assert_eq!(
+            serde_json::from_str::<CliArgKind>(&positional_json).unwrap(),
+            positional
+        );
     }
 
     #[test]

--- a/thoth-plugin-sdk/src/cli.rs
+++ b/thoth-plugin-sdk/src/cli.rs
@@ -3,7 +3,7 @@
 //! CLI support is opt-in: ordinary plugins do not implement [`PluginCli`]. A
 //! host reads [`CliSchema`] to construct its native argument parser, then sends
 //! a validated [`CliInvocation`] across the component boundary. Results remain
-//! structured until the host serializes each record as newline-delimited JSON.
+//! structured until the host renders the records for its output surface.
 //!
 //! # Minimal plugin
 //!
@@ -20,10 +20,12 @@
 //!         CliSchema {
 //!             id: "status".into(),
 //!             about: "Inspect service status".into(),
+//!             examples: vec!["thoth status ping".into()],
 //!             subcommands: vec![CliSubcommand {
 //!                 name: "ping".into(),
 //!                 about: "Check connectivity".into(),
 //!                 args: vec![],
+//!                 examples: vec!["thoth status ping".into()],
 //!             }],
 //!         }
 //!     }
@@ -48,6 +50,9 @@ pub struct CliSchema {
     pub id: String,
     /// One-line description shown in top-level help.
     pub about: String,
+    /// Complete invocations shown at the bottom of plugin help.
+    #[serde(default)]
+    pub examples: Vec<String>,
     /// Commands offered beneath the plugin id.
     pub subcommands: Vec<CliSubcommand>,
 }
@@ -129,6 +134,9 @@ pub struct CliSubcommand {
     /// Arguments accepted by this command.
     #[serde(default)]
     pub args: Vec<CliArg>,
+    /// Complete invocations shown at the bottom of command help.
+    #[serde(default)]
+    pub examples: Vec<String>,
 }
 
 /// One positional, option, or boolean flag in a plugin command.
@@ -187,12 +195,12 @@ pub struct CliInvocation {
 /// Structured records produced by a plugin invocation.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct CliOutput {
-    /// Each value is emitted as one JSON line, in order.
+    /// Values the host renders as rows, in order.
     pub records: Vec<Value>,
 }
 
 impl CliOutput {
-    /// Build output containing one JSON record.
+    /// Build output containing one structured record.
     pub fn one(record: Value) -> Self {
         Self {
             records: vec![record],
@@ -218,6 +226,7 @@ mod tests {
         let schema = CliSchema {
             id: "demo".into(),
             about: "Demo commands".into(),
+            examples: vec![],
             subcommands: vec![CliSubcommand {
                 name: "show".into(),
                 about: "Show a record".into(),
@@ -230,6 +239,7 @@ mod tests {
                         short: Some('p'),
                     },
                 }],
+                examples: vec![],
             }],
         };
 
@@ -244,10 +254,12 @@ mod tests {
             name: "show".into(),
             about: String::new(),
             args: vec![],
+            examples: vec![],
         };
         let schema = CliSchema {
             id: "demo".into(),
             about: String::new(),
+            examples: vec![],
             subcommands: vec![command.clone(), command],
         };
 

--- a/thoth-plugin-sdk/src/lib.rs
+++ b/thoth-plugin-sdk/src/lib.rs
@@ -28,6 +28,7 @@
 #![deny(missing_docs)]
 
 pub mod actions;
+pub mod cli;
 pub mod components;
 pub mod dataset;
 pub(crate) mod helpers;

--- a/thoth-plugin-sdk/src/prelude.rs
+++ b/thoth-plugin-sdk/src/prelude.rs
@@ -14,6 +14,9 @@
 //! Host-only items (the `egui` renderer, the `theme` palette) are intentionally
 //! left out; import those directly when building the host.
 
+pub use crate::cli::{
+    CliArg, CliArgKind, CliInvocation, CliOutput, CliSchema, CliSubcommand, PluginCli,
+};
 pub use crate::components::*;
 pub use crate::render_node::RenderNode;
 pub use crate::settings::SettingsMap;

--- a/wit/thoth-plugin.wit
+++ b/wit/thoth-plugin.wit
@@ -143,7 +143,8 @@ interface plugin-cli {
     schema: func() -> result<string, plugin-error>;
 
     /// Run a JSON-encoded `CliInvocation`. On success, return a JSON-encoded
-    /// `CliOutput`; the host writes each output record as one JSON line.
+    /// `CliOutput`; the host renders its structured records for the active
+    /// output surface (for example, a table in the terminal).
     run: func(invocation-json: string) -> result<string, plugin-error>;
 }
 
@@ -921,6 +922,10 @@ world base-plugin {
 /// A headless-only plugin that exposes command-line operations.
 world cli-plugin {
     include base-plugin;
+    import plugin-storage;
+    import secure-storage;
+    import http-client;
+    import tcp-client;
     export plugin-cli;
 }
 

--- a/wit/thoth-plugin.wit
+++ b/wit/thoth-plugin.wit
@@ -912,16 +912,21 @@ interface dataset-bus {
 }
 
 
-/// Every plugin must satisfy this base world.
-world base-plugin {
+/// Metadata and lifecycle shared by graphical and headless plugins.
+world plugin-common {
     export plugin-meta;
     export plugin-lifecycle;
+}
+
+/// Graphical plugins also expose settings metadata and callbacks.
+world base-plugin {
+    include plugin-common;
     export plugin-settings;
 }
 
 /// A headless-only plugin that exposes command-line operations.
 world cli-plugin {
-    include base-plugin;
+    include plugin-common;
     import plugin-storage;
     import secure-storage;
     import http-client;

--- a/wit/thoth-plugin.wit
+++ b/wit/thoth-plugin.wit
@@ -77,6 +77,8 @@ interface types {
         // data-renderer.render and appears as an extra view format in a
         // DataView (alongside table / json / raw).
         renderer,
+        // Exposes commands through the optional plugin-cli interface.
+        cli,
     }
 
     /// Maps from src/wit/mod.rs `Plugin` struct.
@@ -121,6 +123,28 @@ interface plugin-meta {
     /// Return static metadata about this plugin.
     /// Called once by the host immediately after instantiation.
     get-info: func() -> plugin-info;
+}
+
+
+// ---------------------------------------------------------------------------
+// plugin-cli — optional display-free command interface
+//
+// The schema and invocation payloads use the versioned JSON structures from
+// thoth-plugin-sdk::cli. JSON keeps this boundary extensible and equally usable
+// from non-Rust component languages. Worlds that do not export this interface
+// remain fully compatible.
+// ---------------------------------------------------------------------------
+
+interface plugin-cli {
+    use types.{plugin-error};
+
+    /// Return a JSON-encoded `CliSchema`. The host uses it to build clap help,
+    /// validation, and completion definitions before invoking the plugin.
+    schema: func() -> result<string, plugin-error>;
+
+    /// Run a JSON-encoded `CliInvocation`. On success, return a JSON-encoded
+    /// `CliOutput`; the host writes each output record as one JSON line.
+    run: func(invocation-json: string) -> result<string, plugin-error>;
 }
 
 
@@ -894,6 +918,12 @@ world base-plugin {
     export plugin-settings;
 }
 
+/// A headless-only plugin that exposes command-line operations.
+world cli-plugin {
+    include base-plugin;
+    export plugin-cli;
+}
+
 /// A plugin that teaches Thoth to open a new file format.
 world file-loader-plugin {
     include base-plugin;
@@ -945,6 +975,13 @@ world data-source-plugin {
     export ui-component;
     export tab-host;
     export data-producer;
+}
+
+/// A data-source plugin that also opts into command-line operations. Keeping
+/// this as a distinct world means existing data-source plugins need no changes.
+world data-source-cli-plugin {
+    include data-source-plugin;
+    export plugin-cli;
 }
 
 /// A plugin that adds a new export format or destination.


### PR DESCRIPTION
## Summary

- split host/plugin core behavior from UI state and add a display-free runtime
- add clap routing, completions, plugin-declared help, arguments, and examples
- define the WIT `plugin-cli` contract and host bridges for storage, secrets, HTTP, TCP, and WASI randomness
- expose Seshat `connections`, `ping`, `indices`, and `query` commands using saved connection IDs or explicit connection strings
- render structured plugin results as readable terminal tables
- remove plugin discovery diagnostics from normal CLI and UI output

## Examples

```bash
thoth plugins
thoth seshat connections
thoth seshat ping cr-prod
thoth seshat indices cr-prod
thoth seshat query cr-prod -q "select * from logs" --limit 100
```

## Verification

- `cargo test -p seshat --lib` (42 passed)
- `cargo test --lib cli::tests --no-default-features` (8 passed)
- `cargo component check -p seshat`
- `cargo check --all-targets`
- manually verified saved PostgreSQL SCRAM connection with `ping` and `indices`
- manually verified `connections` and command-specific help render correctly

Closes #139
Closes #140
Closes #141
Closes #142
Closes #143
Closes #144
Closes #145
Closes #138