### PR TITLE
fix(plugins): resolve symlinked executable paths

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -28,3 +28,42 @@ pub use file_io::FileIO;
 pub use file_open_channel::{drain_open_requests, enqueue_open_request};
 pub use fonts::{find_font_bytes, find_font_bytes_weighted, has_weight, list_system_font_families};
 pub use fs::get_fs_ops;
+
+/// Return the real executable path used to anchor bundled resources and PATH
+/// registrations. Unix launchers commonly invoke Thoth through a symlink; the
+/// unresolved launcher path does not live next to the application resources.
+pub(crate) fn current_executable_path() -> std::io::Result<std::path::PathBuf> {
+    resolve_executable_path(&std::env::current_exe()?)
+}
+
+fn resolve_executable_path(path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
+    #[cfg(unix)]
+    {
+        path.canonicalize()
+    }
+    #[cfg(not(unix))]
+    {
+        Ok(path.to_path_buf())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    #[test]
+    fn executable_path_resolves_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let executable = dir.path().join("Thoth.app/Contents/MacOS/thoth");
+        std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
+        std::fs::write(&executable, b"binary").unwrap();
+        let launcher = dir.path().join("thoth");
+        symlink(&executable, &launcher).unwrap();
+
+        assert_eq!(
+            super::resolve_executable_path(&launcher).unwrap(),
+            executable.canonicalize().unwrap()
+        );
+    }
+}

--- a/src/platform/path_registry.rs
+++ b/src/platform/path_registry.rs
@@ -7,7 +7,6 @@
 ///   on PATH by default on Ubuntu 20.04+, Fedora, Arch, etc.
 /// - Windows: Modifies the User PATH registry key via PowerShell.
 use crate::error::{Result, ThothError};
-use std::env;
 use std::path::PathBuf;
 
 #[cfg(target_os = "windows")]
@@ -33,7 +32,7 @@ pub fn is_in_path() -> bool {
 }
 
 fn get_executable_path() -> Result<PathBuf> {
-    env::current_exe().map_err(|e| ThothError::PathRegistryError {
+    super::current_executable_path().map_err(|e| ThothError::PathRegistryError {
         reason: format!("Failed to get executable path: {}", e),
     })
 }

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
@@ -386,8 +385,10 @@ impl PluginManager {
     }
 
     fn bundled_plugins_dir(&self) -> Result<PathBuf> {
-        let exe = env::current_exe().map_err(|_| ThothError::PluginDirectoryInvalid {
-            dir: "Bundled".to_string(),
+        let exe = crate::platform::current_executable_path().map_err(|_| {
+            ThothError::PluginDirectoryInvalid {
+                dir: "Bundled".to_string(),
+            }
         })?;
         let exe_dir = exe
             .parent()


### PR DESCRIPTION
## Summary
- resolve Unix executable symlinks before locating bundled plugin assets
- reuse the resolved executable path when registering the `thoth` launcher in PATH
- cover symlink resolution with a regression test

## Context
Launching the packaged macOS app through `/usr/local/bin/thoth` anchored plugin discovery under `/usr/local` instead of `Thoth.app/Contents/Resources`, hiding bundled plugins in both CLI and UI modes. Linux symlink launchers are covered by the same Unix path resolution. Windows continues using its executable directory directly.

## Validation
- `cargo test -p thoth platform::tests::executable_path_resolves_symlinks`
- `cargo test -p thoth platform::path_registry::tests`
- `cargo clippy -p thoth --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`